### PR TITLE
update PHP extensions in CI workflow for improved compatibility

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -13,7 +13,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: ctype, curl, dom, fileinfo, filter, hash, mbstring, openssl, pcre, pdo, session, tokenizer, xml
           coverage: xdebug
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request includes changes to the `jobs` section in the `.github/workflows/laravel.yml` file, specifically updating the PHP extensions list for the setup-php action.

Updates to PHP extensions:

* [`.github/workflows/laravel.yml`](diffhunk://#diff-780598065d009a102c43b543e7f6670ce1d9029b6ddb86dc98cb1a94433cccb1L16-R16): Updated the list of PHP extensions to include `ctype`, `fileinfo`, `filter`, `hash`, `openssl`, `pcre`, `session`, and `tokenizer`, and removed `libxml`, `zip`, `pcntl`, `sqlite`, `pdo_sqlite`, `bcmath`, `soap`, `intl`, `gd`, `exif`, and `iconv`.