### PR TITLE
Fix/peoplecount reset foreign key constraints

### DIFF
--- a/.github/workflows/mariadb-migration-tests.yml
+++ b/.github/workflows/mariadb-migration-tests.yml
@@ -1,0 +1,93 @@
+name: MariaDB Migration Tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  mariadb-migration-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:lts
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: musikfestapp_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: composer:v2
+          extensions: pdo_mysql
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-
+
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Create MariaDB Test Environment
+        run: |
+          cp .env.local .env
+          echo "DB_CONNECTION=mariadb" >> .env
+          echo "DB_HOST=127.0.0.1" >> .env
+          echo "DB_PORT=3306" >> .env
+          echo "DB_DATABASE=musikfestapp_test" >> .env
+          echo "DB_USERNAME=root" >> .env
+          echo "DB_PASSWORD=password" >> .env
+
+      - name: Generate Application Key
+        run: php artisan key:generate
+
+      - name: Wait for MariaDB to be ready
+        run: |
+          until php artisan db:show --database=mariadb; do
+            echo "Waiting for MariaDB to be ready..."
+            sleep 2
+          done
+
+      - name: Run Migration Tests
+        run: |
+          echo "Testing fresh migrations..."
+          php artisan migrate:fresh --force --database=mariadb
+
+          echo "Testing migration rollback..."
+          php artisan migrate:rollback --step=5 --database=mariadb
+
+          echo "Testing migration re-run..."
+          php artisan migrate --force --database=mariadb
+
+          echo "Testing fresh migrations with seeding..."
+          php artisan migrate:fresh --seed --force --database=mariadb
+
+      - name: Run Basic Database Tests
+        run: |
+          # Run only database-related tests against MariaDB
+          ./vendor/bin/pest --parallel --filter="Migration|Database|Model" --stop-on-failure
+        env:
+          DB_CONNECTION: mariadb
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: musikfestapp_test
+          DB_USERNAME: root
+          DB_PASSWORD: password

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Type Coverage Tests
         run: ./vendor/bin/pest --type-coverage
 
+  mariadb-migration-tests:
+    needs: basic-tests
+    uses: ./.github/workflows/mariadb-migration-tests.yml
+    secrets: inherit
+
   coverage-and-mutation-tests:
     runs-on: ubuntu-latest
     needs: basic-tests

--- a/database/migrations/2025_07_27_124203_create_peoplecount_area_single_resets_table.php
+++ b/database/migrations/2025_07_27_124203_create_peoplecount_area_single_resets_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->foreignIdFor(Area::class)->constrained('peoplecount_areas')->cascadeOnDelete();
             $table->integer('reset_value');
             $table->datetime('effective_at');
-            $table->foreignIdFor(User::class, 'created_by')->constrained('users')->nullOnDelete();
+            $table->foreignIdFor(User::class, 'created_by')->nullable()->constrained('users')->nullOnDelete();
             $table->text('notes')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
This pull request addresses a previously undetected bug in a database migration file that caused deployment failure. The CI/CD pipeline did not catch the issue initially due to a missing test case. This PR resolves the bug and introduces a dedicated test to ensure such errors are reliably detected in the future.

### ✅ Fixes and Improvements:

**CI Workflow Enhancements:**

* [`[.github/workflows/mariadb-migration-tests.yml](diffhunk://#diff-22b338c54468d3c97691805c5d1afcbdfcc935435942961f7fbd4644e1faf1dcR1-R99)`](diffhunk://#diff-22b338c54468d3c97691805c5d1afcbdfcc935435942961f7fbd4644e1faf1dcR1-R99): Adds a new workflow to verify MariaDB migrations, including environment setup and migration verification steps.
* [`[.github/workflows/tests.yml](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR86-R90)`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR86-R90): Integrates the new workflow into the main CI pipeline, ensuring migration compatibility checks are part of every run.

**Bug Fix:**

* [`[database/migrations/2025_07_27_124203_create_peoplecount_area_single_resets_table.php](diffhunk://#diff-f9968a3e062e39babf6d11f88313868c70cb7a4a913e3654392286128ff5831cL21-R21)`](diffhunk://#diff-f9968a3e062e39babf6d11f88313868c70cb7a4a913e3654392286128ff5831cL21-R21): Corrects a bug that caused deployment failure due to an invalid migration constraint.

**New Test Coverage:**

* Adds a regression test to ensure that broken MariaDB migrations are caught during CI, preventing similar issues from reaching production again.