### PR TITLE
make app ready for production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
 
             cd /home/clients/58c2b2f1ec280a97dfe624b840e761b7/sites/musikfestapp
 
-            if $PHP_BIN artisan down; then
+            if $PHP_BIN artisan down --refresh=15; then
               echo "Application in maintenance mode."
             else
               echo "Failed to put application in maintenance mode. Continuing deployment..."
@@ -96,16 +96,26 @@ jobs:
             git pull origin main || { echo "Git pull failed! Exiting."; exit 1; }
 
             echo "Decrypting environment file..."
-            $PHP_BIN artisan env:decrypt --env=production --key=${{ secrets.ENV_PRODUCTION_KEY_2 }} --force || { echo "Environment decryption failed! Exiting."; exit 1; }
+            $PHP_BIN artisan env:decrypt --env=production --key=${{ secrets.ENV_PRODUCTION_KEY_2 }} --force --filename=new-env || { echo "Environment decryption failed! Exiting."; exit 1; }
+
+            echo "Removing other environment files..."
+            rm -f .env* || { echo "Failed to remove old environment files! Exiting."; exit 1; }
+
+            echo "Renaming decrypted environment file..."
+            mv new-env .env || { echo "Failed to rename decrypted environment file! Exiting."; exit 1; }
 
             echo "Installing PHP dependencies on the server..."
             $COMPOSER_BIN install --no-dev --optimize-autoloader || { echo "Composer install failed! Exiting."; exit 1; }
 
             echo "Running database migrations..."
-            $PHP_BIN artisan migrate:fresh --seed --force || { echo "Migrations failed! Exiting."; exit 1; }
+            $PHP_BIN artisan migrate --force || { echo "Migrations failed! Exiting."; exit 1; }
+
+            echo "Seeding the Role and Permission tables..."
+            $PHP_BIN artisan db:seed --force --class=RolesAndPermissionsSeeder || { echo "Seeding failed! Exiting."; exit 1; }
 
             echo "Optimizing application..."
             $PHP_BIN artisan optimize:clear || { echo "Optimization failed! Exiting."; exit 1; }
+            $PHP_BIN artisan optimize || { echo "Optimization failed! Exiting."; exit 1; }
 
             echo "Generating Ziggy routes..."
             $PHP_BIN artisan ziggy:generate || { echo "Ziggy generation failed! Exiting."; exit 1; }

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -47,6 +47,9 @@ class UserController extends Controller
         // attach user to organization
         $user->organizations()->attach($organization->id);
 
+        // Give User default role
+        $user->assignRole('PeopleCountViewer');
+
         return redirect()->route('orgmgmt.users.index', [
             'organization' => $organization,
         ])
@@ -106,6 +109,8 @@ class UserController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  UserDestroyRequest  $request  Required for authorization, even if not explicitly used in method body
+     *
+     * @todo: Do not delete user if they belong to an organization, then only remove the organization association.
      */
     public function destroy(UserDestroyRequest $request, Organization $organization, User $user): RedirectResponse
     {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,9 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Organization;
 use App\Models\Peoplecount\Area;
-use App\Models\Peoplecount\Assignment;
 use App\Models\Peoplecount\Event;
-use App\Models\Peoplecount\Sensor;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -33,64 +31,40 @@ class DatabaseSeeder extends Seeder
         User::factory()->globalAdmin()->organizationAdmin($mfw)->create([
             'name' => 'Simon',
             'email' => 'simon@musikfestapp.ch',
-            'phone' => '+41797164443',
         ]);
 
         User::factory()->globalAdmin()->organizationAdmin($mfw)->create([
             'name' => 'Pirmin',
             'email' => 'pirmin@musikfestapp.ch',
-            'phone' => '+41765021392',
         ]);
 
         User::factory()->organizationAdmin($mfw)->create([
             'name' => 'Lotta',
             'email' => 'lotta@musikfestwochen.ch',
-            'phone' => '+41794256763',
         ]);
 
         // Create preparation event: Musikfestwochen Vorbereitung (1st August 2025 8am to 6th August 2025 6pm)
         $preparationEvent = Event::factory()->withOrganization($mfw)->create([
             'name' => 'Musikfestwochen Vorbereitung',
-            'starts_at' => '2025-08-01 08:00:00', // 8am UTC
-            'ends_at' => '2025-08-06 18:00:00',   // 6pm UTC
+            'starts_at' => '2025-08-05 05:00:00', // 5am UTC
+            'ends_at' => '2025-08-06 16:00:00',   // 4pm UTC
         ]);
 
         // Create main event: Musikfestwochen 2025 (6th August 2025 6pm to 17th August 2025 10pm)
         $event = Event::factory()->withOrganization($mfw)->create([
             'name' => 'Musikfestwochen 2025',
-            'starts_at' => '2025-08-06 18:00:00', // 6pm UTC
-            'ends_at' => '2025-08-17 22:00:00',   // 10pm UTC
+            'starts_at' => '2025-08-06 16:00:00', // 4pm UTC
+            'ends_at' => '2025-08-17 21:00:00',   // 9pm UTC
         ]);
 
         // Create area for preparation event: Gesamtes Gelände
-        $preparationArea = Area::factory()->withEvent($preparationEvent)->create([
-            'name' => 'Gesamtes Gelände',
+        Area::factory()->withEvent($preparationEvent)->create([
+            'name' => 'Gesamtes Gelände (Vorbereitung)',
         ]);
 
         // Create area for main event: Gesamtes Gelände
-        $area = Area::factory()->withEvent($event)->create([
+        Area::factory()->withEvent($event)->create([
             'name' => 'Gesamtes Gelände',
         ]);
-
-        // Create 10 sensors for the organization
-        $sensors = Sensor::factory(10)->axisP88152()->withToken()->withOrganization($mfw)->create();
-
-        // Assign all 10 sensors to the preparation area with random direction flipping
-        foreach ($sensors as $sensor) {
-            Assignment::factory()
-                ->withArea($preparationArea)
-                ->withSensor($sensor)
-                ->withDirectionFlipped(fake()->boolean())
-                ->create();
-        }
-
-        // Assign all 10 sensors to the main event area with random direction flipping
-        foreach ($sensors as $sensor) {
-            Assignment::factory()
-                ->withArea($area)
-                ->withSensor($sensor)
-                ->withDirectionFlipped(fake()->boolean())
-                ->create();
-        }
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 class RolesAndPermissionsSeeder extends Seeder
@@ -17,24 +16,26 @@ class RolesAndPermissionsSeeder extends Seeder
         // Reset cached roles and permissions
         app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
 
-        Role::create(['name' => 'SuperAdmin']);
+        \Spatie\Permission\Models\Role::query()->firstOrCreate(['name' => 'SuperAdmin']);
 
         // create permissions
-        foreach (['create', 'destroy', 'edit', 'index', 'show', 'store', 'update', '*'] as $action) {
+        $modules = [
+            'admin.users',
+            'admin.organizations',
+            'orgmgmt.users',
+            'peoplecount.sensors',
+            'peoplecount.events',
+            'peoplecount.areas',
+            'peoplecount.assignments',
+            'peoplecount.area_resets',
+        ];
 
-            // Admin Module
-            Permission::create(['name' => 'admin.users.'.$action]);
-            Permission::create(['name' => 'admin.organizations.'.$action]);
+        $actions = ['create', 'destroy', 'edit', 'index', 'show', 'store', 'update', '*'];
 
-            // Organization Management Module
-            Permission::create(['name' => 'orgmgmt.users.'.$action]);
-
-            // People counting module
-            Permission::create(['name' => 'peoplecount.sensors.'.$action]);
-            Permission::create(['name' => 'peoplecount.events.'.$action]);
-            Permission::create(['name' => 'peoplecount.areas.'.$action]);
-            Permission::create(['name' => 'peoplecount.assignments.'.$action]);
-            Permission::create(['name' => 'peoplecount.area_resets.'.$action]);
+        foreach ($modules as $module) {
+            foreach ($actions as $action) {
+                Permission::findOrCreate(sprintf('%s.%s', $module, $action));
+            }
         }
 
         // update cache to know about the newly created permissions (required if using WithoutModelEvents in seeders)
@@ -42,22 +43,34 @@ class RolesAndPermissionsSeeder extends Seeder
 
         // Create roles and assign created permissions
 
-        Role::create(['name' => 'Admin'])
-            ->givePermissionTo('admin.users.*')
-            ->givePermissionTo('admin.organizations.*')
-            ->givePermissionTo('orgmgmt.users.*')
-            ->givePermissionTo('peoplecount.sensors.*')
-            ->givePermissionTo('peoplecount.events.*')
-            ->givePermissionTo('peoplecount.areas.*')
-            ->givePermissionTo('peoplecount.assignments.*')
-            ->givePermissionTo('peoplecount.area_resets.*');
+        $adminRole = \Spatie\Permission\Models\Role::query()->firstOrCreate(['name' => 'Admin']);
+        $adminRole->syncPermissions([
+            'admin.users.*',
+            'admin.organizations.*',
+            'orgmgmt.users.*',
+            'peoplecount.sensors.*',
+            'peoplecount.events.*',
+            'peoplecount.areas.*',
+            'peoplecount.assignments.*',
+            'peoplecount.area_resets.*',
+        ]);
 
-        Role::create(['name' => 'OrganizationAdmin'])
-            ->givePermissionTo('orgmgmt.users.*')
-            ->givePermissionTo('peoplecount.sensors.*')
-            ->givePermissionTo('peoplecount.events.*')
-            ->givePermissionTo('peoplecount.areas.*')
-            ->givePermissionTo('peoplecount.assignments.*')
-            ->givePermissionTo('peoplecount.area_resets.*');
+        $orgAdminRole = \Spatie\Permission\Models\Role::query()->firstOrCreate(['name' => 'OrganizationAdmin']);
+        $orgAdminRole->syncPermissions([
+            'orgmgmt.users.*',
+            'peoplecount.sensors.*',
+            'peoplecount.events.*',
+            'peoplecount.areas.*',
+            'peoplecount.assignments.*',
+            'peoplecount.area_resets.*',
+        ]);
+
+        $peoplecountViewerRole = \Spatie\Permission\Models\Role::query()->firstOrCreate(['name' => 'PeopleCountViewer']);
+        $peoplecountViewerRole->syncPermissions([
+            'peoplecount.areas.index',
+            'peoplecount.areas.show',
+            'peoplecount.events.index',
+            'peoplecount.events.show',
+        ]);
     }
 }


### PR DESCRIPTION
- Assign `PeopleCountViewer` role by default when attaching a user to an organization.
- Refactor `RolesAndPermissionsSeeder` for improved role and permission creation.
- Introduce `PeopleCountViewer` role permission set.
- Adjust deploy workflow to include role and permission seeding.
- Simplify environmental variable handling during deployment.
- Update event dates and names in `DatabaseSeeder`