### PR TITLE
Fix: Mark email as verified during password reset

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -52,6 +52,11 @@ class NewPasswordController extends Controller
                     'remember_token' => Str::random(60),
                 ])->save();
 
+                // Mark email as verified if it wasn't already
+                if (! $user->hasVerifiedEmail()) {
+                    $user->markEmailAsVerified();
+                }
+
                 event(new PasswordReset($user));
             }
         );

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -59,6 +59,37 @@ it('can reset password with valid token', function () {
     });
 });
 
+it('marks email as verified when resetting password', function () {
+    Notification::fake();
+
+    // Create user with unverified email
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    // Ensure email is not verified initially
+    expect($user->hasVerifiedEmail())->toBeFalse();
+
+    $this->post('/forgot-password', ['email' => $user->email]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user): true {
+        $this->post('/reset-password', [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        // Refresh user from database
+        $user->refresh();
+
+        // Check that email is now verified
+        expect($user->hasVerifiedEmail())->toBeTrue();
+
+        return true;
+    });
+});
+
 it('cannot reset password with invalid token', function () {
     Notification::fake();
 


### PR DESCRIPTION
This pull request includes the following changes:

- Updated the password reset logic to mark the user's email as verified upon successful reset.
- Added a test case to ensure the email verification functionality works as intended.
- Closes #77 