### PR TITLE
fix: fix reset time calculations in AreaRecurringReset

### DIFF
--- a/app/Models/Peoplecount/AreaRecurringReset.php
+++ b/app/Models/Peoplecount/AreaRecurringReset.php
@@ -59,13 +59,13 @@ class AreaRecurringReset extends Model
     {
         // Ensure we're working with a copy of the input date to avoid modifying the original
         $now = $from instanceof Carbon ? $from->copy()->setTimezone($this->timezone) : Carbon::now($this->timezone);
-        $resetTime = Carbon::createFromFormat('H:i', $this->reset_time, $this->timezone);
+        $resetTime = Carbon::parse($this->reset_time, $this->timezone);
 
         // Set the date part of resetTime to match the date part of now
         $resetTime->setDate($now->year, $now->month, $now->day);
 
         // If today's reset time has not yet occurred, get yesterday's reset
-        if ($now->format('H:i') < $this->reset_time) {
+        if ($now->lt($resetTime)) {
             $resetTime->subDay();
         }
 
@@ -106,13 +106,13 @@ class AreaRecurringReset extends Model
     {
         // Ensure we're working with a copy of the input date to avoid modifying the original
         $now = $from instanceof Carbon ? $from->copy()->setTimezone($this->timezone) : Carbon::now($this->timezone);
-        $resetTime = Carbon::createFromFormat('H:i', $this->reset_time, $this->timezone);
+        $resetTime = Carbon::parse($this->reset_time, $this->timezone);
 
         // Set the date part of resetTime to match the date part of now
         $resetTime->setDate($now->year, $now->month, $now->day);
 
         // If today's reset time has already passed, get tomorrow's reset
-        if ($now->format('H:i') >= $this->reset_time) {
+        if ($now->gte($resetTime)) {
             $resetTime->addDay();
         }
 


### PR DESCRIPTION
This pull request updates the logic for calculating previous and next daily occurrences in the `AreaRecurringReset` model. The main improvements involve more robust handling of time comparisons and parsing, which makes the code clearer and less error-prone.

Closes #79 

**Improvements to time parsing and comparison:**

* Replaced `Carbon::createFromFormat('H:i', $this->reset_time, $this->timezone)` with `Carbon::parse($this->reset_time, $this->timezone)` for more flexible and reliable time parsing in both `getPreviousDailyOccurrence` and `getNextDailyOccurrence` methods. [[1]](diffhunk://#diff-4c18b387f0fab355d2b7d128dd562b4bbdaf5036bc87bd2e720213512eb1b2d0L62-R68) [[2]](diffhunk://#diff-4c18b387f0fab355d2b7d128dd562b4bbdaf5036bc87bd2e720213512eb1b2d0L109-R115)
* Updated time comparison logic from string-based checks (`$now->format('H:i') < $this->reset_time`) to direct Carbon object comparisons (`$now->lt($resetTime)` and `$now->gte($resetTime)`), improving accuracy and readability. [[1]](diffhunk://#diff-4c18b387f0fab355d2b7d128dd562b4bbdaf5036bc87bd2e720213512eb1b2d0L62-R68) [[2]](diffhunk://#diff-4c18b387f0fab355d2b7d128dd562b4bbdaf5036bc87bd2e720213512eb1b2d0L109-R115)