### PR TITLE
fix: enforce HTTPS in production via AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Services\Peoplecount\SensorService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\Events\PermissionAttached;
 use Spatie\Permission\Events\PermissionDetached;
@@ -48,6 +49,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Model::automaticallyEagerLoadRelationships();
+
+        URL::forceHttps($this->app->isProduction());
 
         Gate::before(function (User $user, string $ability): ?bool {
             return GlobalPermissionService::canGlobally($user, $ability);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -50,7 +50,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Model::automaticallyEagerLoadRelationships();
 
-        URL::forceHttps($this->app->isProduction());
+        URL::forceHttps(app()->isProduction());
 
         Gate::before(function (User $user, string $ability): ?bool {
             return GlobalPermissionService::canGlobally($user, $ability);


### PR DESCRIPTION
This pull request introduces a small but important change to the application's service provider to improve security in production environments.

Fixes #82 

* Security enhancement:
  * Enforces HTTPS for all URLs when the application is running in production by using `URL::forceHttps($this->app->isProduction())` in the `boot` method of `AppServiceProvider.php`.
* Dependency update:
  * Adds the `Illuminate\Support\Facades\URL` import to `AppServiceProvider.php` to support HTTPS enforcement.