### PR TITLE
fix: build assets before pest shard update workflow

### DIFF
--- a/.github/workflows/update-pest-shards.yml
+++ b/.github/workflows/update-pest-shards.yml
@@ -60,8 +60,11 @@ jobs:
       - name: Publish Ziggy Configuration
         run: php artisan ziggy:generate
 
+      - name: Build Assets
+        run: npm run build
+
       - name: Update shard timings
-        run: ./vendor/bin/pest --parallel --update-shards
+        run: ./vendor/bin/pest --ci --parallel --update-shards
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
This fixes the scheduled shard-timing workflow by building frontend assets before running Pest. It also switches the shard update run to CI mode so output is consistent with the rest of our workflows.

## Details
- Adds `npm run build` in `.github/workflows/update-pest-shards.yml` before `./vendor/bin/pest --update-shards`.
- Updates Pest command to `./vendor/bin/pest --ci --parallel --update-shards` to align with CI output behavior used elsewhere.