### PR TITLE
Support merge queue checks

### DIFF
--- a/.ai/skills/pr-description/SKILL.md
+++ b/.ai/skills/pr-description/SKILL.md
@@ -59,6 +59,10 @@ npm run build
 ```
 
 Fixes #<number>
+
+---
+**«<inspiring quote here>»**
+_<author>_
 ````
 
 ### Section Guidelines
@@ -88,6 +92,15 @@ Fixes #<number>
     - A screenshot placeholder (`> TODO: attach before/after screenshots`) for visual changes.
     - Do **not** include these subsections by default. Only when they are genuinely important.
 - **Fixes #N**: Only include when the PR actually fixes/closes a GitHub issue. Use `Fixes #<number>` syntax (one per line if multiple). Do not fabricate issue numbers -- ask the user if unsure.
+- **Ending line + quote (required):** End every PR description with horizontal rule, then one inspiring quote line. Format:
+
+  ```markdown
+  ---
+  **«<inspiring quote here>»**
+  _<author>_
+  ```
+
+  Use `php artisan inspire --no-interaction` to source quote.
 
 ## Multi-Purpose PR Detection
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: linter
 
 on:
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   workflow_call:
 
 permissions:
@@ -35,13 +40,28 @@ jobs:
         run: vendor/bin/rector --dry-run
 
       - name: Run Pint
-        run: vendor/bin/pint
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            vendor/bin/pint --test
+          else
+            vendor/bin/pint
+          fi
 
       - name: Format Frontend
-        run: npm run format
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            npm run format:check
+          else
+            npm run format
+          fi
 
       - name: Lint Frontend
-        run: npm run lint
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            npx eslint .
+          else
+            npm run lint
+          fi
 
       - name: Run Typos Check
         run: vendor/bin/peck

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,11 @@ on:
       - '.junie/**'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -14,7 +19,7 @@ on:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
   schedule:
-    - cron: "35 4 * * 2"
+    - cron: '35 4 * * 2'
   workflow_dispatch:
 
 permissions:
@@ -22,7 +27,7 @@ permissions:
 
 jobs:
   lockfile-consistency:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,8 +38,15 @@ jobs:
       - name: Validate lockfile consistency
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.sha }}"
+
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE_SHA="${{ github.event.merge_group.base_sha }}"
+            HEAD_SHA="${{ github.event.merge_group.head_sha }}"
+          else
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
           CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
 
           if echo "$CHANGED_FILES" | grep -qx "package.json" && ! echo "$CHANGED_FILES" | grep -qx "package-lock.json"; then
@@ -59,7 +71,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
 
       - name: Validate composer files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,13 @@ on:
       - '.junie/**'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   workflow_call:
   workflow_dispatch:
-
 
 permissions:
   # Only read access to repository contents is needed for running tests


### PR DESCRIPTION
Merge queue entries now run the same required checks as pull requests, so GitHub can evaluate queued changes before merging to `main`. This also keeps formatting jobs non-mutating in merge queue runs and teaches the PR-description skill to include the required quote footer.

## Notes

Validated workflow syntax with `actionlint`. A real GitHub merge queue event was not executed locally, so runtime behavior depends on GitHub's merge queue event payload.

---
**«It is never too late to be what you might have been.»**
_George Eliot_