### PR TITLE
fix(ci): harden deploy sync with fetch + reset

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,9 @@ jobs:
 
             PHP_BIN="/opt/php8.4/bin/php"
             COMPOSER_BIN="/opt/php8.4/bin/composer"
+            APP_PATH="/home/clients/58c2b2f1ec280a97dfe624b840e761b7/sites/musikfestapp"
 
-            cd /home/clients/58c2b2f1ec280a97dfe624b840e761b7/sites/musikfestapp
+            cd "$APP_PATH"
 
             if $PHP_BIN artisan down --refresh=15; then
               echo "Application in maintenance mode."
@@ -104,9 +105,9 @@ jobs:
               echo "Failed to put application in maintenance mode. Continuing deployment..."
             fi
 
-            echo "Pulling latest changes from the repository..."
-            git reset --hard
-            git pull origin main || { echo "Git pull failed! Exiting."; exit 1; }
+            echo "Fetching latest changes from the repository..."
+            git fetch origin main || { echo "Git fetch failed! Exiting."; exit 1; }
+            git reset --hard origin/main || { echo "Git reset to origin/main failed! Exiting."; exit 1; }
 
             echo "Decrypting environment file..."
             $PHP_BIN artisan env:decrypt --env=production --key=${{ secrets.ENV_PRODUCTION_KEY_2 }} --force --filename=new-env || { echo "Environment decryption failed! Exiting."; exit 1; }


### PR DESCRIPTION
Hardened deployment git sync on server to always fetch remote `main` and hard-reset working tree to `origin/main`. This removes merge-path behavior from `git pull`, which previously failed when server git committer identity was not configured.

## Details

- [.github/workflows/deploy.yml](https://github.com/musikfestwochen/musikfestapp/blob/fix/deploy-ff-only-and-up-trap/.github/workflows/deploy.yml) - replaces `git pull origin main` with deterministic `git fetch origin main` plus `git reset --hard origin/main`, and normalizes app path usage in script.

---
**«Act only according to that maxim whereby you can, at the same time, will that it should become universal law.»**
_Immanuel Kant_