### PR TITLE
chore: align Rector + architecture strict-types enforcement

### DIFF
--- a/app/Casts/BinaryHexCast.php
+++ b/app/Casts/BinaryHexCast.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/app/Http/Controllers/Admin/OrganizationController.php
+++ b/app/Http/Controllers/Admin/OrganizationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/OrganizationSelectionController.php
+++ b/app/Http/Controllers/OrganizationSelectionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\OrganizationSelectionRequest;

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Orgmgmt;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/AlertController.php
+++ b/app/Http/Controllers/Peoplecount/AlertController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/AreaController.php
+++ b/app/Http/Controllers/Peoplecount/AreaController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Enums\Peoplecount\AlertChannel;

--- a/app/Http/Controllers/Peoplecount/AreaRecurringResetController.php
+++ b/app/Http/Controllers/Peoplecount/AreaRecurringResetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/AreaSingleResetController.php
+++ b/app/Http/Controllers/Peoplecount/AreaSingleResetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/AssignmentController.php
+++ b/app/Http/Controllers/Peoplecount/AssignmentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/EventController.php
+++ b/app/Http/Controllers/Peoplecount/EventController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/IntervalCountController.php
+++ b/app/Http/Controllers/Peoplecount/IntervalCountController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;
@@ -34,9 +36,9 @@ class IntervalCountController extends Controller
             // Return the number of persisted IntervalCount records
             if ($numPersisted > 0) {
                 return response()->json(['message' => 'Interval count data processed successfully.', 'count' => $numPersisted], 201);
-            } else {
-                return response()->json(['message' => 'No interval count data to process.'], 200);
             }
+
+            return response()->json(['message' => 'No interval count data to process.'], 200);
         } catch (Exception $exception) {
             // Return the exception message in JSON response without logging
             return response()->json([

--- a/app/Http/Controllers/Peoplecount/SensorController.php
+++ b/app/Http/Controllers/Peoplecount/SensorController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Peoplecount/SensorTokenController.php
+++ b/app/Http/Controllers/Peoplecount/SensorTokenController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Peoplecount;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Settings/AppearanceController.php
+++ b/app/Http/Controllers/Settings/AppearanceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Widgets/PeoplecountActiveAreaCountsWidgetController.php
+++ b/app/Http/Controllers/Widgets/PeoplecountActiveAreaCountsWidgetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Widgets;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Widgets/PeoplecountAreaCountHistoryWidgetController.php
+++ b/app/Http/Controllers/Widgets/PeoplecountAreaCountHistoryWidgetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Widgets;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Widgets/PeoplecountMostActiveSensorsWidgetController.php
+++ b/app/Http/Controllers/Widgets/PeoplecountMostActiveSensorsWidgetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Widgets;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Widgets/PeoplecountSensorHealthStatusWidgetController.php
+++ b/app/Http/Controllers/Widgets/PeoplecountSensorHealthStatusWidgetController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Widgets;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use App\Services\GlobalPermissionService;

--- a/app/Http/Middleware/Permissions/GlobalOrganizationMiddleware.php
+++ b/app/Http/Middleware/Permissions/GlobalOrganizationMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware\Permissions;
 
 use Closure;

--- a/app/Http/Middleware/Permissions/OrganizationSlugMiddleware.php
+++ b/app/Http/Middleware/Permissions/OrganizationSlugMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware\Permissions;
 
 use Closure;

--- a/app/Http/Middleware/VerifyWebcronToken.php
+++ b/app/Http/Middleware/VerifyWebcronToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use Closure;

--- a/app/Http/Requests/Admin/OrganizationCreateRequest.php
+++ b/app/Http/Requests/Admin/OrganizationCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationDestroyRequest.php
+++ b/app/Http/Requests/Admin/OrganizationDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationEditRequest.php
+++ b/app/Http/Requests/Admin/OrganizationEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationIndexRequest.php
+++ b/app/Http/Requests/Admin/OrganizationIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationShowRequest.php
+++ b/app/Http/Requests/Admin/OrganizationShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationStoreRequest.php
+++ b/app/Http/Requests/Admin/OrganizationStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/OrganizationUpdateRequest.php
+++ b/app/Http/Requests/Admin/OrganizationUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/UserCreateRequest.php
+++ b/app/Http/Requests/Admin/UserCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/UserDestroyRequest.php
+++ b/app/Http/Requests/Admin/UserDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use App\Models\User;

--- a/app/Http/Requests/Admin/UserEditRequest.php
+++ b/app/Http/Requests/Admin/UserEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/UserIndexRequest.php
+++ b/app/Http/Requests/Admin/UserIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/UserShowRequest.php
+++ b/app/Http/Requests/Admin/UserShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Admin/UserStoreRequest.php
+++ b/app/Http/Requests/Admin/UserStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use App\Models\User;

--- a/app/Http/Requests/Admin/UserUpdateRequest.php
+++ b/app/Http/Requests/Admin/UserUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Admin;
 
 use AllowDynamicProperties;

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;
@@ -80,6 +82,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->string('email')->toString()).'|'.$this->ip());
     }
 }

--- a/app/Http/Requests/OrganizationSelectionRequest.php
+++ b/app/Http/Requests/OrganizationSelectionRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use App\Models\Organization;

--- a/app/Http/Requests/Orgmgmt/UserCreateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Orgmgmt/UserDestroyRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use App\Models\User;

--- a/app/Http/Requests/Orgmgmt/UserEditRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Orgmgmt/UserIndexRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Orgmgmt/UserShowRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Orgmgmt/UserStoreRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Orgmgmt;
 
 use AllowDynamicProperties;

--- a/app/Http/Requests/Peoplecount/AlertCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AlertDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AlertEditRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AlertShowRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AlertStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use App\Enums\Peoplecount\AlertChannel;

--- a/app/Http/Requests/Peoplecount/AlertUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/AlertUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use App\Enums\Peoplecount\AlertChannel;

--- a/app/Http/Requests/Peoplecount/AreaCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaEditRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaIndexRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetEditRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetShowRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaRecurringResetUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaRecurringResetUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaShowRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaSingleResetCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaSingleResetCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaSingleResetDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaSingleResetDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use App\Models\Peoplecount\AreaSingleReset;
@@ -15,8 +17,11 @@ class AreaSingleResetDestroyRequest extends FormRequest
     {
         /** @var AreaSingleReset $singleReset */
         $singleReset = $this->route('single_reset');
+        if (auth()->user()->can('peoplecount.area_resets.destroy')) {
+            return true;
+        }
 
-        return auth()->user()->can('peoplecount.area_resets.destroy') || $singleReset->created_by === auth()->user()->id;
+        return $singleReset->created_by === auth()->user()->id;
     }
 
     /**

--- a/app/Http/Requests/Peoplecount/AreaSingleResetIndexRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaSingleResetIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaSingleResetStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaSingleResetStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AreaUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentEditRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentIndexRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentShowRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/AssignmentUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/EventCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/EventDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventEditRequest.php
+++ b/app/Http/Requests/Peoplecount/EventEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventIndexRequest.php
+++ b/app/Http/Requests/Peoplecount/EventIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventShowRequest.php
+++ b/app/Http/Requests/Peoplecount/EventShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/EventStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/EventUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/EventUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorCreateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorCreateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorDestroyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorEditRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorEditRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorIndexRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorShowRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShowRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorStoreRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorTokenUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorTokenUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Peoplecount/SensorUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Peoplecount;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Settings/AppearanceUpdateRequest.php
+++ b/app/Http/Requests/Settings/AppearanceUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Widgets/Peoplecount/ActiveAreaCountsIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/ActiveAreaCountsIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Widgets\Peoplecount;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Widgets\Peoplecount;
 
 use Illuminate\Contracts\Validation\Validator;

--- a/app/Http/Requests/Widgets/Peoplecount/MostActiveSensorsIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/MostActiveSensorsIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Widgets\Peoplecount;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Widgets/Peoplecount/SensorHealthIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/SensorHealthIndexRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Widgets\Peoplecount;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Jobs/AggregateAreaCounts.php
+++ b/app/Jobs/AggregateAreaCounts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Jobs;
 
 use App\Models\Peoplecount\Area;

--- a/app/Listeners/Permissions/PermissionAttachedListener.php
+++ b/app/Listeners/Permissions/PermissionAttachedListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Listeners\Permissions;
 
 use App\Models\User;

--- a/app/Listeners/Permissions/PermissionDetachedListener.php
+++ b/app/Listeners/Permissions/PermissionDetachedListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Listeners\Permissions;
 
 use App\Models\User;

--- a/app/Listeners/Permissions/RoleAttachedListener.php
+++ b/app/Listeners/Permissions/RoleAttachedListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Listeners\Permissions;
 
 use App\Models\User;

--- a/app/Listeners/Permissions/RoleDetachedListener.php
+++ b/app/Listeners/Permissions/RoleDetachedListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Listeners\Permissions;
 
 use App\Models\User;

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Database\Factories\OrganizationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -24,27 +27,21 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  */
+#[Fillable([
+    'name',
+    'slug',
+    'description',
+    'email',
+    'phone',
+    'website',
+    'logo',
+])]
 class Organization extends Model
 {
     /** @use HasFactory<OrganizationFactory> */
     use HasFactory;
 
     use SoftDeletes;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'slug',
-        'description',
-        'email',
-        'phone',
-        'website',
-        'logo',
-    ];
 
     /**
      * The users that belong to the organization.

--- a/app/Models/Peoplecount/Alert.php
+++ b/app/Models/Peoplecount/Alert.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use App\Enums\Peoplecount\AlertChannel;
 use App\Enums\Peoplecount\AlertType;
 use App\Models\User;
 use Database\Factories\Peoplecount\AlertFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,25 +28,19 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
+#[Fillable([
+    'area_id',
+    'type',
+    'channel',
+    'cooldown_minutes',
+    'created_by',
+    'occupancy_alert_threshold',
+])]
+#[Table(name: 'peoplecount_alerts')]
 class Alert extends Model
 {
     /** @use HasFactory<AlertFactory> */
     use HasFactory;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_alerts';
-
-    /**
-     * @var list<string>
-     */
-    protected $fillable = [
-        'area_id',
-        'type',
-        'channel',
-        'cooldown_minutes',
-        'created_by',
-        'occupancy_alert_threshold',
-    ];
 
     /**
      * The Area that owns the alert.

--- a/app/Models/Peoplecount/Area.php
+++ b/app/Models/Peoplecount/Area.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use Database\Factories\Peoplecount\AreaFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -18,25 +22,17 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  */
+#[Fillable([
+    'name',
+    'event_id',
+])]
+#[Table(name: 'peoplecount_areas')]
 class Area extends Model
 {
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_areas';
-
     /** @use HasFactory<AreaFactory> */
     use HasFactory;
 
     use SoftDeletes;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'event_id',
-    ];
 
     /**
      * The Event that owns the area.

--- a/app/Models/Peoplecount/AreaAggregatedCount.php
+++ b/app/Models/Peoplecount/AreaAggregatedCount.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use App\Casts\BinaryHexCast;
 use Database\Factories\Peoplecount\AreaAggregatedCountFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,27 +22,19 @@ use Illuminate\Support\Carbon;
  * @property Carbon $period_end
  * @property string $checksum
  */
+#[Fillable([
+    'area_id',
+    'count',
+    'period_start',
+    'period_end',
+    'checksum',
+])]
+#[Table(name: 'peoplecount_area_aggregated_counts')]
+#[WithoutTimestamps]
 class AreaAggregatedCount extends Model
 {
     /** @use HasFactory<AreaAggregatedCountFactory> */
     use HasFactory;
-
-    public $timestamps = false;
-
-    protected $table = 'peoplecount_area_aggregated_counts';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'area_id',
-        'count',
-        'period_start',
-        'period_end',
-        'checksum',
-    ];
 
     /**
      * @return BelongsTo<Area, $this>

--- a/app/Models/Peoplecount/AreaRecurringReset.php
+++ b/app/Models/Peoplecount/AreaRecurringReset.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use Database\Factories\Peoplecount\AreaRecurringResetFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,26 +23,18 @@ use Illuminate\Support\Facades\Date;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
+#[Fillable([
+    'area_id',
+    'reset_value',
+    'reset_time',
+    'timezone',
+    'notes',
+])]
+#[Table(name: 'peoplecount_area_recurring_resets')]
 class AreaRecurringReset extends Model
 {
     /** @use HasFactory<AreaRecurringResetFactory> */
     use HasFactory;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_area_recurring_resets';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'area_id',
-        'reset_value',
-        'reset_time',
-        'timezone',
-        'notes',
-    ];
 
     /**
      * The Area that owns the recurring reset.

--- a/app/Models/Peoplecount/AreaSingleReset.php
+++ b/app/Models/Peoplecount/AreaSingleReset.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use App\Models\User;
 use Database\Factories\Peoplecount\AreaSingleResetFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,26 +23,18 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
+#[Fillable([
+    'area_id',
+    'reset_value',
+    'effective_at',
+    'created_by',
+    'notes',
+])]
+#[Table(name: 'peoplecount_area_single_resets')]
 class AreaSingleReset extends Model
 {
     /** @use HasFactory<AreaSingleResetFactory> */
     use HasFactory;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_area_single_resets';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'area_id',
-        'reset_value',
-        'effective_at',
-        'created_by',
-        'notes',
-    ];
 
     /**
      * The Area that owns the reset.

--- a/app/Models/Peoplecount/Assignment.php
+++ b/app/Models/Peoplecount/Assignment.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use Database\Factories\Peoplecount\AssignmentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,29 +25,21 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  */
+#[Fillable([
+    'event_id',
+    'area_id',
+    'sensor_id',
+    'direction_flipped',
+    'active_from',
+    'active_to',
+])]
+#[Table(name: 'peoplecount_assignments')]
 class Assignment extends Model
 {
     /** @use HasFactory<AssignmentFactory> */
     use HasFactory;
 
     use SoftDeletes;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_assignments';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'event_id',
-        'area_id',
-        'sensor_id',
-        'direction_flipped',
-        'active_from',
-        'active_to',
-    ];
 
     /**
      * The Event that owns the assignment.

--- a/app/Models/Peoplecount/Event.php
+++ b/app/Models/Peoplecount/Event.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use App\Models\Organization;
 use Database\Factories\Peoplecount\EventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,27 +25,19 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  */
+#[Fillable([
+    'name',
+    'organization_id',
+    'starts_at',
+    'ends_at',
+])]
+#[Table(name: 'peoplecount_events')]
 class Event extends Model
 {
     /** @use HasFactory<EventFactory> */
     use HasFactory;
 
     use SoftDeletes;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_events';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'organization_id',
-        'starts_at',
-        'ends_at',
-    ];
 
     /**
      * The Organization that owns the event.

--- a/app/Models/Peoplecount/IntervalCount.php
+++ b/app/Models/Peoplecount/IntervalCount.php
@@ -1,36 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
+use Carbon\CarbonImmutable;
 use Database\Factories\Peoplecount\IntervalCountFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int $id
+ * @property int $sensor_id
+ * @property CarbonImmutable $ts_from
+ * @property CarbonImmutable $ts_to
+ * @property CarbonImmutable $received_at
+ * @property int $count_in
+ * @property int $count_out
+ */
+#[Fillable([
+    'sensor_id',
+    'ts_from',
+    'ts_to',
+    'received_at',
+    'count_in',
+    'count_out',
+])]
+#[Table(name: 'peoplecount_interval_counts')]
+#[WithoutTimestamps]
 class IntervalCount extends Model
 {
     /** @use HasFactory<IntervalCountFactory> */
     use HasFactory;
-
-    /**
-     * Disable created_at and modified_at timestamps
-     */
-    public $timestamps = false;
-
-    /** The table associated with the model. */
-    protected $table = 'peoplecount_interval_counts';
-
-    /**
-     * The attributes that are mass assignable.
-     */
-    protected $fillable = [
-        'sensor_id',
-        'ts_from',
-        'ts_to',
-        'received_at',
-        'count_in',
-        'count_out',
-    ];
 
     /**
      * Relationship with the Sensor model.

--- a/app/Models/Peoplecount/Sensor.php
+++ b/app/Models/Peoplecount/Sensor.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models\Peoplecount;
 
 use App\Models\Organization;
 use Database\Factories\Peoplecount\SensorFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,29 +15,30 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * @property int $id
+ * @property string $vendor
+ * @property string $model
+ * @property string $serial
+ * @property int $organization_id
+ * @property string|null $api_token
+ */
+#[Fillable([
+    'vendor',
+    'model',
+    'serial',
+    'organization_id',
+    'api_token', // TODO: Storing token in plaintext, revisit if API becomes sensitive
+])]
+#[Table(name: 'peoplecount_sensors')]
 class Sensor extends Model
 {
-    protected $table = 'peoplecount_sensors';
-
     use HasApiTokens;
 
     /** @use HasFactory<SensorFactory> */
     use HasFactory;
 
     use SoftDeletes;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'vendor',
-        'model',
-        'serial',
-        'organization_id',
-        'api_token', // TODO: Storing token in plaintext, revisit if API becomes sensitive
-    ];
 
     /**
      * The Organization that owns the sensor.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Models\Peoplecount\AreaSingleReset;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,6 +18,17 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Spatie\Permission\Traits\HasRoles;
 
+#[Fillable([
+    'name',
+    'email',
+    'phone',
+    'password',
+    'eastereggs_activated',
+])]
+#[Hidden([
+    'password',
+    'remember_token',
+])]
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
@@ -21,29 +36,6 @@ class User extends Authenticatable implements MustVerifyEmail
 
     use HasRoles;
     use Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'phone',
-        'password',
-        'eastereggs_activated',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
 
     /**
      * The organizations that belong to the user.

--- a/app/Notifications/Peoplecount/AreaOccupancyAlert.php
+++ b/app/Notifications/Peoplecount/AreaOccupancyAlert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Notifications\Peoplecount;
 
 use Illuminate\Bus\Queueable;

--- a/app/PHPStan/Rules/ForbiddenMethodsRule.php
+++ b/app/PHPStan/Rules/ForbiddenMethodsRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\PHPStan\Rules;
 
 use PhpParser\Node;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
 use App\Listeners\Permissions\PermissionAttachedListener;

--- a/app/Services/GlobalPermissionService.php
+++ b/app/Services/GlobalPermissionService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\User;

--- a/app/Services/OrganizationSelectionService.php
+++ b/app/Services/OrganizationSelectionService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\Organization;

--- a/app/Services/OrganizationService.php
+++ b/app/Services/OrganizationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\Organization;

--- a/app/Services/Peoplecount/AlertService.php
+++ b/app/Services/Peoplecount/AlertService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Enums\Peoplecount\AlertChannel;

--- a/app/Services/Peoplecount/AreaAggregationService.php
+++ b/app/Services/Peoplecount/AreaAggregationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Organization;

--- a/app/Services/Peoplecount/AreaResetService.php
+++ b/app/Services/Peoplecount/AreaResetService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/app/Services/Peoplecount/AreaService.php
+++ b/app/Services/Peoplecount/AreaService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Organization;

--- a/app/Services/Peoplecount/AssignmentService.php
+++ b/app/Services/Peoplecount/AssignmentService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Peoplecount\Area;
@@ -145,8 +147,8 @@ class AssignmentService
 
         $activeFromDate = new DateTime($activeFrom);
         $activeToDate = new DateTime($activeTo);
-        $eventStartsAtDate = new DateTime($event->starts_at);
-        $eventEndsAtDate = new DateTime($event->ends_at);
+        $eventStartsAtDate = new DateTime($event->starts_at->toDateTimeString());
+        $eventEndsAtDate = new DateTime($event->ends_at->toDateTimeString());
 
         throw_if($activeFromDate < $eventStartsAtDate || $activeToDate > $eventEndsAtDate, ValidationException::withMessages([
             'active_from' => 'The assignment time boundaries must be within the event time boundaries.',

--- a/app/Services/Peoplecount/EventService.php
+++ b/app/Services/Peoplecount/EventService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Peoplecount\Event;

--- a/app/Services/Peoplecount/IntervalCountService.php
+++ b/app/Services/Peoplecount/IntervalCountService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Peoplecount\IntervalCount;

--- a/app/Services/Peoplecount/SensorActivityService.php
+++ b/app/Services/Peoplecount/SensorActivityService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Organization;

--- a/app/Services/Peoplecount/SensorService.php
+++ b/app/Services/Peoplecount/SensorService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Peoplecount;
 
 use App\Models\Organization;
@@ -89,7 +91,7 @@ class SensorService
                     ->get(['id', 'sensor_id', 'ts_from', 'ts_to', 'count_in', 'count_out']);
 
                 $latest = $counts->first();
-                $isRecent = $latest && Date::parse($latest->ts_to)->greaterThanOrEqualTo($recentThreshold);
+                $isRecent = $latest && $latest->ts_to->greaterThanOrEqualTo($recentThreshold);
                 $anyNonZero = $counts->contains(function (IntervalCount $c): bool {
                     return ($c->count_in ?? 0) > 0 || ($c->count_out ?? 0) > 0;
                 });
@@ -99,11 +101,11 @@ class SensorService
                     'serial' => $sensor->serial,
                     'vendor' => $sensor->vendor,
                     'model' => $sensor->model,
-                    'latest_ts' => $latest ? Date::parse($latest->ts_to)->toIso8601String() : null,
+                    'latest_ts' => $latest ? $latest->ts_to->toIso8601String() : null,
                     'interval_counts' => $counts->map(function (IntervalCount $c): array {
                         return [
-                            'ts_from' => Date::parse($c->ts_from)->toIso8601String(),
-                            'ts_to' => Date::parse($c->ts_to)->toIso8601String(),
+                            'ts_from' => $c->ts_from->toIso8601String(),
+                            'ts_to' => $c->ts_to->toIso8601String(),
                             'count_in' => (int) $c->count_in,
                             'count_out' => (int) $c->count_out,
                         ];

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\Organization;

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use App\Models\Organization;

--- a/database/factories/Peoplecount/AreaAggregatedCountFactory.php
+++ b/database/factories/Peoplecount/AreaAggregatedCountFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/database/factories/Peoplecount/AreaFactory.php
+++ b/database/factories/Peoplecount/AreaFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/database/factories/Peoplecount/AreaRecurringResetFactory.php
+++ b/database/factories/Peoplecount/AreaRecurringResetFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/database/factories/Peoplecount/AreaSingleResetFactory.php
+++ b/database/factories/Peoplecount/AreaSingleResetFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/database/factories/Peoplecount/AssignmentFactory.php
+++ b/database/factories/Peoplecount/AssignmentFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Peoplecount\Area;

--- a/database/factories/Peoplecount/EventFactory.php
+++ b/database/factories/Peoplecount/EventFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Organization;

--- a/database/factories/Peoplecount/SensorFactory.php
+++ b/database/factories/Peoplecount/SensorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories\Peoplecount;
 
 use App\Models\Organization;

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use App\Models\Organization;

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Organization;

--- a/database/seeders/PlaywrightTestSeeder.php
+++ b/database/seeders/PlaywrightTestSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Organization;

--- a/rector.php
+++ b/rector.php
@@ -2,16 +2,18 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Rector\ValueObject\PhpVersion;
 use RectorLaravel\Set\LaravelLevelSetList;
 use RectorLaravel\Set\LaravelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    // Paths to analyze (keep lean for precommit)
     $rectorConfig->paths([
         __DIR__.'/app',
         __DIR__.'/config',
@@ -19,10 +21,11 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__.'/routes',
     ]);
 
-    // Explicitly skip heavy or external directories
     $rectorConfig->skip([
-        RenameClassRector::class, // Skipping class renaming
-        AddClosureVoidReturnTypeWhereNoReturnRector::class, // Skipping void return type addition for closures
+        RenameClassRector::class,
+        AddClosureVoidReturnTypeWhereNoReturnRector::class,
+        SafeDeclareStrictTypesRector::class,
+        CompactToVariablesRector::class,
         __DIR__.'/vendor/*',
         __DIR__.'/node_modules/*',
         __DIR__.'/storage/*',
@@ -30,9 +33,8 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__.'/tests/*',
     ]);
 
-    // Apply sets for Laravel and general code quality
     $rectorConfig->sets([
-        LaravelLevelSetList::UP_TO_LARAVEL_120,
+        LaravelLevelSetList::UP_TO_LARAVEL_130,
         LaravelSetList::LARAVEL_CODE_QUALITY,
         LaravelSetList::LARAVEL_COLLECTION,
         LaravelSetList::LARAVEL_ARRAYACCESS_TO_METHOD_CALL,
@@ -46,9 +48,13 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::CODE_QUALITY,
         SetList::CODING_STYLE,
         SetList::TYPE_DECLARATION,
-        SetList::STRICT_BOOLEANS,
+        SetList::PHP_84,
+        SetList::EARLY_RETURN,
     ]);
 
-    // Define PHP version for Rector
+    $rectorConfig->rules([
+        DeclareStrictTypesRector::class,
+    ]);
+
     $rectorConfig->phpVersion(PhpVersion::PHP_84);
 };

--- a/tests/Architecture/PresetsTest.php
+++ b/tests/Architecture/PresetsTest.php
@@ -3,3 +3,8 @@
 arch()->preset()->php();
 arch()->preset()->security();
 arch()->preset()->laravel();
+
+arch()->expect('App')
+    ->classes()->not->toBeFinal()
+    ->classes()->not->toHavePrivateMethods()
+    ->toUseStrictTypes();


### PR DESCRIPTION
This PR applies the Rector/architecture alignment from #117 and then runs Rector to apply project-wide mechanical refactors. Result: strict types are now enforced consistently by both tooling and architecture tests, with no static analysis regressions.

## Details

- [rector.php](https://github.com/musikfestwochen/musikfestapp/blob/chore/update-rector-and-architecture-rules/rector.php) - bumps Laravel Rector level to v13, adds PHP 8.4 and early-return sets, enables explicit strict types rule, skips conflicting rules.
- [tests/Architecture/PresetsTest.php](https://github.com/musikfestwochen/musikfestapp/blob/chore/update-rector-and-architecture-rules/tests/Architecture/PresetsTest.php) - keeps relaxed class shape while enforcing strict types for App namespace.
- [app/Models/Peoplecount/Sensor.php](https://github.com/musikfestwochen/musikfestapp/blob/chore/update-rector-and-architecture-rules/app/Models/Peoplecount/Sensor.php) - representative model update after Rector attribute migrations plus PHPStan-friendly property docs.
- [app/Models/Peoplecount/IntervalCount.php](https://github.com/musikfestwochen/musikfestapp/blob/chore/update-rector-and-architecture-rules/app/Models/Peoplecount/IntervalCount.php) - representative interval model update including casts/property typing alignment.

Fixes #117

---
**«I have not failed. I've just found 10,000 ways that won't work.»**
_Thomas Edison_