### PR TITLE
Fix Ziggy import for asset builds

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -6,7 +6,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import { ZiggyVue } from 'ziggy-js';
 import { initializeTheme } from './composables/useAppearance';
 import { usePermissions } from './composables/usePermissions';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,15 +34,12 @@
         "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         "paths": {
-            /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"],
-            "ziggy-js": ["./vendor/tightenco/ziggy"]
+            /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"]
         },
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
         "types": [
             "vite/client",
-            "vue/tsx",
-            "./resources/js/types",
             "vitest/globals"
         ] /* Specify type package names to be included without being referenced in a source file. */,
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
Use the npm Ziggy package for the Vue plugin so frontend builds no longer depend on Composer's vendor directory being present. This matches the upstream Laravel Vue starter kit direction and prevents deploy builds from failing when PHP dependencies are intentionally skipped before asset compilation.

## Details

- [app.ts](https://github.com/musikfestwochen/musikfestapp/blob/fix/ziggy-import/resources/js/app.ts) - imports Ziggy from the npm package instead of Composer vendor files.
- [tsconfig.json](https://github.com/musikfestwochen/musikfestapp/blob/fix/ziggy-import/tsconfig.json) - removes the stale Ziggy vendor alias and invalid type references.

## Notes

Tested with `npm run build`. `npx vue-tsc --noEmit` now gets past the removed invalid type references, then reports existing app type errors outside this fix.

## Reviewer Setup

Frontend build configuration changed. You likely need to run:

```sh
npm run build
```

---
**«Do what you can, with what you have, where you are.»**
_Theodore Roosevelt_