### PR TITLE
feat: add peoplecount sensor sharing and archiving

### DIFF
--- a/app/Http/Controllers/Peoplecount/AssignmentController.php
+++ b/app/Http/Controllers/Peoplecount/AssignmentController.php
@@ -14,15 +14,21 @@ use App\Http\Requests\Peoplecount\AssignmentStoreRequest;
 use App\Http\Requests\Peoplecount\AssignmentUpdateRequest;
 use App\Models\Organization;
 use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Sensor;
 use App\Services\Peoplecount\AssignmentService;
+use App\Services\Peoplecount\SensorService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class AssignmentController extends Controller
 {
-    public function __construct(private readonly AssignmentService $assignmentService) {}
+    public function __construct(
+        private readonly AssignmentService $assignmentService,
+        private readonly SensorService $sensorService,
+    ) {}
 
     /**
      * Display a listing of the resource.
@@ -68,7 +74,7 @@ class AssignmentController extends Controller
         return Inertia::render('peoplecount/NewAssignment', [
             'organization' => $organization,
             'events' => $organization->events()->with('areas')->get(),
-            'sensors' => $organization->sensors()->get(),
+            'sensors' => $this->sensorService->getAssignableSensorsForOrganization($organization),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -80,6 +86,8 @@ class AssignmentController extends Controller
      */
     public function show(AssignmentShowRequest $request, Organization $organization, Assignment $assignment): RedirectResponse
     {
+        $this->assignmentService->verifyAssignmentBelongsToCurrentOrganization($assignment);
+
         return to_route('peoplecount.assignments.edit', [
             'organization' => $organization,
             'assignment' => $assignment,
@@ -91,14 +99,16 @@ class AssignmentController extends Controller
      */
     public function edit(AssignmentEditRequest $request, Organization $organization, Assignment $assignment): Response
     {
+        $this->assignmentService->verifyAssignmentBelongsToCurrentOrganization($assignment);
+
         // Load relationships
-        $assignment->load(['event', 'area', 'sensor']);
+        $assignment->load(['event', 'area', 'sensor.organization']);
 
         return Inertia::render('peoplecount/EditAssignment', [
             'organization' => $organization,
             'assignment' => $assignment,
             'events' => $organization->events()->with('areas')->get(),
-            'sensors' => $organization->sensors()->get(),
+            'sensors' => $this->getAssignableSensorsForAssignmentEdit($organization, $assignment),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -136,11 +146,29 @@ class AssignmentController extends Controller
      */
     public function destroy(AssignmentDestroyRequest $request, Organization $organization, Assignment $assignment): RedirectResponse
     {
+        $this->assignmentService->verifyAssignmentBelongsToCurrentOrganization($assignment);
+
         $assignment->delete();
 
         return to_route('peoplecount.assignments.index', [
             'organization' => $organization,
         ])
             ->with('status', 'Assignment deleted successfully.');
+    }
+
+    /**
+     * Include current assignment sensor even when archived or outside current share window.
+     *
+     * @return Collection<int, Sensor>
+     */
+    protected function getAssignableSensorsForAssignmentEdit(Organization $organization, Assignment $assignment): Collection
+    {
+        $sensors = $this->sensorService->getAssignableSensorsForOrganization($organization);
+
+        if ($assignment->sensor && $sensors->doesntContain('id', $assignment->sensor->id)) {
+            $sensors->push($assignment->sensor);
+        }
+
+        return $sensors->unique('id')->values();
     }
 }

--- a/app/Http/Controllers/Peoplecount/AssignmentController.php
+++ b/app/Http/Controllers/Peoplecount/AssignmentController.php
@@ -14,11 +14,9 @@ use App\Http\Requests\Peoplecount\AssignmentStoreRequest;
 use App\Http\Requests\Peoplecount\AssignmentUpdateRequest;
 use App\Models\Organization;
 use App\Models\Peoplecount\Assignment;
-use App\Models\Peoplecount\Sensor;
 use App\Services\Peoplecount\AssignmentService;
 use App\Services\Peoplecount\SensorService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -49,12 +47,12 @@ class AssignmentController extends Controller
     {
         try {
             $this->assignmentService->create([
-                'event_id' => $request->input('event_id'),
-                'area_id' => $request->input('area_id'),
-                'sensor_id' => $request->input('sensor_id'),
-                'direction_flipped' => $request->input('direction_flipped'),
-                'active_from' => $request->input('active_from'),
-                'active_to' => $request->input('active_to'),
+                'event_id' => $request->validated('event_id'),
+                'area_id' => $request->validated('area_id'),
+                'sensor_id' => $request->validated('sensor_id'),
+                'direction_flipped' => $request->validated('direction_flipped'),
+                'active_from' => $request->validated('active_from'),
+                'active_to' => $request->validated('active_to'),
             ]);
 
             return to_route('peoplecount.assignments.index', [
@@ -108,7 +106,7 @@ class AssignmentController extends Controller
             'organization' => $organization,
             'assignment' => $assignment,
             'events' => $organization->events()->with('areas')->get(),
-            'sensors' => $this->getAssignableSensorsForAssignmentEdit($organization, $assignment),
+            'sensors' => $this->sensorService->getAssignableSensorsForAssignmentEdit($organization, $assignment),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -122,12 +120,12 @@ class AssignmentController extends Controller
     {
         try {
             $this->assignmentService->update($assignment, [
-                'event_id' => $request->input('event_id'),
-                'area_id' => $request->input('area_id'),
-                'sensor_id' => $request->input('sensor_id'),
-                'direction_flipped' => $request->input('direction_flipped'),
-                'active_from' => $request->input('active_from'),
-                'active_to' => $request->input('active_to'),
+                'event_id' => $request->validated('event_id'),
+                'area_id' => $request->validated('area_id'),
+                'sensor_id' => $request->validated('sensor_id'),
+                'direction_flipped' => $request->validated('direction_flipped'),
+                'active_from' => $request->validated('active_from'),
+                'active_to' => $request->validated('active_to'),
             ]);
 
             return to_route('peoplecount.assignments.index', [
@@ -154,21 +152,5 @@ class AssignmentController extends Controller
             'organization' => $organization,
         ])
             ->with('status', 'Assignment deleted successfully.');
-    }
-
-    /**
-     * Include current assignment sensor even when archived or outside current share window.
-     *
-     * @return Collection<int, Sensor>
-     */
-    protected function getAssignableSensorsForAssignmentEdit(Organization $organization, Assignment $assignment): Collection
-    {
-        $sensors = $this->sensorService->getAssignableSensorsForOrganization($organization);
-
-        if ($assignment->sensor && $sensors->doesntContain('id', $assignment->sensor->id)) {
-            $sensors->push($assignment->sensor);
-        }
-
-        return $sensors->unique('id')->values();
     }
 }

--- a/app/Http/Controllers/Peoplecount/SensorArchiveController.php
+++ b/app/Http/Controllers/Peoplecount/SensorArchiveController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Peoplecount;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Peoplecount\SensorArchiveUpdateRequest;
+use App\Models\Organization;
+use App\Models\Peoplecount\Sensor;
+use App\Services\Peoplecount\SensorService;
+use Illuminate\Http\RedirectResponse;
+
+class SensorArchiveController extends Controller
+{
+    public function __construct(private readonly SensorService $sensorService) {}
+
+    public function store(SensorArchiveUpdateRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
+    {
+        $this->sensorService->archive($sensor);
+
+        return to_route('peoplecount.sensors.index', [
+            'organization' => $organization,
+        ])->with('status', 'Sensor archived successfully.');
+    }
+
+    public function destroy(SensorArchiveUpdateRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
+    {
+        $this->sensorService->unarchive($sensor);
+
+        return to_route('peoplecount.sensors.index', [
+            'organization' => $organization,
+            'archived' => true,
+        ])->with('status', 'Sensor restored successfully.');
+    }
+}

--- a/app/Http/Controllers/Peoplecount/SensorController.php
+++ b/app/Http/Controllers/Peoplecount/SensorController.php
@@ -17,6 +17,7 @@ use App\Models\Peoplecount\Sensor;
 use App\Services\Peoplecount\SensorService;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -30,8 +31,9 @@ class SensorController extends Controller
     public function index(SensorIndexRequest $request, Organization $organization): Response
     {
         return Inertia::render('peoplecount/Sensors', [
-            'sensors' => $this->sensorService->getSensors(),
+            'sensors' => $this->sensorService->getSensors($request->boolean('archived')),
             'organization' => $organization,
+            'showArchived' => $request->boolean('archived'),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -83,14 +85,24 @@ class SensorController extends Controller
      */
     public function edit(SensorEditRequest $request, Organization $organization, Sensor $sensor): Response
     {
+        $this->sensorService->verifySensorManagedByCurrentOrganization($sensor);
+
         // get the last 10 interval counts for the sensor
         $sensor->load(['intervalCounts' => function (HasMany $query) {
             $query->orderBy('ts_from', 'desc')->take(10);
+        }, 'shares' => function (HasMany $query) {
+            $query->with('borrowerOrganization')
+                ->withCount('assignments')
+                ->latest('starts_at');
         }]);
 
         return Inertia::render('peoplecount/EditSensor', [
             'organization' => $organization,
             'sensor' => $sensor,
+            'organizations' => Organization::query()
+                ->whereKeyNot($organization->id)
+                ->orderBy('name')
+                ->get(['id', 'name']),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -102,7 +114,9 @@ class SensorController extends Controller
      */
     public function update(SensorUpdateRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
     {
-        $sensor->update($request->all());
+        $this->sensorService->verifySensorManagedByCurrentOrganization($sensor);
+
+        $sensor->update($request->validated());
 
         return to_route('peoplecount.sensors.index', [
             'organization' => $organization,
@@ -119,7 +133,12 @@ class SensorController extends Controller
     public function destroy(SensorDestroyRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
     {
         $name = $sensor->vendor.' '.$sensor->model.' '.$sensor->serial;
-        $sensor->delete();
+
+        try {
+            $this->sensorService->delete($sensor);
+        } catch (ValidationException $validationException) {
+            return back()->withErrors($validationException->errors());
+        }
 
         return to_route('peoplecount.sensors.index', [
             'organization' => $organization,

--- a/app/Http/Controllers/Peoplecount/SensorShareController.php
+++ b/app/Http/Controllers/Peoplecount/SensorShareController.php
@@ -24,9 +24,9 @@ class SensorShareController extends Controller
         try {
             $this->sensorShareService->create([
                 'sensor_id' => $sensor->id,
-                'borrower_organization_id' => $request->input('borrower_organization_id'),
-                'starts_at' => $request->input('starts_at'),
-                'ends_at' => $request->input('ends_at'),
+                'borrower_organization_id' => $request->validated('borrower_organization_id'),
+                'starts_at' => $request->validated('starts_at'),
+                'ends_at' => $request->validated('ends_at'),
             ]);
         } catch (ValidationException $validationException) {
             return back()->withErrors($validationException->errors())->withInput();
@@ -44,9 +44,9 @@ class SensorShareController extends Controller
 
         try {
             $this->sensorShareService->update($share, [
-                'borrower_organization_id' => $request->input('borrower_organization_id'),
-                'starts_at' => $request->input('starts_at'),
-                'ends_at' => $request->input('ends_at'),
+                'borrower_organization_id' => $request->validated('borrower_organization_id'),
+                'starts_at' => $request->validated('starts_at'),
+                'ends_at' => $request->validated('ends_at'),
             ]);
         } catch (ValidationException $validationException) {
             return back()->withErrors($validationException->errors())->withInput();

--- a/app/Http/Controllers/Peoplecount/SensorShareController.php
+++ b/app/Http/Controllers/Peoplecount/SensorShareController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Peoplecount;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Peoplecount\SensorShareDestroyRequest;
+use App\Http\Requests\Peoplecount\SensorShareStoreRequest;
+use App\Http\Requests\Peoplecount\SensorShareUpdateRequest;
+use App\Models\Organization;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use App\Services\Peoplecount\SensorShareService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
+
+class SensorShareController extends Controller
+{
+    public function __construct(private readonly SensorShareService $sensorShareService) {}
+
+    public function store(SensorShareStoreRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
+    {
+        try {
+            $this->sensorShareService->create([
+                'sensor_id' => $sensor->id,
+                'borrower_organization_id' => $request->input('borrower_organization_id'),
+                'starts_at' => $request->input('starts_at'),
+                'ends_at' => $request->input('ends_at'),
+            ]);
+        } catch (ValidationException $validationException) {
+            return back()->withErrors($validationException->errors())->withInput();
+        }
+
+        return to_route('peoplecount.sensors.edit', [
+            'organization' => $organization,
+            'sensor' => $sensor,
+        ])->with('status', 'Sensor shared successfully.');
+    }
+
+    public function update(SensorShareUpdateRequest $request, Organization $organization, Sensor $sensor, SensorShare $share): RedirectResponse
+    {
+        abort_if($share->sensor_id !== $sensor->id, 404);
+
+        try {
+            $this->sensorShareService->update($share, [
+                'borrower_organization_id' => $request->input('borrower_organization_id'),
+                'starts_at' => $request->input('starts_at'),
+                'ends_at' => $request->input('ends_at'),
+            ]);
+        } catch (ValidationException $validationException) {
+            return back()->withErrors($validationException->errors())->withInput();
+        }
+
+        return to_route('peoplecount.sensors.edit', [
+            'organization' => $organization,
+            'sensor' => $sensor,
+        ])->with('status', 'Sensor share updated successfully.');
+    }
+
+    public function destroy(SensorShareDestroyRequest $request, Organization $organization, Sensor $sensor, SensorShare $share): RedirectResponse
+    {
+        abort_if($share->sensor_id !== $sensor->id, 404);
+
+        try {
+            $this->sensorShareService->delete($share);
+        } catch (ValidationException $validationException) {
+            return back()->withErrors($validationException->errors());
+        }
+
+        return to_route('peoplecount.sensors.edit', [
+            'organization' => $organization,
+            'sensor' => $sensor,
+        ])->with('status', 'Sensor share deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Peoplecount/SensorTokenController.php
+++ b/app/Http/Controllers/Peoplecount/SensorTokenController.php
@@ -22,6 +22,8 @@ class SensorTokenController extends Controller
      */
     public function update(SensorTokenUpdateRequest $request, Organization $organization, Sensor $sensor): RedirectResponse
     {
+        $this->sensorService->verifySensorManagedByCurrentOrganization($sensor);
+
         $token = $this->sensorService->createOrRegenerateToken($sensor);
         $sensor->api_token = $token;
         $sensor->save();

--- a/app/Http/Requests/Peoplecount/SensorArchiveUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorArchiveUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Peoplecount;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SensorArchiveUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->can('peoplecount.sensors.update');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+        ];
+    }
+}

--- a/app/Http/Requests/Peoplecount/SensorShareDestroyRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShareDestroyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Peoplecount;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SensorShareDestroyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->can('peoplecount.sensors.update');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+        ];
+    }
+}

--- a/app/Http/Requests/Peoplecount/SensorShareStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShareStoreRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Peoplecount;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SensorShareStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->can('peoplecount.sensors.update');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
+            'starts_at' => ['required', 'date', 'before:ends_at'],
+            'ends_at' => ['required', 'date', 'after:starts_at'],
+        ];
+    }
+}

--- a/app/Http/Requests/Peoplecount/SensorShareUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShareUpdateRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Peoplecount;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SensorShareUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->can('peoplecount.sensors.update');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
+            'starts_at' => ['required', 'date', 'before:ends_at'],
+            'ends_at' => ['required', 'date', 'after:starts_at'],
+        ];
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -92,4 +92,24 @@ class Organization extends Model
     {
         return $this->hasManyThrough(Peoplecount\Assignment::class, Peoplecount\Event::class);
     }
+
+    /**
+     * Sensor shares this organization has created for other organizations.
+     *
+     * @return HasMany<Peoplecount\SensorShare, $this>
+     */
+    public function lentSensorShares(): HasMany
+    {
+        return $this->hasMany(Peoplecount\SensorShare::class, 'owner_organization_id');
+    }
+
+    /**
+     * Sensor shares this organization can use from other organizations.
+     *
+     * @return HasMany<Peoplecount\SensorShare, $this>
+     */
+    public function borrowedSensorShares(): HasMany
+    {
+        return $this->hasMany(Peoplecount\SensorShare::class, 'borrower_organization_id');
+    }
 }

--- a/app/Models/Peoplecount/Assignment.php
+++ b/app/Models/Peoplecount/Assignment.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Carbon;
  * @property int $event_id
  * @property int $area_id
  * @property int $sensor_id
+ * @property int|null $sensor_share_id
  * @property bool $direction_flipped
  * @property Carbon $active_from
  * @property Carbon $active_to
@@ -29,6 +30,7 @@ use Illuminate\Support\Carbon;
     'event_id',
     'area_id',
     'sensor_id',
+    'sensor_share_id',
     'direction_flipped',
     'active_from',
     'active_to',
@@ -69,6 +71,16 @@ class Assignment extends Model
     public function sensor(): BelongsTo
     {
         return $this->belongsTo(Sensor::class);
+    }
+
+    /**
+     * The share that authorized this assignment, when using a foreign sensor.
+     *
+     * @return BelongsTo<SensorShare, $this>
+     */
+    public function sensorShare(): BelongsTo
+    {
+        return $this->belongsTo(SensorShare::class);
     }
 
     /**

--- a/app/Models/Peoplecount/Sensor.php
+++ b/app/Models/Peoplecount/Sensor.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -22,12 +23,14 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $serial
  * @property int $organization_id
  * @property string|null $api_token
+ * @property Carbon|null $archived_at
  */
 #[Fillable([
     'vendor',
     'model',
     'serial',
     'organization_id',
+    'archived_at',
     'api_token', // TODO: Storing token in plaintext, revisit if API becomes sensitive
 ])]
 #[Table(name: 'peoplecount_sensors')]
@@ -68,5 +71,25 @@ class Sensor extends Model
     public function assignments(): HasMany
     {
         return $this->hasMany(Assignment::class);
+    }
+
+    /**
+     * The shares associated with the sensor.
+     *
+     * @return HasMany<SensorShare, $this>
+     */
+    public function shares(): HasMany
+    {
+        return $this->hasMany(SensorShare::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'archived_at' => 'datetime',
+        ];
     }
 }

--- a/app/Models/Peoplecount/SensorShare.php
+++ b/app/Models/Peoplecount/SensorShare.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
 /**
@@ -24,7 +23,6 @@ use Illuminate\Support\Carbon;
  * @property int|null $created_by
  * @property Carbon $starts_at
  * @property Carbon $ends_at
- * @property Carbon|null $deleted_at
  */
 #[Fillable([
     'sensor_id',
@@ -39,8 +37,6 @@ class SensorShare extends Model
 {
     /** @use HasFactory<SensorShareFactory> */
     use HasFactory;
-
-    use SoftDeletes;
 
     /**
      * @return BelongsTo<Sensor, $this>

--- a/app/Models/Peoplecount/SensorShare.php
+++ b/app/Models/Peoplecount/SensorShare.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Peoplecount;
+
+use App\Models\Organization;
+use App\Models\User;
+use Database\Factories\Peoplecount\SensorShareFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $sensor_id
+ * @property int $owner_organization_id
+ * @property int $borrower_organization_id
+ * @property int|null $created_by
+ * @property Carbon $starts_at
+ * @property Carbon $ends_at
+ * @property Carbon|null $deleted_at
+ */
+#[Fillable([
+    'sensor_id',
+    'owner_organization_id',
+    'borrower_organization_id',
+    'created_by',
+    'starts_at',
+    'ends_at',
+])]
+#[Table(name: 'peoplecount_sensor_shares')]
+class SensorShare extends Model
+{
+    /** @use HasFactory<SensorShareFactory> */
+    use HasFactory;
+
+    use SoftDeletes;
+
+    /**
+     * @return BelongsTo<Sensor, $this>
+     */
+    public function sensor(): BelongsTo
+    {
+        return $this->belongsTo(Sensor::class);
+    }
+
+    /**
+     * @return BelongsTo<Organization, $this>
+     */
+    public function ownerOrganization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class, 'owner_organization_id');
+    }
+
+    /**
+     * @return BelongsTo<Organization, $this>
+     */
+    public function borrowerOrganization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class, 'borrower_organization_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * @return HasMany<Assignment, $this>
+     */
+    public function assignments(): HasMany
+    {
+        return $this->hasMany(Assignment::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Services/Peoplecount/AssignmentService.php
+++ b/app/Services/Peoplecount/AssignmentService.php
@@ -8,6 +8,7 @@ use App\Models\Peoplecount\Area;
 use App\Models\Peoplecount\Assignment;
 use App\Models\Peoplecount\Event;
 use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
 use DateTime;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
@@ -16,6 +17,13 @@ use Illuminate\Validation\ValidationException;
 
 class AssignmentService
 {
+    private readonly SensorShareService $sensorShareService;
+
+    public function __construct(?SensorShareService $sensorShareService = null)
+    {
+        $this->sensorShareService = $sensorShareService ?? new SensorShareService;
+    }
+
     /**
      * Get all assignments for the current organization.
      *
@@ -47,10 +55,9 @@ class AssignmentService
      */
     public function create(array $attributes): Assignment
     {
-        // Verify that the event, area, and sensor belong to the current organization
+        // Verify that the event and area belong to the current organization
         $this->verifyEventBelongsToCurrentOrganization($attributes['event_id']);
         $this->verifyAreaBelongsToEvent($attributes['area_id'], $attributes['event_id']);
-        $this->verifySensorBelongsToCurrentOrganization($attributes['sensor_id']);
 
         // Verify that the assignment time boundaries are within event time boundaries
         $this->verifyAssignmentTimeWithinEventTime(
@@ -67,6 +74,8 @@ class AssignmentService
             $attributes['active_from'],
             $attributes['active_to']
         );
+
+        $attributes['sensor_share_id'] = $this->resolveSensorShareIdForAssignment($attributes);
 
         return Assignment::query()->create($attributes);
     }
@@ -118,11 +127,42 @@ class AssignmentService
      *
      * @throws AuthorizationException
      */
+    public function verifySensorAssignableToEvent(int $sensorId, int $eventId, string $activeFrom, string $activeTo, ?Assignment $assignment = null): ?SensorShare
+    {
+        $currentOrgId = getPermissionsOrgId();
+        $sensor = Sensor::query()->findOrFail($sensorId);
+
+        $this->verifySensorIsNotArchivedForAssignment($sensor, $assignment);
+
+        // Skip check for global organization
+        if ($currentOrgId === GLOBAL_ORG_ID) {
+            return null;
+        }
+
+        $event = Event::query()->findOrFail($eventId);
+
+        if ($sensor->organization_id === $currentOrgId) {
+            return null;
+        }
+
+        $sensorShare = $this->sensorShareService->findValidShareForAssignment($sensor, $event, $activeFrom, $activeTo);
+
+        throw_if(
+            ! $sensorShare instanceof SensorShare,
+            AuthorizationException::class,
+            'You are not authorized to assign this sensor for the selected period.'
+        );
+
+        return $sensorShare;
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
     public function verifySensorBelongsToCurrentOrganization(int $sensorId): void
     {
         $currentOrgId = getPermissionsOrgId();
 
-        // Skip check for global organization
         if ($currentOrgId === GLOBAL_ORG_ID) {
             return;
         }
@@ -170,29 +210,23 @@ class AssignmentService
     ): void {
         $query = Assignment::query()
             ->where('sensor_id', $sensorId)
-            ->where('direction_flipped', $directionFlipped);
+            ->where('direction_flipped', $directionFlipped)
+            ->whereHas('event', function (Builder $query) {
+                $currentOrgId = getPermissionsOrgId();
+
+                if ($currentOrgId !== GLOBAL_ORG_ID) {
+                    $query->where('organization_id', $currentOrgId);
+                }
+            });
 
         // Exclude the current assignment when updating
         if ($assignmentId !== null) {
             $query->where('id', '!=', $assignmentId);
         }
 
-        // Check for overlapping time periods
-        $query->where(function (Builder $query) use ($activeFrom, $activeTo) {
-            $query->where(function (Builder $query) use ($activeFrom) {
-                // New assignment starts during an existing assignment
-                $query->where('active_from', '<=', $activeFrom)
-                    ->where('active_to', '>=', $activeFrom);
-            })->orWhere(function (Builder $query) use ($activeTo) {
-                // New assignment ends during an existing assignment
-                $query->where('active_from', '<=', $activeTo)
-                    ->where('active_to', '>=', $activeTo);
-            })->orWhere(function (Builder $query) use ($activeFrom, $activeTo) {
-                // New assignment completely contains an existing assignment
-                $query->where('active_from', '>=', $activeFrom)
-                    ->where('active_to', '<=', $activeTo);
-            });
-        });
+        // Exclusive boundary overlap: [existing_from, existing_to) intersects [new_from, new_to)
+        $query->where('active_from', '<', $activeTo)
+            ->where('active_to', '>', $activeFrom);
 
         $overlappingAssignments = $query->get();
 
@@ -214,10 +248,11 @@ class AssignmentService
      */
     public function update(Assignment $assignment, array $attributes): Assignment
     {
-        // Verify that the event, area, and sensor belong to the current organization
+        $this->verifyAssignmentBelongsToCurrentOrganization($assignment);
+
+        // Verify that the event and area belong to the current organization
         $this->verifyEventBelongsToCurrentOrganization($attributes['event_id']);
         $this->verifyAreaBelongsToEvent($attributes['area_id'], $attributes['event_id']);
-        $this->verifySensorBelongsToCurrentOrganization($attributes['sensor_id']);
 
         // Verify that the assignment time boundaries are within event time boundaries
         $this->verifyAssignmentTimeWithinEventTime(
@@ -235,8 +270,59 @@ class AssignmentService
             $attributes['active_to']
         );
 
+        $attributes['sensor_share_id'] = $this->resolveSensorShareIdForAssignment($attributes, $assignment);
+
         $assignment->update($attributes);
 
         return $assignment;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    protected function resolveSensorShareIdForAssignment(array $attributes, ?Assignment $assignment = null): ?int
+    {
+        return $this->verifySensorAssignableToEvent(
+            $attributes['sensor_id'],
+            $attributes['event_id'],
+            $attributes['active_from'],
+            $attributes['active_to'],
+            $assignment
+        )?->id;
+    }
+
+    protected function verifySensorIsNotArchivedForAssignment(Sensor $sensor, ?Assignment $assignment): void
+    {
+        if ($sensor->archived_at === null) {
+            return;
+        }
+
+        if ($assignment?->sensor_id === $sensor->id) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'sensor_id' => 'Archived sensors cannot be assigned.',
+        ]);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function verifyAssignmentBelongsToCurrentOrganization(Assignment $assignment): void
+    {
+        $currentOrgId = getPermissionsOrgId();
+
+        if ($currentOrgId === GLOBAL_ORG_ID) {
+            return;
+        }
+
+        $assignment->loadMissing('event');
+
+        throw_if(
+            $assignment->event->organization_id !== $currentOrgId,
+            AuthorizationException::class,
+            'You are not authorized to manage this assignment.'
+        );
     }
 }

--- a/app/Services/Peoplecount/SensorService.php
+++ b/app/Services/Peoplecount/SensorService.php
@@ -58,6 +58,23 @@ class SensorService
     }
 
     /**
+     * Get assignable sensors for editing an assignment, including the assignment's
+     * current sensor even if archived or outside share windows.
+     *
+     * @return Collection<int, Sensor>
+     */
+    public function getAssignableSensorsForAssignmentEdit(Organization $organization, Assignment $assignment): Collection
+    {
+        $sensors = $this->getAssignableSensorsForOrganization($organization);
+
+        if ($assignment->sensor && $sensors->doesntContain('id', $assignment->sensor->id)) {
+            $sensors->push($assignment->sensor);
+        }
+
+        return $sensors->unique('id')->values();
+    }
+
+    /**
      * Get health status for currently assigned sensors in an organization.
      *
      * A sensor is healthy if:

--- a/app/Services/Peoplecount/SensorService.php
+++ b/app/Services/Peoplecount/SensorService.php
@@ -8,9 +8,12 @@ use App\Models\Organization;
 use App\Models\Peoplecount\Assignment;
 use App\Models\Peoplecount\IntervalCount;
 use App\Models\Peoplecount\Sensor;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\ValidationException;
 
 class SensorService
 {
@@ -19,7 +22,7 @@ class SensorService
     /**
      * @return Collection<int, Sensor>
      */
-    public function getSensors(): Collection
+    public function getSensors(bool $onlyArchived = false): Collection
     {
         $currentOrgId = getPermissionsOrgId();
         $query = Sensor::query();
@@ -28,7 +31,30 @@ class SensorService
             $query->where('organization_id', $currentOrgId);
         }
 
+        $onlyArchived
+            ? $query->whereNotNull('archived_at')
+            : $query->whereNull('archived_at');
+
         return $query->get();
+    }
+
+    /**
+     * @return Collection<int, Sensor>
+     */
+    public function getAssignableSensorsForOrganization(Organization $organization): Collection
+    {
+        $ownedSensors = $organization->sensors()
+            ->whereNull('archived_at')
+            ->get();
+
+        $borrowedSensors = $organization->borrowedSensorShares()
+            ->where('ends_at', '>=', Date::now())
+            ->with(['sensor.organization'])
+            ->get()
+            ->pluck('sensor')
+            ->filter(fn (?Sensor $sensor): bool => $sensor instanceof Sensor && $sensor->archived_at === null);
+
+        return $ownedSensors->concat($borrowedSensors)->unique('id')->values();
     }
 
     /**
@@ -52,10 +78,13 @@ class SensorService
             $now = Date::now()->setTimezone($timezone);
             $recentThreshold = $now->copy()->subMinutes(2);
 
-            // Find sensors that are currently assigned somewhere within an active assignment window
+            // Find sensors currently assigned to this organization's events.
             $assignedSensorIds = Assignment::query()
                 ->whereBetween('active_from', ['1900-01-01', $now])
                 ->where('active_to', '>=', $now)
+                ->whereHas('event', function (Builder $query) use ($organization): void {
+                    $query->where('organization_id', $organization->id);
+                })
                 ->pluck('sensor_id')
                 ->unique()
                 ->values();
@@ -74,7 +103,6 @@ class SensorService
             // Load sensors for the organization and that are currently assigned
             $sensors = Sensor::query()
                 ->whereIn('id', $assignedSensorIds)
-                ->where('organization_id', $organization->id)
                 ->get(['id', 'vendor', 'model', 'serial']);
 
             $healthy = [];
@@ -169,5 +197,49 @@ class SensorService
         $parts = explode('|', $token->plainTextToken, 2);
 
         return $parts[1] ?? $token->plainTextToken;
+    }
+
+    public function archive(Sensor $sensor): Sensor
+    {
+        $this->verifySensorManagedByCurrentOrganization($sensor);
+
+        $sensor->update(['archived_at' => Date::now()]);
+
+        return $sensor;
+    }
+
+    public function unarchive(Sensor $sensor): Sensor
+    {
+        $this->verifySensorManagedByCurrentOrganization($sensor);
+
+        $sensor->update(['archived_at' => null]);
+
+        return $sensor;
+    }
+
+    public function delete(Sensor $sensor): void
+    {
+        $this->verifySensorManagedByCurrentOrganization($sensor);
+
+        throw_if($sensor->assignments()->exists(), ValidationException::withMessages([
+            'sensor_id' => 'This sensor cannot be deleted because it is used by assignments.',
+        ]));
+
+        $sensor->delete();
+    }
+
+    public function verifySensorManagedByCurrentOrganization(Sensor $sensor): void
+    {
+        $currentOrgId = getPermissionsOrgId();
+
+        if ($currentOrgId === GLOBAL_ORG_ID) {
+            return;
+        }
+
+        throw_if(
+            $sensor->organization_id !== $currentOrgId,
+            AuthorizationException::class,
+            'You are not authorized to manage this sensor.'
+        );
     }
 }

--- a/app/Services/Peoplecount/SensorService.php
+++ b/app/Services/Peoplecount/SensorService.php
@@ -117,7 +117,7 @@ class SensorService
                 ];
             }
 
-            // Load sensors for the organization and that are currently assigned
+            // Load sensors that are currently assigned within the organization's events
             $sensors = Sensor::query()
                 ->whereIn('id', $assignedSensorIds)
                 ->get(['id', 'vendor', 'model', 'serial']);

--- a/app/Services/Peoplecount/SensorShareService.php
+++ b/app/Services/Peoplecount/SensorShareService.php
@@ -97,6 +97,7 @@ class SensorShareService
             ->where('borrower_organization_id', $event->organization_id)
             ->where('starts_at', '<=', $activeFrom)
             ->where('ends_at', '>=', $activeTo)
+            ->orderByDesc('id')
             ->first();
     }
 

--- a/app/Services/Peoplecount/SensorShareService.php
+++ b/app/Services/Peoplecount/SensorShareService.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Peoplecount;
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Event;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\ValidationException;
+
+class SensorShareService
+{
+    /**
+     * @return Collection<int, SensorShare>
+     */
+    public function getLentShares(Organization $organization): Collection
+    {
+        return $organization->lentSensorShares()
+            ->with(['sensor', 'borrowerOrganization'])
+            ->latest('starts_at')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, SensorShare>
+     */
+    public function getBorrowedShares(Organization $organization): Collection
+    {
+        return $organization->borrowedSensorShares()
+            ->with(['sensor.organization', 'ownerOrganization'])
+            ->latest('starts_at')
+            ->get();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function create(array $attributes): SensorShare
+    {
+        $sensor = Sensor::query()->whereKey((int) $attributes['sensor_id'])->firstOrFail();
+        $this->verifySensorOwnedByCurrentOrganization($sensor);
+        $this->verifyBorrowerIsDifferentOrganization((int) $attributes['borrower_organization_id'], $sensor->organization_id);
+
+        return SensorShare::query()->create([
+            'sensor_id' => $sensor->id,
+            'owner_organization_id' => $sensor->organization_id,
+            'borrower_organization_id' => $attributes['borrower_organization_id'],
+            'created_by' => $attributes['created_by'] ?? auth()->id(),
+            'starts_at' => $attributes['starts_at'],
+            'ends_at' => $attributes['ends_at'],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(SensorShare $sensorShare, array $attributes): SensorShare
+    {
+        $this->verifyShareOwnedByCurrentOrganization($sensorShare);
+        $this->verifyBorrowerCanBeChanged($sensorShare, (int) ($attributes['borrower_organization_id'] ?? $sensorShare->borrower_organization_id));
+        $this->verifyShareWindowContainsAssignments(
+            $sensorShare,
+            Date::parse($attributes['starts_at']),
+            Date::parse($attributes['ends_at'])
+        );
+
+        $sensorShare->update([
+            'borrower_organization_id' => $attributes['borrower_organization_id'] ?? $sensorShare->borrower_organization_id,
+            'starts_at' => $attributes['starts_at'],
+            'ends_at' => $attributes['ends_at'],
+        ]);
+
+        return $sensorShare;
+    }
+
+    public function delete(SensorShare $sensorShare): void
+    {
+        $this->verifyShareOwnedByCurrentOrganization($sensorShare);
+
+        throw_if($sensorShare->assignments()->exists(), ValidationException::withMessages([
+            'sensor_share_id' => 'This sensor share cannot be deleted because it is used by assignments.',
+        ]));
+
+        $sensorShare->delete();
+    }
+
+    public function findValidShareForAssignment(Sensor $sensor, Event $event, string $activeFrom, string $activeTo): ?SensorShare
+    {
+        return SensorShare::query()
+            ->where('sensor_id', $sensor->id)
+            ->where('borrower_organization_id', $event->organization_id)
+            ->where('starts_at', '<=', $activeFrom)
+            ->where('ends_at', '>=', $activeTo)
+            ->first();
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function verifySensorOwnedByCurrentOrganization(Sensor $sensor): void
+    {
+        $currentOrgId = getPermissionsOrgId();
+
+        if ($currentOrgId === GLOBAL_ORG_ID) {
+            return;
+        }
+
+        throw_if(
+            $sensor->organization_id !== $currentOrgId,
+            AuthorizationException::class,
+            'You are not authorized to share this sensor.'
+        );
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    protected function verifyShareOwnedByCurrentOrganization(SensorShare $sensorShare): void
+    {
+        $currentOrgId = getPermissionsOrgId();
+
+        if ($currentOrgId === GLOBAL_ORG_ID) {
+            return;
+        }
+
+        throw_if(
+            $sensorShare->owner_organization_id !== $currentOrgId,
+            AuthorizationException::class,
+            'You are not authorized to manage this sensor share.'
+        );
+    }
+
+    protected function verifyBorrowerIsDifferentOrganization(int $borrowerOrganizationId, int $ownerOrganizationId): void
+    {
+        throw_if($borrowerOrganizationId === $ownerOrganizationId, ValidationException::withMessages([
+            'borrower_organization_id' => 'A sensor can only be shared with another organization.',
+        ]));
+    }
+
+    protected function verifyShareWindowContainsAssignments(SensorShare $sensorShare, Carbon $startsAt, Carbon $endsAt): void
+    {
+        $minActiveFrom = $sensorShare->assignments()->min('active_from');
+        $maxActiveTo = $sensorShare->assignments()->max('active_to');
+
+        if ($minActiveFrom === null || $maxActiveTo === null) {
+            return;
+        }
+
+        throw_if(
+            $startsAt->greaterThan(Date::parse($minActiveFrom)) || $endsAt->lessThan(Date::parse($maxActiveTo)),
+            ValidationException::withMessages([
+                'starts_at' => 'The share period must include all assignments that use this share.',
+                'ends_at' => 'The share period must include all assignments that use this share.',
+            ])
+        );
+    }
+
+    protected function verifyBorrowerCanBeChanged(SensorShare $sensorShare, int $borrowerOrganizationId): void
+    {
+        if ($borrowerOrganizationId === $sensorShare->borrower_organization_id) {
+            return;
+        }
+
+        throw_if($sensorShare->assignments()->exists(), ValidationException::withMessages([
+            'borrower_organization_id' => 'The borrowing organization cannot be changed while assignments use this share.',
+        ]));
+
+        $this->verifyBorrowerIsDifferentOrganization($borrowerOrganizationId, $sensorShare->owner_organization_id);
+    }
+}

--- a/database/factories/Peoplecount/SensorShareFactory.php
+++ b/database/factories/Peoplecount/SensorShareFactory.php
@@ -21,13 +21,15 @@ class SensorShareFactory extends Factory
      */
     public function definition(): array
     {
-        $ownerOrganization = Organization::factory()->create();
-        $borrowerOrganization = Organization::factory()->create();
-        $sensor = Sensor::factory()->withOrganization($ownerOrganization)->create();
+        $ownerOrganization = Organization::query()->inRandomOrder()->first() ?? Organization::factory()->create();
+        $borrowerOrganization = Organization::query()->where('id', '!=', $ownerOrganization->id)->inRandomOrder()->first()
+            ?? Organization::factory()->create();
+        $sensor = Sensor::query()->where('organization_id', $ownerOrganization->id)->inRandomOrder()->first()
+            ?? Sensor::factory()->withOrganization($ownerOrganization)->create();
 
         return [
             'sensor_id' => $sensor->id,
-            'owner_organization_id' => $ownerOrganization->id,
+            'owner_organization_id' => $sensor->organization_id,
             'borrower_organization_id' => $borrowerOrganization->id,
             'starts_at' => now()->subDay(),
             'ends_at' => now()->addDay(),

--- a/database/factories/Peoplecount/SensorShareFactory.php
+++ b/database/factories/Peoplecount/SensorShareFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Peoplecount;
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SensorShare>
+ */
+class SensorShareFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $ownerOrganization = Organization::factory()->create();
+        $borrowerOrganization = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($ownerOrganization)->create();
+
+        return [
+            'sensor_id' => $sensor->id,
+            'owner_organization_id' => $ownerOrganization->id,
+            'borrower_organization_id' => $borrowerOrganization->id,
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->addDay(),
+        ];
+    }
+
+    public function withSensor(Sensor $sensor): static
+    {
+        return $this->state(function (array $attributes) use ($sensor): array {
+            return [
+                'sensor_id' => $sensor->id,
+                'owner_organization_id' => $sensor->organization_id,
+            ];
+        });
+    }
+
+    public function withBorrowerOrganization(Organization $organization): static
+    {
+        return $this->state(function (array $attributes) use ($organization): array {
+            return [
+                'borrower_organization_id' => $organization->id,
+            ];
+        });
+    }
+}

--- a/database/migrations/2026_06_15_083131_create_sensor_shares_table.php
+++ b/database/migrations/2026_06_15_083131_create_sensor_shares_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Peoplecount\Sensor;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('peoplecount_sensor_shares', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Sensor::class)->constrained('peoplecount_sensors')->cascadeOnDelete();
+            $table->foreignId('owner_organization_id')->constrained('organizations')->cascadeOnDelete();
+            $table->foreignId('borrower_organization_id')->constrained('organizations')->cascadeOnDelete();
+            $table->foreignIdFor(User::class, 'created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['sensor_id', 'borrower_organization_id', 'starts_at', 'ends_at'], 'peoplecount_sensor_shares_lookup_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('peoplecount_sensor_shares');
+    }
+};

--- a/database/migrations/2026_06_15_083131_create_sensor_shares_table.php
+++ b/database/migrations/2026_06_15_083131_create_sensor_shares_table.php
@@ -21,7 +21,6 @@ return new class extends Migration
             $table->foreignIdFor(User::class, 'created_by')->nullable()->constrained('users')->nullOnDelete();
             $table->dateTime('starts_at');
             $table->dateTime('ends_at');
-            $table->softDeletes();
             $table->timestamps();
 
             $table->index(['sensor_id', 'borrower_organization_id', 'starts_at', 'ends_at'], 'peoplecount_sensor_shares_lookup_index');

--- a/database/migrations/2026_06_15_083132_add_archived_at_to_peoplecount_sensors_table.php
+++ b/database/migrations/2026_06_15_083132_add_archived_at_to_peoplecount_sensors_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('peoplecount_sensors', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('organization_id')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('peoplecount_sensors', function (Blueprint $table) {
+            $table->dropColumn('archived_at');
+        });
+    }
+};

--- a/database/migrations/2026_06_15_083133_add_sensor_share_id_to_peoplecount_assignments_table.php
+++ b/database/migrations/2026_06_15_083133_add_sensor_share_id_to_peoplecount_assignments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('peoplecount_assignments', function (Blueprint $table) {
+            $table->foreignId('sensor_share_id')
+                ->nullable()
+                ->after('sensor_id')
+                ->constrained('peoplecount_sensor_shares')
+                ->restrictOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('peoplecount_assignments', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('sensor_share_id');
+        });
+    }
+};

--- a/docs/diagrams/erd.md
+++ b/docs/diagrams/erd.md
@@ -7,7 +7,7 @@ Do not edit diagram block manually. Run `composer docs:erd`.
 <!-- mermaid-erd-start -->
 ```mermaid
 ---
-title: 21 tables · 144 columns
+title: 22 tables · 156 columns
 ---
 erDiagram
     model_has_permissions["model_has_permissions (4)"] {
@@ -96,7 +96,7 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    peoplecount_assignments["peoplecount_assignments (10)"] {
+    peoplecount_assignments["peoplecount_assignments (11)"] {
         integer id PK
         integer event_id FK
         integer area_id FK
@@ -107,6 +107,7 @@ erDiagram
         datetime deleted_at "soft-delete, nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
+        integer sensor_share_id FK "nullable"
     }
     peoplecount_events["peoplecount_events (8)"] {
         integer id PK
@@ -127,7 +128,19 @@ erDiagram
         integer count_out
         datetime received_at
     }
-    peoplecount_sensors["peoplecount_sensors (9)"] {
+    peoplecount_sensor_shares["peoplecount_sensor_shares (10)"] {
+        integer id PK
+        integer sensor_id FK
+        integer owner_organization_id FK
+        integer borrower_organization_id FK
+        integer created_by FK "nullable"
+        datetime starts_at
+        datetime ends_at
+        datetime deleted_at "soft-delete, nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    peoplecount_sensors["peoplecount_sensors (10)"] {
         integer id PK
         varchar vendor
         varchar model
@@ -137,6 +150,7 @@ erDiagram
         datetime deleted_at "soft-delete, nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
+        datetime archived_at "nullable"
     }
     permissions["permissions (5)"] {
         integer id PK
@@ -211,11 +225,16 @@ erDiagram
     users |o--o{ peoplecount_area_single_resets : "has many via created_by, set null delete"
     peoplecount_areas ||--o{ peoplecount_area_single_resets : "has many via area_id, cascade delete"
     peoplecount_events ||--o{ peoplecount_areas : "has many via event_id, cascade delete"
-    peoplecount_sensors ||--o{ peoplecount_assignments : "has many via sensor_id, cascade delete"
-    peoplecount_areas ||--o{ peoplecount_assignments : "has many via area_id, cascade delete"
+    peoplecount_sensor_shares |o--o{ peoplecount_assignments : "has many via sensor_share_id"
     peoplecount_events ||--o{ peoplecount_assignments : "has many via event_id, cascade delete"
+    peoplecount_areas ||--o{ peoplecount_assignments : "has many via area_id, cascade delete"
+    peoplecount_sensors ||--o{ peoplecount_assignments : "has many via sensor_id, cascade delete"
     organizations ||--o{ peoplecount_events : "has many via organization_id, cascade delete"
     peoplecount_sensors ||--o{ peoplecount_interval_counts : "has many via sensor_id"
+    users |o--o{ peoplecount_sensor_shares : "has many via created_by, set null delete"
+    organizations ||--o{ peoplecount_sensor_shares : "has many via borrower_organization_id, cascade delete"
+    organizations ||--o{ peoplecount_sensor_shares : "has many via owner_organization_id, cascade delete"
+    peoplecount_sensors ||--o{ peoplecount_sensor_shares : "has many via sensor_id, cascade delete"
     organizations ||--o{ peoplecount_sensors : "has many via organization_id, cascade delete"
     roles ||--o{ role_has_permissions : "pivot, has many via role_id, cascade delete"
     permissions ||--o{ role_has_permissions : "pivot, has many via permission_id, cascade delete"

--- a/docs/diagrams/erd.md
+++ b/docs/diagrams/erd.md
@@ -7,7 +7,7 @@ Do not edit diagram block manually. Run `composer docs:erd`.
 <!-- mermaid-erd-start -->
 ```mermaid
 ---
-title: 22 tables · 156 columns
+title: 22 tables · 155 columns
 ---
 erDiagram
     model_has_permissions["model_has_permissions (4)"] {
@@ -128,7 +128,7 @@ erDiagram
         integer count_out
         datetime received_at
     }
-    peoplecount_sensor_shares["peoplecount_sensor_shares (10)"] {
+    peoplecount_sensor_shares["peoplecount_sensor_shares (9)"] {
         integer id PK
         integer sensor_id FK
         integer owner_organization_id FK
@@ -136,7 +136,6 @@ erDiagram
         integer created_by FK "nullable"
         datetime starts_at
         datetime ends_at
-        datetime deleted_at "soft-delete, nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }

--- a/peck.json
+++ b/peck.json
@@ -38,7 +38,8 @@
             "ids",
             "ds",
             "datepicker",
-            "stylesheets"
+            "stylesheets",
+            "unarchive"
         ],
         "paths": []
     }

--- a/resources/js/components/peoplecount/assignments/AssignmentForm.vue
+++ b/resources/js/components/peoplecount/assignments/AssignmentForm.vue
@@ -133,6 +133,9 @@ const datePickerConfig = {
                     <SelectContent>
                         <SelectItem v-for="sensor in sensors" :key="sensor.id" :value="sensor.id.toString()">
                             {{ sensor.vendor }} {{ sensor.model }} ({{ sensor.serial }})
+                            <span v-if="sensor.organization && sensor.organization_id !== props.organization.id">
+                                · shared by {{ sensor.organization.name }}</span
+                            >
                         </SelectItem>
                     </SelectContent>
                 </Select>

--- a/resources/js/pages/peoplecount/EditSensor.vue
+++ b/resources/js/pages/peoplecount/EditSensor.vue
@@ -1,15 +1,97 @@
 <script lang="ts" setup>
 import Heading from '@/components/Heading.vue';
+import InputError from '@/components/InputError.vue';
 import MeasurementCard from '@/components/peoplecount/cards/MeasurementCard.vue';
 import SensorForm from '@/components/peoplecount/sensors/SensorForm.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
-import { BreadcrumbItem, Organization, PeoplecountSensor } from '@/types';
-import { Head } from '@inertiajs/vue3';
+import { BreadcrumbItem, Organization, PeoplecountSensor, PeoplecountSensorShare } from '@/types';
+import { formatLocalDateTime, getUTCStringFromLocal } from '@/utils/dateTimeHelpers';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { LoaderCircle } from 'lucide-vue-next';
+import { ref } from 'vue';
 
 const props = defineProps<{
     sensor: PeoplecountSensor;
     organization: Organization;
+    organizations: Organization[];
 }>();
+
+const shareForm = useForm({
+    borrower_organization_id: '',
+    starts_at: '',
+    ends_at: '',
+});
+
+const editingShareId = ref<number | null>(null);
+
+const editShareForm = useForm({
+    borrower_organization_id: '',
+    starts_at: '',
+    ends_at: '',
+});
+
+const formatDateTimeLocal = (value: string) => {
+    const date = new Date(value);
+    const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+
+    return localDate.toISOString().slice(0, 16);
+};
+
+const submitShare = () => {
+    shareForm
+        .transform((data) => ({
+            ...data,
+            starts_at: getUTCStringFromLocal(new Date(data.starts_at)),
+            ends_at: getUTCStringFromLocal(new Date(data.ends_at)),
+        }))
+        .post(
+            route('peoplecount.sensors.shares.store', {
+                organization: props.organization.slug,
+                sensor: props.sensor.id,
+            }),
+            {
+                preserveScroll: true,
+                onSuccess: () => shareForm.reset(),
+            },
+        );
+};
+
+const editShare = (share: PeoplecountSensorShare) => {
+    editingShareId.value = share.id;
+    editShareForm.clearErrors();
+    editShareForm.borrower_organization_id = share.borrower_organization_id.toString();
+    editShareForm.starts_at = formatDateTimeLocal(share.starts_at);
+    editShareForm.ends_at = formatDateTimeLocal(share.ends_at);
+};
+
+const cancelEditShare = () => {
+    editingShareId.value = null;
+    editShareForm.reset();
+    editShareForm.clearErrors();
+};
+
+const updateShare = (share: PeoplecountSensorShare) => {
+    editShareForm
+        .transform((data) => ({
+            ...data,
+            starts_at: getUTCStringFromLocal(new Date(data.starts_at)),
+            ends_at: getUTCStringFromLocal(new Date(data.ends_at)),
+        }))
+        .put(
+            route('peoplecount.sensors.shares.update', {
+                organization: props.organization.slug,
+                sensor: props.sensor.id,
+                share: share.id,
+            }),
+            {
+                preserveScroll: true,
+                onSuccess: () => cancelEditShare(),
+            },
+        );
+};
 
 const breadcrumbItems: BreadcrumbItem[] = [
     {
@@ -37,6 +119,161 @@ const breadcrumbItems: BreadcrumbItem[] = [
         <div class="px-4 py-6">
             <Heading title="Edit Sensor" />
             <SensorForm :organization="props.organization" :sensor="props.sensor" />
+
+            <div class="mt-8 rounded-lg border p-6">
+                <div class="flex items-start justify-between gap-4">
+                    <div>
+                        <Heading description="Hide retired sensors without breaking assignments or history" title="Archive" />
+                        <p v-if="props.sensor.archived_at" class="text-muted-foreground mt-2 text-sm">
+                            Archived {{ formatLocalDateTime(props.sensor.archived_at) }}
+                        </p>
+                    </div>
+
+                    <Link
+                        v-if="props.sensor.archived_at"
+                        :href="route('peoplecount.sensors.archive.destroy', { organization: props.organization.slug, sensor: props.sensor.id })"
+                        as="button"
+                        method="delete"
+                    >
+                        <Button variant="outline">Unarchive</Button>
+                    </Link>
+                    <Link
+                        v-else
+                        :href="route('peoplecount.sensors.archive.store', { organization: props.organization.slug, sensor: props.sensor.id })"
+                        as="button"
+                        method="post"
+                    >
+                        <Button variant="outline">Archive</Button>
+                    </Link>
+                </div>
+            </div>
+
+            <div class="mt-8 rounded-lg border p-6">
+                <Heading description="Allow another organization to assign this sensor inside a selected period" title="Sharing" />
+
+                <form class="mt-4 grid max-w-3xl gap-4 md:grid-cols-4" @submit.prevent="submitShare">
+                    <div class="grid gap-2 md:col-span-2">
+                        <Label for="borrower_organization_id">Organization</Label>
+                        <select
+                            id="borrower_organization_id"
+                            v-model="shareForm.borrower_organization_id"
+                            class="bg-background rounded-md border px-3 py-2"
+                            required
+                        >
+                            <option value="" disabled>Select organization</option>
+                            <option v-for="org in props.organizations" :key="org.id" :value="org.id">
+                                {{ org.name }}
+                            </option>
+                        </select>
+                        <InputError :message="shareForm.errors.borrower_organization_id" />
+                    </div>
+
+                    <div class="grid gap-2">
+                        <Label for="starts_at">Starts at</Label>
+                        <Input id="starts_at" v-model="shareForm.starts_at" required type="datetime-local" />
+                        <InputError :message="shareForm.errors.starts_at" />
+                    </div>
+
+                    <div class="grid gap-2">
+                        <Label for="ends_at">Ends at</Label>
+                        <Input id="ends_at" v-model="shareForm.ends_at" required type="datetime-local" />
+                        <InputError :message="shareForm.errors.ends_at" />
+                    </div>
+
+                    <Button :disabled="shareForm.processing" class="md:col-span-4" type="submit">
+                        <LoaderCircle v-if="shareForm.processing" class="h-4 w-4 animate-spin" />
+                        <span v-else>Share Sensor</span>
+                    </Button>
+                </form>
+
+                <div v-if="(props.sensor.shares?.length ?? 0) > 0" class="mt-6 divide-y rounded-md border">
+                    <div v-for="share in props.sensor.shares" :key="share.id" class="p-4">
+                        <form v-if="editingShareId === share.id" class="grid gap-4 md:grid-cols-4" @submit.prevent="updateShare(share)">
+                            <div class="grid gap-2 md:col-span-2">
+                                <Label :for="`edit_borrower_organization_id_${share.id}`">Organization</Label>
+                                <select
+                                    :id="`edit_borrower_organization_id_${share.id}`"
+                                    v-model="editShareForm.borrower_organization_id"
+                                    :disabled="(share.assignments_count ?? 0) > 0"
+                                    class="bg-background rounded-md border px-3 py-2 disabled:opacity-50"
+                                    required
+                                >
+                                    <option v-for="org in props.organizations" :key="org.id" :value="org.id.toString()">
+                                        {{ org.name }}
+                                    </option>
+                                </select>
+                                <InputError :message="editShareForm.errors.borrower_organization_id" />
+                                <p v-if="(share.assignments_count ?? 0) > 0" class="text-muted-foreground text-xs">
+                                    Borrowing organization cannot change while assignments use this share.
+                                </p>
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label :for="`edit_starts_at_${share.id}`">Starts at</Label>
+                                <Input :id="`edit_starts_at_${share.id}`" v-model="editShareForm.starts_at" required type="datetime-local" />
+                                <InputError :message="editShareForm.errors.starts_at" />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label :for="`edit_ends_at_${share.id}`">Ends at</Label>
+                                <Input :id="`edit_ends_at_${share.id}`" v-model="editShareForm.ends_at" required type="datetime-local" />
+                                <InputError :message="editShareForm.errors.ends_at" />
+                            </div>
+
+                            <div class="flex gap-2 md:col-span-4">
+                                <Button :disabled="editShareForm.processing" size="sm" type="submit">
+                                    <LoaderCircle v-if="editShareForm.processing" class="h-4 w-4 animate-spin" />
+                                    <span v-else>Save</span>
+                                </Button>
+                                <Button :disabled="editShareForm.processing" size="sm" type="button" variant="outline" @click="cancelEditShare"
+                                    >Cancel</Button
+                                >
+                            </div>
+                        </form>
+
+                        <div v-else class="flex items-center justify-between gap-4">
+                            <div class="text-sm">
+                                <p class="font-medium">{{ share.borrower_organization?.name ?? 'Unknown organization' }}</p>
+                                <p class="text-muted-foreground">
+                                    {{ formatLocalDateTime(share.starts_at) }} to {{ formatLocalDateTime(share.ends_at) }} ·
+                                    {{ share.assignments_count ?? 0 }} assignments
+                                </p>
+                            </div>
+
+                            <div class="flex gap-2">
+                                <Button size="sm" type="button" variant="outline" @click="editShare(share)">Edit</Button>
+
+                                <Button
+                                    v-if="(share.assignments_count ?? 0) > 0"
+                                    disabled
+                                    size="sm"
+                                    title="Shares with assignments cannot be deleted"
+                                    variant="destructive"
+                                >
+                                    Delete
+                                </Button>
+                                <Link
+                                    v-else
+                                    :href="
+                                        route('peoplecount.sensors.shares.destroy', {
+                                            organization: props.organization.slug,
+                                            sensor: props.sensor.id,
+                                            share: share.id,
+                                        })
+                                    "
+                                    as="button"
+                                    method="delete"
+                                    preserve-scroll
+                                >
+                                    <Button size="sm" variant="destructive">Delete</Button>
+                                </Link>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <p v-else class="text-muted-foreground mt-4 text-sm">This sensor is not shared.</p>
+            </div>
 
             <div class="mt-8">
                 <Heading title="Last Measurements" />

--- a/resources/js/pages/peoplecount/Sensors.vue
+++ b/resources/js/pages/peoplecount/Sensors.vue
@@ -1,14 +1,16 @@
 <script lang="ts" setup>
 import Heading from '@/components/Heading.vue';
 import SensorsTable from '@/components/peoplecount/sensors/SensorsTable.vue';
+import { Button } from '@/components/ui/button';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
 import { type BreadcrumbItem, Organization, PeoplecountSensor } from '@/types';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
 
 const props = defineProps<{
     sensors: PeoplecountSensor[];
     status?: string;
     organization: Organization;
+    showArchived: boolean;
 }>();
 
 const breadcrumbItems: BreadcrumbItem[] = [
@@ -36,7 +38,15 @@ const breadcrumbItems: BreadcrumbItem[] = [
         </div>
 
         <div class="px-4 py-6">
-            <Heading description="See all your sensors and manage their API tokens" title="Sensors" />
+            <div class="flex items-start justify-between gap-4">
+                <Heading description="See all your sensors and manage their API tokens" title="Sensors" />
+
+                <Button as-child size="sm" variant="outline">
+                    <Link :href="route('peoplecount.sensors.index', { organization: props.organization.slug, archived: !props.showArchived })">
+                        {{ props.showArchived ? 'Show Active' : 'Show Archived' }}
+                    </Link>
+                </Button>
+            </div>
 
             <div class="mt-4">
                 <SensorsTable :organization="props.organization" :sensors="sensors" />

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -76,6 +76,7 @@ export interface PeoplecountSensor {
     model: string;
     serial: string;
     organization_id: number;
+    archived_at?: string | null;
     api_token?: string | null; // Plaintext API token, nullable
     created_at: string;
     updated_at: string;
@@ -83,6 +84,23 @@ export interface PeoplecountSensor {
     interval_counts?: PeopleCountIntervalCount[]; // Optional, for related interval counts
     organization?: Organization; // Optional, for related organization
     assignments?: PeoplecountAssignment[]; // Optional, for related assignments
+    shares?: PeoplecountSensorShare[]; // Optional, for related shares
+}
+
+export interface PeoplecountSensorShare {
+    id: number;
+    sensor_id: number;
+    owner_organization_id: number;
+    borrower_organization_id: number;
+    starts_at: string;
+    ends_at: string;
+    created_at: string;
+    updated_at: string;
+    deleted_at?: string;
+    assignments_count?: number;
+    sensor?: PeoplecountSensor;
+    borrower_organization?: Organization;
+    owner_organization?: Organization;
 }
 
 export interface PeopleCountIntervalCount {
@@ -127,6 +145,7 @@ export interface PeoplecountAssignment {
     event_id: number;
     area_id: number;
     sensor_id: number;
+    sensor_share_id?: number | null;
     direction_flipped: boolean;
     active_from: string; // ISO 8601 date-time string (UTC)
     active_to: string; // ISO 8601 date-time string (UTC)

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -96,7 +96,6 @@ export interface PeoplecountSensorShare {
     ends_at: string;
     created_at: string;
     updated_at: string;
-    deleted_at?: string;
     assignments_count?: number;
     sensor?: PeoplecountSensor;
     borrower_organization?: Organization;

--- a/routes/peoplecount.php
+++ b/routes/peoplecount.php
@@ -66,12 +66,10 @@ Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(
         Route::delete('sensors/{sensor}/archive', [SensorArchiveController::class, 'destroy'])
             ->name('sensors.archive.destroy');
 
-        Route::post('sensors/{sensor}/shares', [SensorShareController::class, 'store'])
-            ->name('sensors.shares.store');
-        Route::put('sensors/{sensor}/shares/{share}', [SensorShareController::class, 'update'])
-            ->name('sensors.shares.update');
-        Route::delete('sensors/{sensor}/shares/{share}', [SensorShareController::class, 'destroy'])
-            ->name('sensors.shares.destroy');
+        Route::resource('sensors.shares', SensorShareController::class)
+            ->scoped(['organization' => 'slug'])
+            ->only(['store', 'update', 'destroy'])
+            ->names('sensors.shares');
 
         // Area Aggregation route
         Route::get('area-aggregation', [PeoplecountActiveAreaCountsWidgetController::class, 'index'])

--- a/routes/peoplecount.php
+++ b/routes/peoplecount.php
@@ -8,7 +8,9 @@ use App\Http\Controllers\Peoplecount\AreaRecurringResetController;
 use App\Http\Controllers\Peoplecount\AreaSingleResetController;
 use App\Http\Controllers\Peoplecount\AssignmentController;
 use App\Http\Controllers\Peoplecount\EventController;
+use App\Http\Controllers\Peoplecount\SensorArchiveController;
 use App\Http\Controllers\Peoplecount\SensorController;
+use App\Http\Controllers\Peoplecount\SensorShareController;
 use App\Http\Controllers\Peoplecount\SensorTokenController;
 use App\Http\Controllers\Widgets\PeoplecountActiveAreaCountsWidgetController;
 use App\Http\Controllers\Widgets\PeoplecountAreaCountHistoryWidgetController;
@@ -58,6 +60,18 @@ Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(
         // Regenerate token route
         Route::post('sensors/{sensor}/regenerate-token', [SensorTokenController::class, 'update'])
             ->name('sensors.regenerate-token');
+
+        Route::post('sensors/{sensor}/archive', [SensorArchiveController::class, 'store'])
+            ->name('sensors.archive.store');
+        Route::delete('sensors/{sensor}/archive', [SensorArchiveController::class, 'destroy'])
+            ->name('sensors.archive.destroy');
+
+        Route::post('sensors/{sensor}/shares', [SensorShareController::class, 'store'])
+            ->name('sensors.shares.store');
+        Route::put('sensors/{sensor}/shares/{share}', [SensorShareController::class, 'update'])
+            ->name('sensors.shares.update');
+        Route::delete('sensors/{sensor}/shares/{share}', [SensorShareController::class, 'destroy'])
+            ->name('sensors.shares.destroy');
 
         // Area Aggregation route
         Route::get('area-aggregation', [PeoplecountActiveAreaCountsWidgetController::class, 'index'])

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -76,7 +76,7 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors/{sensor}/archive'],
         ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}/archive'],
         ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares'],
-        ['method' => 'PUT', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
+        ['method' => 'PUT|PATCH', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
         ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
 
         // People Count Events Routes

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -73,6 +73,11 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'PUT|PATCH', 'uri' => '{organization}/peoplecount/sensors/{sensor}'],
         ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}'],
         ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors/{sensor}/regenerate-token'],
+        ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors/{sensor}/archive'],
+        ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}/archive'],
+        ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares'],
+        ['method' => 'PUT', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
+        ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
 
         // People Count Events Routes
         ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount/events'],

--- a/tests/Feature/Peoplecount/SensorArchiveControllerTest.php
+++ b/tests/Feature/Peoplecount/SensorArchiveControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Sensor;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+});
+
+it('archives a sensor', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($organization)->create();
+
+    $this->actingAs($admin)
+        ->post(route('peoplecount.sensors.archive.store', [
+            'organization' => $organization->slug,
+            'sensor' => $sensor->id,
+        ]))
+        ->assertRedirect(route('peoplecount.sensors.index', ['organization' => $organization->slug]));
+
+    expect($sensor->refresh()->archived_at)->not->toBeNull();
+});
+
+it('restores an archived sensor', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($organization)->create(['archived_at' => now()]);
+
+    $this->actingAs($admin)
+        ->delete(route('peoplecount.sensors.archive.destroy', [
+            'organization' => $organization->slug,
+            'sensor' => $sensor->id,
+        ]))
+        ->assertRedirect(route('peoplecount.sensors.index', [
+            'organization' => $organization->slug,
+            'archived' => true,
+        ]));
+
+    expect($sensor->refresh()->archived_at)->toBeNull();
+});

--- a/tests/Feature/Peoplecount/SensorShareControllerTest.php
+++ b/tests/Feature/Peoplecount/SensorShareControllerTest.php
@@ -145,7 +145,7 @@ it('destroys a sensor share', function () {
             'sensor' => $sensor->id,
         ]));
 
-    $this->assertSoftDeleted('peoplecount_sensor_shares', ['id' => $share->id]);
+    $this->assertDatabaseMissing('peoplecount_sensor_shares', ['id' => $share->id]);
 });
 
 it('rejects destroying a share for another sensor', function () {

--- a/tests/Feature/Peoplecount/SensorShareControllerTest.php
+++ b/tests/Feature/Peoplecount/SensorShareControllerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Area;
+use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Event;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+});
+
+it('stores a sensor share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+
+    $this->actingAs($admin)
+        ->post(route('peoplecount.sensors.shares.store', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+        ]), [
+            'borrower_organization_id' => $borrower->id,
+            'starts_at' => '2026-08-01 09:00:00',
+            'ends_at' => '2026-08-01 18:00:00',
+        ])
+        ->assertRedirect(route('peoplecount.sensors.edit', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+        ]));
+
+    $this->assertDatabaseHas('peoplecount_sensor_shares', [
+        'sensor_id' => $sensor->id,
+        'owner_organization_id' => $owner->id,
+        'borrower_organization_id' => $borrower->id,
+    ]);
+});
+
+it('returns validation errors when storing invalid share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+
+    $this->actingAs($admin)
+        ->from(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->post(route('peoplecount.sensors.shares.store', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+        ]), [
+            'borrower_organization_id' => $owner->id,
+            'starts_at' => '2026-08-01 09:00:00',
+            'ends_at' => '2026-08-01 18:00:00',
+        ])
+        ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->assertSessionHasErrors('borrower_organization_id');
+});
+
+it('updates a sensor share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $newBorrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->put(route('peoplecount.sensors.shares.update', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]), [
+            'borrower_organization_id' => $newBorrower->id,
+            'starts_at' => '2026-08-01 08:00:00',
+            'ends_at' => '2026-08-01 19:00:00',
+        ])
+        ->assertRedirect(route('peoplecount.sensors.edit', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+        ]));
+
+    expect($share->refresh()->borrower_organization_id)->toBe($newBorrower->id);
+});
+
+it('rejects updating a share for another sensor', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $otherSensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($otherSensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->put(route('peoplecount.sensors.shares.update', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]), [
+            'borrower_organization_id' => $borrower->id,
+            'starts_at' => '2026-08-01 08:00:00',
+            'ends_at' => '2026-08-01 19:00:00',
+        ])
+        ->assertNotFound();
+});
+
+it('returns validation errors when updating invalid share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->from(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->put(route('peoplecount.sensors.shares.update', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]), [
+            'borrower_organization_id' => $owner->id,
+            'starts_at' => '2026-08-01 08:00:00',
+            'ends_at' => '2026-08-01 19:00:00',
+        ])
+        ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->assertSessionHasErrors('borrower_organization_id');
+});
+
+it('destroys a sensor share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->delete(route('peoplecount.sensors.shares.destroy', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]))
+        ->assertRedirect(route('peoplecount.sensors.edit', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+        ]));
+
+    $this->assertSoftDeleted('peoplecount_sensor_shares', ['id' => $share->id]);
+});
+
+it('rejects destroying a share for another sensor', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $otherSensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($otherSensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->delete(route('peoplecount.sensors.shares.destroy', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]))
+        ->assertNotFound();
+});
+
+it('returns validation errors when destroying used share', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+    $event = Event::factory()->withOrganization($borrower)->create();
+    $area = Area::factory()->withEvent($event)->create();
+    Assignment::factory()->withEvent($event)->withArea($area)->withSensor($sensor)->create([
+        'sensor_share_id' => $share->id,
+    ]);
+
+    $this->actingAs($admin)
+        ->from(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->delete(route('peoplecount.sensors.shares.destroy', [
+            'organization' => $owner->slug,
+            'sensor' => $sensor->id,
+            'share' => $share->id,
+        ]))
+        ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
+        ->assertSessionHasErrors('sensor_share_id');
+});

--- a/tests/Integration/Peoplecount/AssignmentControllerTest.php
+++ b/tests/Integration/Peoplecount/AssignmentControllerTest.php
@@ -109,6 +109,48 @@ it('shows the edit assignment form for an organization assignment', function () 
         );
 });
 
+it('shows archived current sensor when editing an existing assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $event = Event::factory()->for($org, 'organization')->create();
+    $area = Area::factory()->for($event)->create();
+    $sensor = Sensor::factory()->for($org)->create([
+        'archived_at' => now(),
+    ]);
+    $assignment = Assignment::factory()
+        ->for($event)
+        ->for($area)
+        ->for($sensor)
+        ->create();
+
+    $this->actingAs($admin)
+        ->get(route('peoplecount.assignments.edit', ['organization' => $org->slug, 'assignment' => $assignment->id]))
+        ->assertStatus(200)
+        ->assertInertia(fn ($page) => $page
+            ->component('peoplecount/EditAssignment')
+            ->has('sensors', 1)
+            ->where('sensors.0.id', $sensor->id)
+        );
+});
+
+it('does not show edit form for another organization assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $foreignEvent = Event::factory()->for($foreignOrg, 'organization')->create();
+    $foreignArea = Area::factory()->for($foreignEvent)->create();
+    $foreignSensor = Sensor::factory()->for($foreignOrg)->create();
+    $foreignAssignment = Assignment::factory()
+        ->for($foreignEvent)
+        ->for($foreignArea)
+        ->for($foreignSensor)
+        ->create();
+
+    $this->actingAs($admin)
+        ->get(route('peoplecount.assignments.edit', ['organization' => $org->slug, 'assignment' => $foreignAssignment->id]))
+        ->assertNotFound();
+});
+
 it('can update an assignment for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -147,6 +189,42 @@ it('can update an assignment for an organization', function () {
     ]);
 });
 
+it('does not update another organization assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $event = Event::factory()->for($org, 'organization')->create([
+        'starts_at' => now()->subDays(5),
+        'ends_at' => now()->addDays(5),
+    ]);
+    $area = Area::factory()->for($event)->create();
+    $sensor = Sensor::factory()->for($org)->create();
+    $foreignOrg = Organization::factory()->create();
+    $foreignEvent = Event::factory()->for($foreignOrg, 'organization')->create([
+        'starts_at' => now()->subDays(5),
+        'ends_at' => now()->addDays(5),
+    ]);
+    $foreignArea = Area::factory()->for($foreignEvent)->create();
+    $foreignSensor = Sensor::factory()->for($foreignOrg)->create();
+    $foreignAssignment = Assignment::factory()
+        ->for($foreignEvent)
+        ->for($foreignArea)
+        ->for($foreignSensor)
+        ->create(['direction_flipped' => false]);
+
+    $this->actingAs($admin)
+        ->put(route('peoplecount.assignments.update', ['organization' => $org->slug, 'assignment' => $foreignAssignment->id]), [
+            'event_id' => $event->id,
+            'area_id' => $area->id,
+            'sensor_id' => $sensor->id,
+            'direction_flipped' => true,
+            'active_from' => now()->subDay()->toDateTimeString(),
+            'active_to' => now()->addDay()->toDateTimeString(),
+        ])
+        ->assertNotFound();
+
+    expect($foreignAssignment->refresh()->direction_flipped)->toBeFalse();
+});
+
 it('can delete an assignment for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -167,6 +245,26 @@ it('can delete an assignment for an organization', function () {
     ]);
 });
 
+it('does not delete another organization assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $foreignEvent = Event::factory()->for($foreignOrg, 'organization')->create();
+    $foreignArea = Area::factory()->for($foreignEvent)->create();
+    $foreignSensor = Sensor::factory()->for($foreignOrg)->create();
+    $foreignAssignment = Assignment::factory()
+        ->for($foreignEvent)
+        ->for($foreignArea)
+        ->for($foreignSensor)
+        ->create();
+
+    $this->actingAs($admin)
+        ->delete(route('peoplecount.assignments.destroy', ['organization' => $org->slug, 'assignment' => $foreignAssignment->id]))
+        ->assertNotFound();
+
+    $this->assertNotSoftDeleted('peoplecount_assignments', ['id' => $foreignAssignment->id]);
+});
+
 it('redirects show to edit for an organization assignment', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -182,6 +280,24 @@ it('redirects show to edit for an organization assignment', function () {
     $response = $this->actingAs($admin)
         ->get(route('peoplecount.assignments.show', ['organization' => $org->slug, 'assignment' => $assignment->id]));
     $response->assertRedirect(route('peoplecount.assignments.edit', ['organization' => $org->slug, 'assignment' => $assignment->id]));
+});
+
+it('does not show another organization assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $foreignEvent = Event::factory()->for($foreignOrg, 'organization')->create();
+    $foreignArea = Area::factory()->for($foreignEvent)->create();
+    $foreignSensor = Sensor::factory()->for($foreignOrg)->create();
+    $foreignAssignment = Assignment::factory()
+        ->for($foreignEvent)
+        ->for($foreignArea)
+        ->for($foreignSensor)
+        ->create();
+
+    $this->actingAs($admin)
+        ->get(route('peoplecount.assignments.show', ['organization' => $org->slug, 'assignment' => $foreignAssignment->id]))
+        ->assertNotFound();
 });
 
 it('validates overlapping assignments on create', function () {

--- a/tests/Integration/Peoplecount/SensorControllerTest.php
+++ b/tests/Integration/Peoplecount/SensorControllerTest.php
@@ -9,7 +9,11 @@ use App\Http\Requests\Peoplecount\SensorShowRequest;
 use App\Http\Requests\Peoplecount\SensorStoreRequest;
 use App\Http\Requests\Peoplecount\SensorUpdateRequest;
 use App\Models\Organization;
+use App\Models\Peoplecount\Area;
+use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Event;
 use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
 use App\Models\User;
 
 beforeEach(function () {
@@ -77,6 +81,17 @@ it('shows the edit sensor form for an organization sensor', function () {
         );
 });
 
+it('does not show edit form for another organization sensor', function () {
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $foreignSensor = Sensor::factory()->for($foreignOrg)->create();
+
+    $this->actingAs($admin)
+        ->get(route('peoplecount.sensors.edit', ['organization' => $org->slug, 'sensor' => $foreignSensor->id]))
+        ->assertNotFound();
+});
+
 it('can update a sensor for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -97,6 +112,36 @@ it('can update a sensor for an organization', function () {
     ]);
 });
 
+it('ignores unvalidated sensor update fields', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($org)->create([
+        'api_token' => 'original-token',
+        'archived_at' => null,
+    ]);
+
+    $this->actingAs($admin)
+        ->put(route('peoplecount.sensors.update', ['organization' => $org->slug, 'sensor' => $sensor->id]), [
+            'vendor' => 'UpdatedVendor',
+            'model' => 'UpdatedModel',
+            'serial' => 'UpdatedSerial',
+            'organization_id' => $foreignOrg->id,
+            'api_token' => 'changed-token',
+            'archived_at' => now()->toDateTimeString(),
+        ])
+        ->assertRedirect(route('peoplecount.sensors.index', ['organization' => $org->slug]));
+
+    $sensor->refresh();
+
+    expect($sensor->vendor)->toBe('UpdatedVendor')
+        ->and($sensor->model)->toBe('UpdatedModel')
+        ->and($sensor->serial)->toBe('UpdatedSerial')
+        ->and($sensor->organization_id)->toBe($org->id)
+        ->and($sensor->api_token)->toBe('original-token')
+        ->and($sensor->archived_at)->toBeNull();
+});
+
 it('can delete a sensor for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -109,6 +154,41 @@ it('can delete a sensor for an organization', function () {
         'id' => $sensor->id,
         'serial' => 'delete-me-serial',
     ]);
+});
+
+it('can delete a sensor with unused shares', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($org)->create();
+    SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+
+    $this->actingAs($admin)
+        ->delete(route('peoplecount.sensors.destroy', ['organization' => $org->slug, 'sensor' => $sensor->id]))
+        ->assertRedirect(route('peoplecount.sensors.index', ['organization' => $org->slug]));
+
+    $this->assertSoftDeleted('peoplecount_sensors', ['id' => $sensor->id]);
+});
+
+it('returns validation errors when deleting a sensor used by a shared assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($org)->create();
+    $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+    $event = Event::factory()->for($borrower, 'organization')->create();
+    $area = Area::factory()->for($event)->create();
+    Assignment::factory()
+        ->for($event)
+        ->for($area)
+        ->for($sensor)
+        ->create(['sensor_share_id' => $share->id]);
+
+    $this->actingAs($admin)
+        ->from(route('peoplecount.sensors.edit', ['organization' => $org->slug, 'sensor' => $sensor->id]))
+        ->delete(route('peoplecount.sensors.destroy', ['organization' => $org->slug, 'sensor' => $sensor->id]))
+        ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $org->slug, 'sensor' => $sensor->id]))
+        ->assertSessionHasErrors('sensor_id');
 });
 
 it('redirects show to edit for an organization sensor', function () {

--- a/tests/Integration/Peoplecount/SensorTokenControllerTest.php
+++ b/tests/Integration/Peoplecount/SensorTokenControllerTest.php
@@ -53,6 +53,20 @@ it('regenerates an existing token', function () {
         ->and($sensor->fresh()->api_token)->not->toBe($originalToken);
 });
 
+it('does not regenerate token for another organization sensor', function () {
+    $org = Organization::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $foreignSensor = Sensor::factory()->withOrganization($foreignOrg)->create();
+
+    test()->actingAs($admin)
+        ->post(route('peoplecount.sensors.regenerate-token', [
+            'organization' => $org->slug,
+            'sensor' => $foreignSensor->id,
+        ]))
+        ->assertForbidden();
+});
+
 it('uses the correct form requests', function () {
     // middleware
     test()->assertRouteUsesMiddleware(

--- a/tests/Integration/Services/Peoplecount/AssignmentServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/AssignmentServiceTest.php
@@ -5,6 +5,7 @@ use App\Models\Peoplecount\Area;
 use App\Models\Peoplecount\Assignment;
 use App\Models\Peoplecount\Event;
 use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
 use App\Services\Peoplecount\AssignmentService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -770,6 +771,117 @@ describe('verifySensorBelongsToCurrentOrganization', function () {
 
         // If we get here, the test passes
         $this->assertTrue(true);
+    });
+});
+
+describe('verifyAssignmentBelongsToCurrentOrganization', function () {
+    it('passes for any assignment when organization is global', function () {
+        $owner = Organization::factory()->create();
+        $event = Event::factory()->for($owner, 'organization')->create();
+        $area = Area::factory()->for($event)->create();
+        $sensor = Sensor::factory()->withOrganization($owner)->create();
+        $assignment = Assignment::factory()->for($event)->for($area)->for($sensor)->create();
+
+        setPermissionsOrgId(GLOBAL_ORG_ID);
+
+        $this->service->verifyAssignmentBelongsToCurrentOrganization($assignment);
+
+        $this->assertTrue(true);
+    });
+
+    it('throws when assignment belongs to another organization', function () {
+        $org = Organization::factory()->create();
+        $foreignOrg = Organization::factory()->create();
+        $event = Event::factory()->for($foreignOrg, 'organization')->create();
+        $area = Area::factory()->for($event)->create();
+        $sensor = Sensor::factory()->withOrganization($foreignOrg)->create();
+        $assignment = Assignment::factory()->for($event)->for($area)->for($sensor)->create();
+
+        setPermissionsOrgId($org->id);
+
+        $this->expectException(AuthorizationException::class);
+        $this->service->verifyAssignmentBelongsToCurrentOrganization($assignment);
+    });
+});
+
+describe('verifySensorAssignableToEvent', function () {
+    it('returns a valid share for a borrowed sensor', function () {
+        $owner = Organization::factory()->create();
+        $borrower = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($owner)->create();
+        $event = Event::factory()->withOrganization($borrower)->create();
+        $share = SensorShare::factory()
+            ->withSensor($sensor)
+            ->withBorrowerOrganization($borrower)
+            ->create([
+                'starts_at' => '2026-08-01 09:00:00',
+                'ends_at' => '2026-08-01 18:00:00',
+            ]);
+
+        setPermissionsOrgId($borrower->id);
+
+        $result = $this->service->verifySensorAssignableToEvent(
+            $sensor->id,
+            $event->id,
+            '2026-08-01 10:00:00',
+            '2026-08-01 12:00:00'
+        );
+
+        expect($result)->toBeInstanceOf(SensorShare::class)
+            ->and($result->is($share))->toBeTrue();
+    });
+
+    it('returns null for global organization before loading event', function () {
+        $org = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($org)->create();
+
+        setPermissionsOrgId(GLOBAL_ORG_ID);
+
+        $result = $this->service->verifySensorAssignableToEvent(
+            $sensor->id,
+            999999,
+            now()->toDateTimeString(),
+            now()->addHour()->toDateTimeString()
+        );
+
+        expect($result)->toBeNull();
+    });
+
+    it('allows keeping an archived sensor on its existing assignment', function () {
+        $org = Organization::factory()->create();
+        $event = Event::factory()->for($org, 'organization')->create();
+        $area = Area::factory()->for($event)->create();
+        $sensor = Sensor::factory()->withOrganization($org)->create(['archived_at' => now()]);
+        $assignment = Assignment::factory()->withEvent($event)->withArea($area)->withSensor($sensor)->create();
+
+        setPermissionsOrgId($org->id);
+
+        $result = $this->service->verifySensorAssignableToEvent(
+            $sensor->id,
+            $event->id,
+            $assignment->active_from->toDateTimeString(),
+            $assignment->active_to->toDateTimeString(),
+            $assignment
+        );
+
+        expect($result)->toBeNull();
+    });
+
+    it('rejects assigning an archived sensor to a new assignment', function () {
+        $org = Organization::factory()->create();
+        $event = Event::factory()->for($org, 'organization')->create();
+        $sensor = Sensor::factory()->withOrganization($org)->create(['archived_at' => now()]);
+
+        setPermissionsOrgId($org->id);
+
+        $this->expectException(ValidationException::class);
+
+        $this->service->verifySensorAssignableToEvent(
+            $sensor->id,
+            $event->id,
+            now()->toDateTimeString(),
+            now()->addHour()->toDateTimeString()
+        );
     });
 });
 

--- a/tests/Integration/Services/Peoplecount/SensorServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/SensorServiceTest.php
@@ -1,14 +1,19 @@
 <?php
 
 use App\Models\Organization;
+use App\Models\Peoplecount\Area;
 use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Event;
 use App\Models\Peoplecount\IntervalCount;
 use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
 use App\Services\Peoplecount\SensorService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Validation\ValidationException;
 
 uses(RefreshDatabase::class);
 
@@ -67,6 +72,101 @@ describe('getSensors', function () {
 
         expect($result)->toBeInstanceOf(Collection::class)
             ->and($result->count())->toBe(0);
+    });
+
+    it('returns all active sensors for global organization', function () {
+        $org = Organization::factory()->create();
+        $foreignOrg = Organization::factory()->create();
+        Sensor::factory()->withOrganization($org)->create();
+        Sensor::factory()->withOrganization($foreignOrg)->create();
+
+        setPermissionsOrgId(GLOBAL_ORG_ID);
+
+        $result = $this->service->getSensors();
+
+        expect($result)->toHaveCount(2);
+    });
+
+    it('returns archived sensors only', function () {
+        $org = Organization::factory()->create();
+        Sensor::factory()->withOrganization($org)->create();
+        $archivedSensor = Sensor::factory()->withOrganization($org)->create(['archived_at' => now()]);
+
+        setPermissionsOrgId($org->id);
+
+        $result = $this->service->getSensors(true);
+
+        expect($result)->toHaveCount(1)
+            ->and($result->first()->is($archivedSensor))->toBeTrue();
+    });
+});
+
+describe('archive', function () {
+    it('archives and restores a sensor', function () {
+        $org = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($org)->create();
+
+        setPermissionsOrgId($org->id);
+
+        $archived = $this->service->archive($sensor);
+        expect($archived->archived_at)->not->toBeNull();
+
+        $restored = $this->service->unarchive($sensor);
+        expect($restored->archived_at)->toBeNull();
+    });
+
+    it('allows global organization to manage any sensor', function () {
+        $org = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($org)->create();
+
+        setPermissionsOrgId(GLOBAL_ORG_ID);
+
+        expect($this->service->archive($sensor)->archived_at)->not->toBeNull();
+    });
+
+    it('blocks managing another organization sensor', function () {
+        $org = Organization::factory()->create();
+        $foreignOrg = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($foreignOrg)->create();
+
+        setPermissionsOrgId($org->id);
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->service->archive($sensor);
+    });
+});
+
+describe('delete', function () {
+    it('allows deleting a sensor with unused shares', function () {
+        $owner = Organization::factory()->create();
+        $borrower = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($owner)->create();
+        SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+
+        setPermissionsOrgId($owner->id);
+
+        $this->service->delete($sensor);
+
+        $this->assertSoftDeleted('peoplecount_sensors', ['id' => $sensor->id]);
+    });
+
+    it('blocks deleting a sensor used by a shared assignment', function () {
+        $owner = Organization::factory()->create();
+        $borrower = Organization::factory()->create();
+        $sensor = Sensor::factory()->withOrganization($owner)->create();
+        $share = SensorShare::factory()->withSensor($sensor)->withBorrowerOrganization($borrower)->create();
+        $event = Event::factory()->withOrganization($borrower)->create();
+        $area = Area::factory()->withEvent($event)->create();
+        Assignment::factory()->withEvent($event)->withArea($area)->withSensor($sensor)->create([
+            'sensor_share_id' => $share->id,
+        ]);
+
+        setPermissionsOrgId($owner->id);
+
+        $this->expectException(ValidationException::class);
+
+        $this->service->delete($sensor);
     });
 });
 
@@ -329,7 +429,10 @@ describe('getAssignedSensorsHealthStatus', function () {
         $foreignOrg = Organization::factory()->create();
 
         $foreignSensor = Sensor::factory()->withOrganization($foreignOrg)->create(['serial' => 'X']);
-        Assignment::factory()->withSensor($foreignSensor)->create([
+        $foreignEvent = Event::factory()->withOrganization($foreignOrg)->create();
+        $foreignArea = Area::factory()->withEvent($foreignEvent)->create();
+
+        Assignment::factory()->withEvent($foreignEvent)->withArea($foreignArea)->withSensor($foreignSensor)->create([
             'active_from' => Carbon::now()->subHour(),
             'active_to' => Carbon::now()->addHour(),
         ]);
@@ -340,7 +443,7 @@ describe('getAssignedSensorsHealthStatus', function () {
 
         $result = $this->service->getAssignedSensorsHealthStatus($org);
         expect($result['total'])->toBe(0)
-            ->and($result['all_healthy'])->toBeFalse()
+            ->and($result['all_healthy'])->toBeTrue()
             ->and($result['last_updated'])->toBeString();
     });
 

--- a/tests/Integration/Services/Peoplecount/SensorShareServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/SensorShareServiceTest.php
@@ -1,0 +1,414 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Area;
+use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Event;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use App\Services\Peoplecount\AssignmentService;
+use App\Services\Peoplecount\SensorService;
+use App\Services\Peoplecount\SensorShareService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+covers(SensorShareService::class);
+
+beforeEach(function () {
+    if (! defined('GLOBAL_ORG_ID')) {
+        define('GLOBAL_ORG_ID', 0);
+    }
+
+    $this->assignmentService = new AssignmentService;
+    $this->sensorShareService = new SensorShareService;
+    $this->sensorService = new SensorService;
+});
+
+it('lists lent and borrowed shares with relationships', function () {
+    [$owner, $borrower, $sensor, , , $share] = sharedSensorScenario();
+
+    $lentShares = $this->sensorShareService->getLentShares($owner);
+    $borrowedShares = $this->sensorShareService->getBorrowedShares($borrower);
+
+    expect($lentShares)->toHaveCount(1)
+        ->and($lentShares->first()->is($share))->toBeTrue()
+        ->and($lentShares->first()->relationLoaded('sensor'))->toBeTrue()
+        ->and($lentShares->first()->relationLoaded('borrowerOrganization'))->toBeTrue()
+        ->and($borrowedShares)->toHaveCount(1)
+        ->and($borrowedShares->first()->is($share))->toBeTrue()
+        ->and($borrowedShares->first()->relationLoaded('sensor'))->toBeTrue()
+        ->and($borrowedShares->first()->relationLoaded('ownerOrganization'))->toBeTrue()
+        ->and($borrowedShares->first()->sensor->relationLoaded('organization'))->toBeTrue();
+});
+
+it('creates a sensor share for the current owner organization', function () {
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+
+    setPermissionsOrgId($owner->id);
+
+    $share = $this->sensorShareService->create([
+        'sensor_id' => $sensor->id,
+        'borrower_organization_id' => $borrower->id,
+        'created_by' => null,
+        'starts_at' => '2026-08-01 09:00:00',
+        'ends_at' => '2026-08-01 18:00:00',
+    ]);
+
+    expect($share->sensor_id)->toBe($sensor->id)
+        ->and($share->owner_organization_id)->toBe($owner->id)
+        ->and($share->borrower_organization_id)->toBe($borrower->id);
+});
+
+it('updates a share and can change borrower before assignments use it', function () {
+    [$owner, , , , , $share] = sharedSensorScenario();
+    $newBorrower = Organization::factory()->create();
+
+    setPermissionsOrgId($owner->id);
+
+    $updated = $this->sensorShareService->update($share, [
+        'borrower_organization_id' => $newBorrower->id,
+        'starts_at' => '2026-08-01 08:00:00',
+        'ends_at' => '2026-08-01 19:00:00',
+    ]);
+
+    expect($updated->borrower_organization_id)->toBe($newBorrower->id)
+        ->and($updated->starts_at->toDateTimeString())->toBe('2026-08-01 08:00:00')
+        ->and($updated->ends_at->toDateTimeString())->toBe('2026-08-01 19:00:00');
+});
+
+it('deletes an unused share', function () {
+    [$owner, , , , , $share] = sharedSensorScenario();
+
+    setPermissionsOrgId($owner->id);
+
+    $this->sensorShareService->delete($share);
+
+    $this->assertSoftDeleted('peoplecount_sensor_shares', ['id' => $share->id]);
+});
+
+it('allows global organization to manage shares', function () {
+    [, $borrower, , , , $share] = sharedSensorScenario();
+
+    setPermissionsOrgId(GLOBAL_ORG_ID);
+
+    $updated = $this->sensorShareService->update($share, [
+        'borrower_organization_id' => $borrower->id,
+        'starts_at' => '2026-08-01 08:00:00',
+        'ends_at' => '2026-08-01 19:00:00',
+    ]);
+
+    expect($updated->starts_at->toDateTimeString())->toBe('2026-08-01 08:00:00');
+});
+
+function sharedSensorScenario(): array
+{
+    $owner = Organization::factory()->create();
+    $borrower = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+    $event = Event::factory()->withOrganization($borrower)->create([
+        'starts_at' => Carbon::parse('2026-08-01 08:00:00'),
+        'ends_at' => Carbon::parse('2026-08-01 22:00:00'),
+    ]);
+    $area = Area::factory()->withEvent($event)->create();
+    $share = SensorShare::factory()
+        ->withSensor($sensor)
+        ->withBorrowerOrganization($borrower)
+        ->create([
+            'starts_at' => Carbon::parse('2026-08-01 09:00:00'),
+            'ends_at' => Carbon::parse('2026-08-01 18:00:00'),
+        ]);
+
+    return [$owner, $borrower, $sensor, $event, $area, $share];
+}
+
+it('allows borrower organization to assign a shared sensor inside the share window', function () {
+    [, $borrower, $sensor, $event, $area, $share] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+
+    $assignment = $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    expect($assignment->sensor_share_id)->toBe($share->id);
+});
+
+it('rejects sharing a sensor with its owning organization', function () {
+    $owner = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($owner)->create();
+
+    setPermissionsOrgId(GLOBAL_ORG_ID);
+
+    $this->expectException(ValidationException::class);
+
+    $this->sensorShareService->create([
+        'sensor_id' => $sensor->id,
+        'borrower_organization_id' => $owner->id,
+        'starts_at' => '2026-08-01 09:00:00',
+        'ends_at' => '2026-08-01 18:00:00',
+    ]);
+});
+
+it('rejects borrower assignment outside the share window', function () {
+    [, $borrower, $sensor, $event, $area] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+
+    $this->expectException(AuthorizationException::class);
+
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 08:30:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+});
+
+it('rejects creating an assignment with an archived sensor', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($organization)->create([
+        'archived_at' => now(),
+    ]);
+    $event = Event::factory()->withOrganization($organization)->create([
+        'starts_at' => Carbon::parse('2026-08-01 08:00:00'),
+        'ends_at' => Carbon::parse('2026-08-01 22:00:00'),
+    ]);
+    $area = Area::factory()->withEvent($event)->create();
+
+    setPermissionsOrgId($organization->id);
+
+    $this->expectException(ValidationException::class);
+
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+});
+
+it('allows updating an existing assignment that already uses an archived sensor', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($organization)->create([
+        'archived_at' => now(),
+    ]);
+    $event = Event::factory()->withOrganization($organization)->create([
+        'starts_at' => Carbon::parse('2026-08-01 08:00:00'),
+        'ends_at' => Carbon::parse('2026-08-01 22:00:00'),
+    ]);
+    $area = Area::factory()->withEvent($event)->create();
+    $assignment = Assignment::factory()->withEvent($event)->withArea($area)->withSensor($sensor)->create([
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($organization->id);
+
+    $updatedAssignment = $this->assignmentService->update($assignment, [
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => true,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    expect($updatedAssignment->direction_flipped)->toBeTrue();
+});
+
+it('allows overlapping assignments for the same sensor in different organizations', function () {
+    [$owner, $borrower, $sensor, $borrowerEvent, $borrowerArea] = sharedSensorScenario();
+
+    $ownerEvent = Event::factory()->withOrganization($owner)->create([
+        'starts_at' => Carbon::parse('2026-08-01 08:00:00'),
+        'ends_at' => Carbon::parse('2026-08-01 22:00:00'),
+    ]);
+    $ownerArea = Area::factory()->withEvent($ownerEvent)->create();
+
+    Assignment::factory()->withEvent($ownerEvent)->withArea($ownerArea)->withSensor($sensor)->create([
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($borrower->id);
+
+    $assignment = $this->assignmentService->create([
+        'event_id' => $borrowerEvent->id,
+        'area_id' => $borrowerArea->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:30:00',
+        'active_to' => '2026-08-01 11:30:00',
+    ]);
+
+    expect($assignment)->toBeInstanceOf(Assignment::class);
+});
+
+it('allows adjacent assignments in the same organization', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->withOrganization($organization)->create();
+    $event = Event::factory()->withOrganization($organization)->create([
+        'starts_at' => Carbon::parse('2026-08-01 08:00:00'),
+        'ends_at' => Carbon::parse('2026-08-01 22:00:00'),
+    ]);
+    $area = Area::factory()->withEvent($event)->create();
+
+    Assignment::factory()->withEvent($event)->withArea($area)->withSensor($sensor)->create([
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 09:00:00',
+        'active_to' => '2026-08-01 10:00:00',
+    ]);
+
+    setPermissionsOrgId($organization->id);
+
+    $assignment = $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 11:00:00',
+    ]);
+
+    expect($assignment)->toBeInstanceOf(Assignment::class);
+});
+
+it('blocks deleting a share that is used by an assignment', function () {
+    [$owner, $borrower, $sensor, $event, $area, $share] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($owner->id);
+
+    $this->expectException(ValidationException::class);
+
+    $this->sensorShareService->delete($share);
+});
+
+it('database rejects hard deleting a share that is used by an assignment', function () {
+    [, $borrower, $sensor, $event, $area, $share] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    $this->expectException(QueryException::class);
+
+    $share->forceDelete();
+});
+
+it('blocks shrinking share period outside assignments using the share', function () {
+    [$owner, $borrower, $sensor, $event, $area, $share] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($owner->id);
+
+    $this->expectException(ValidationException::class);
+
+    $this->sensorShareService->update($share, [
+        'borrower_organization_id' => $borrower->id,
+        'starts_at' => '2026-08-01 11:00:00',
+        'ends_at' => '2026-08-01 18:00:00',
+    ]);
+});
+
+it('blocks changing borrower organization while assignments use the share', function () {
+    [$owner, $borrower, $sensor, $event, $area, $share] = sharedSensorScenario();
+    $anotherBorrower = Organization::factory()->create();
+
+    setPermissionsOrgId($borrower->id);
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($owner->id);
+
+    $this->expectException(ValidationException::class);
+
+    $this->sensorShareService->update($share, [
+        'borrower_organization_id' => $anotherBorrower->id,
+        'starts_at' => '2026-08-01 09:00:00',
+        'ends_at' => '2026-08-01 18:00:00',
+    ]);
+});
+
+it('blocks sensor deletion when any assignment references the sensor', function () {
+    [$owner, $borrower, $sensor, $event, $area] = sharedSensorScenario();
+
+    setPermissionsOrgId($borrower->id);
+    $this->assignmentService->create([
+        'event_id' => $event->id,
+        'area_id' => $area->id,
+        'sensor_id' => $sensor->id,
+        'direction_flipped' => false,
+        'active_from' => '2026-08-01 10:00:00',
+        'active_to' => '2026-08-01 12:00:00',
+    ]);
+
+    setPermissionsOrgId($owner->id);
+
+    $this->expectException(ValidationException::class);
+
+    $this->sensorService->delete($sensor);
+});
+
+it('hides archived sensors from default sensor list', function () {
+    $organization = Organization::factory()->create();
+    $activeSensor = Sensor::factory()->withOrganization($organization)->create();
+    $archivedSensor = Sensor::factory()->withOrganization($organization)->create();
+
+    setPermissionsOrgId($organization->id);
+
+    $this->sensorService->archive($archivedSensor);
+
+    expect($this->sensorService->getSensors()->pluck('id')->all())
+        ->toBe([$activeSensor->id])
+        ->and($this->sensorService->getSensors(true)->pluck('id')->all())
+        ->toBe([$archivedSensor->id]);
+});

--- a/tests/Integration/Services/Peoplecount/SensorShareServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/SensorShareServiceTest.php
@@ -90,7 +90,7 @@ it('deletes an unused share', function () {
 
     $this->sensorShareService->delete($share);
 
-    $this->assertSoftDeleted('peoplecount_sensor_shares', ['id' => $share->id]);
+    $this->assertDatabaseMissing('peoplecount_sensor_shares', ['id' => $share->id]);
 });
 
 it('allows global organization to manage shares', function () {

--- a/tests/Unit/Models/OrganizationTest.php
+++ b/tests/Unit/Models/OrganizationTest.php
@@ -48,6 +48,20 @@ it('has many sensors', function () {
     expect($relation)->toBeInstanceOf(HasMany::class);
 });
 
+it('has many lent sensor shares', function () {
+    $org = new Organization;
+    $relation = $org->lentSensorShares();
+
+    expect($relation)->toBeInstanceOf(HasMany::class);
+});
+
+it('has many borrowed sensor shares', function () {
+    $org = new Organization;
+    $relation = $org->borrowedSensorShares();
+
+    expect($relation)->toBeInstanceOf(HasMany::class);
+});
+
 it('has many events', function () {
     $org = new Organization;
     $relation = $org->events();

--- a/tests/Unit/Models/Peoplecount/AssignmentTest.php
+++ b/tests/Unit/Models/Peoplecount/AssignmentTest.php
@@ -4,6 +4,7 @@ use App\Models\Peoplecount\Area;
 use App\Models\Peoplecount\Assignment;
 use App\Models\Peoplecount\Event;
 use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -16,6 +17,7 @@ it('has correct fillable attributes', function () {
         'event_id',
         'area_id',
         'sensor_id',
+        'sensor_share_id',
         'direction_flipped',
         'active_from',
         'active_to',
@@ -59,6 +61,14 @@ it('belongs to a sensor', function () {
 
     expect($relation)->toBeInstanceOf(BelongsTo::class);
     expect($relation->getRelated())->toBeInstanceOf(Sensor::class);
+});
+
+it('belongs to a sensor share', function () {
+    $model = new Assignment;
+    $relation = $model->sensorShare();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class);
+    expect($relation->getRelated())->toBeInstanceOf(SensorShare::class);
 });
 
 it('has factory', function () {

--- a/tests/Unit/Models/Peoplecount/SensorShareTest.php
+++ b/tests/Unit/Models/Peoplecount/SensorShareTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Peoplecount\Assignment;
+use App\Models\Peoplecount\Sensor;
+use App\Models\Peoplecount\SensorShare;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+covers(SensorShare::class);
+
+it('has correct fillable attributes', function () {
+    $model = new SensorShare;
+
+    expect($model->getFillable())->toEqualCanonicalizing([
+        'sensor_id',
+        'owner_organization_id',
+        'borrower_organization_id',
+        'created_by',
+        'starts_at',
+        'ends_at',
+    ]);
+});
+
+it('has correct table name', function () {
+    $model = new SensorShare;
+
+    expect($model->getTable())->toBe('peoplecount_sensor_shares');
+});
+
+it('uses timestamps', function () {
+    $model = new SensorShare;
+
+    expect($model->timestamps)->toBeTrue();
+});
+
+it('uses soft deletes', function () {
+    $model = new SensorShare;
+
+    expect(in_array(SoftDeletes::class, class_uses_recursive($model)))->toBeTrue();
+});
+
+it('belongs to a sensor', function () {
+    $model = new SensorShare;
+    $relation = $model->sensor();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class);
+    expect($relation->getRelated())->toBeInstanceOf(Sensor::class);
+});
+
+it('belongs to an owner organization', function () {
+    $model = new SensorShare;
+    $relation = $model->ownerOrganization();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class);
+    expect($relation->getRelated())->toBeInstanceOf(Organization::class);
+});
+
+it('belongs to a borrower organization', function () {
+    $model = new SensorShare;
+    $relation = $model->borrowerOrganization();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class);
+    expect($relation->getRelated())->toBeInstanceOf(Organization::class);
+});
+
+it('belongs to a creator', function () {
+    $model = new SensorShare;
+    $relation = $model->createdBy();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class);
+    expect($relation->getRelated())->toBeInstanceOf(User::class);
+});
+
+it('has many assignments', function () {
+    $model = new SensorShare;
+    $relation = $model->assignments();
+
+    expect($relation)->toBeInstanceOf(HasMany::class);
+    expect($relation->getRelated())->toBeInstanceOf(Assignment::class);
+});
+
+it('has factory', function () {
+    expect(SensorShare::factory())->toBeInstanceOf(Factory::class);
+});
+
+it('casts fields correctly', function () {
+    $model = new SensorShare;
+    $casts = $model->getCasts();
+
+    expect($casts)->toHaveKey('starts_at', 'datetime');
+    expect($casts)->toHaveKey('ends_at', 'datetime');
+});

--- a/tests/Unit/Models/Peoplecount/SensorShareTest.php
+++ b/tests/Unit/Models/Peoplecount/SensorShareTest.php
@@ -37,10 +37,10 @@ it('uses timestamps', function () {
     expect($model->timestamps)->toBeTrue();
 });
 
-it('uses soft deletes', function () {
+it('does not use soft deletes', function () {
     $model = new SensorShare;
 
-    expect(in_array(SoftDeletes::class, class_uses_recursive($model)))->toBeTrue();
+    expect(in_array(SoftDeletes::class, class_uses_recursive($model)))->toBeFalse();
 });
 
 it('belongs to a sensor', function () {

--- a/tests/Unit/Models/Peoplecount/SensorTest.php
+++ b/tests/Unit/Models/Peoplecount/SensorTest.php
@@ -14,6 +14,7 @@ it('has correct fillable attributes', function () {
         'serial',
         'api_token',
         'organization_id',
+        'archived_at',
     ]);
 });
 
@@ -48,6 +49,13 @@ it('has many interval counts', function () {
 it('has many assignments', function () {
     $sensor = new Sensor;
     $relation = $sensor->assignments();
+
+    expect($relation)->toBeInstanceOf(HasMany::class);
+});
+
+it('has many shares', function () {
+    $sensor = new Sensor;
+    $relation = $sensor->shares();
 
     expect($relation)->toBeInstanceOf(HasMany::class);
 });

--- a/tests/Unit/Requests/Peoplecount/SensorArchiveUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorArchiveUpdateRequestTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Http\Requests\Peoplecount\SensorArchiveUpdateRequest;
+use App\Models\User;
+
+covers(SensorArchiveUpdateRequest::class);
+
+beforeEach(function () {
+    $this->request = new SensorArchiveUpdateRequest;
+});
+
+it('has correct rules', function () {
+    expect($this->request->rules())->toBe([]);
+});
+
+it('authorizes when user can update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(true);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeTrue();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorArchiveUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorArchiveUpdateRequestTest.php
@@ -21,3 +21,12 @@ it('authorizes when user can update sensors', function () {
 
     expect($this->request->authorize())->toBeTrue();
 });
+
+it('does not authorize when user cannot update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(false);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareDestroyRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareDestroyRequestTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Http\Requests\Peoplecount\SensorShareDestroyRequest;
+use App\Models\User;
+
+covers(SensorShareDestroyRequest::class);
+
+beforeEach(function () {
+    $this->request = new SensorShareDestroyRequest;
+});
+
+it('has correct rules', function () {
+    expect($this->request->rules())->toBe([]);
+});
+
+it('authorizes when user can update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(true);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeTrue();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareDestroyRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareDestroyRequestTest.php
@@ -21,3 +21,12 @@ it('authorizes when user can update sensors', function () {
 
     expect($this->request->authorize())->toBeTrue();
 });
+
+it('does not authorize when user cannot update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(false);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Http\Requests\Peoplecount\SensorShareStoreRequest;
+use App\Models\User;
+
+covers(SensorShareStoreRequest::class);
+
+beforeEach(function () {
+    $this->request = new SensorShareStoreRequest;
+});
+
+it('has correct rules', function () {
+    expect($this->request->rules())->toBe([
+        'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
+        'starts_at' => ['required', 'date', 'before:ends_at'],
+        'ends_at' => ['required', 'date', 'after:starts_at'],
+    ]);
+});
+
+it('authorizes when user can update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(true);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeTrue();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
@@ -25,3 +25,12 @@ it('authorizes when user can update sensors', function () {
 
     expect($this->request->authorize())->toBeTrue();
 });
+
+it('does not authorize when user cannot update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(false);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
@@ -25,3 +25,12 @@ it('authorizes when user can update sensors', function () {
 
     expect($this->request->authorize())->toBeTrue();
 });
+
+it('does not authorize when user cannot update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(false);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Http\Requests\Peoplecount\SensorShareUpdateRequest;
+use App\Models\User;
+
+covers(SensorShareUpdateRequest::class);
+
+beforeEach(function () {
+    $this->request = new SensorShareUpdateRequest;
+});
+
+it('has correct rules', function () {
+    expect($this->request->rules())->toBe([
+        'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
+        'starts_at' => ['required', 'date', 'before:ends_at'],
+        'ends_at' => ['required', 'date', 'after:starts_at'],
+    ]);
+});
+
+it('authorizes when user can update sensors', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('peoplecount.sensors.update')->andReturn(true);
+
+    Auth::shouldReceive('user')->andReturn($user);
+
+    expect($this->request->authorize())->toBeTrue();
+});


### PR DESCRIPTION
Peoplecount sensor sharing now supports cross-organization lending with bounded share windows, while ownership, token control, and borrower privacy stay isolated. Sensors can be archived without breaking history, and assignments using borrowed sensors are attributed to the authorizing share for auditability.

## Details

- SensorShareService.php - enforces share lifecycle rules (create/update/delete restrictions, assignment-window containment, borrower change constraints).
- AssignmentService.php - authorizes borrowed assignment only inside valid share windows and stores sensor_share_id attribution.
- EditSensor.vue - adds archive controls plus share create/edit/delete UI with assignment-aware actions.
- create_sensor_shares_table migration - introduces persistence for owner/borrower/time-bounded shares.

## Notes

- Share-to-assignment linkage is enforced in app logic and DB relationships to preserve attribution.
- Coverage added across feature, integration, and unit tests for controllers, services, models, and requests.

## Reviewer Setup

In this PR vs origin/main, backend schema/services and frontend Inertia pages changed. You likely need to run:

```sh
php artisan migrate
npm run build
```

---
**«We must ship.»**
_Taylor Otwell_