### PR TITLE
fix(log-viewer): use web session middleware for API routes

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -4,7 +4,6 @@ use Opcodes\LogViewer\Enums\SortingMethod;
 use Opcodes\LogViewer\Enums\SortingOrder;
 use Opcodes\LogViewer\Enums\Theme;
 use Opcodes\LogViewer\Http\Middleware\AuthorizeLogViewer;
-use Opcodes\LogViewer\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 return [
 
@@ -117,7 +116,7 @@ return [
     */
 
     'api_middleware' => [
-        EnsureFrontendRequestsAreStateful::class,
+        'web',
         AuthorizeLogViewer::class,
     ],
 

--- a/tests/Feature/LogViewerTest.php
+++ b/tests/Feature/LogViewerTest.php
@@ -24,3 +24,17 @@ it('allows log admins to view logs', function () {
         ->get('/admin/logs')
         ->assertSuccessful();
 });
+
+it('allows log admins to load log files', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+
+    $user = User::factory()->create();
+
+    setPermissionsOrgId(GLOBAL_ORG_ID);
+    Permission::findOrCreate('admin.logs');
+    $user->givePermissionTo('admin.logs');
+
+    $this->actingAs($user)
+        ->get('/admin/logs/api/files')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
Log viewer's API routes used conditional session middleware that skipped authentication when domain/referrer matching failed, returning 403 for authorized users. Replaced with `web` middleware so API requests always run through the same session stack as the page.

## Details

- [config/log-viewer.php](https://github.com/musikfestwochen/musikfestapp/blob/fix/admin-log-viewer/config/log-viewer.php) — `api_middleware` uses `'web'` instead of `EnsureFrontendRequestsAreStateful`
- [tests/Feature/LogViewerTest.php](https://github.com/musikfestwochen/musikfestapp/blob/fix/admin-log-viewer/tests/Feature/LogViewerTest.php) — added coverage for `/admin/logs/api/files` to prevent regression

---

**"Happiness is not something readymade. It comes from your own actions."**
_Dalai Lama_