### PR TITLE
Fix area aggregate checkpoint recalculation

### DIFF
--- a/app/Services/Peoplecount/AreaAggregationService.php
+++ b/app/Services/Peoplecount/AreaAggregationService.php
@@ -89,18 +89,23 @@ class AreaAggregationService
             return;
         }
 
-        $this->deleteRowsWithInvalidChecksum($area, $areaConfigChecksum);
-        $this->deleteRowsWithInvalidWindowSize($area);
+        if ($this->deleteRowsWithInvalidChecksum($area, $areaConfigChecksum) > 0) {
+            $area->forceFill(['data_watermark' => null])->save();
+        }
+
+        if ($this->deleteRowsWithInvalidWindowSize($area) > 0) {
+            $area->forceFill(['data_watermark' => null])->save();
+        }
     }
 
     /**
      * Delete aggregated counts that have a different checksum.
      */
-    protected function deleteRowsWithInvalidChecksum(Area $area, string $areaConfigChecksum): void
+    protected function deleteRowsWithInvalidChecksum(Area $area, string $areaConfigChecksum): int
     {
         $binaryChecksum = hex2bin($areaConfigChecksum);
 
-        $area->aggregatedCounts()
+        return $area->aggregatedCounts()
             ->where('checksum', '!=', $binaryChecksum)
             ->delete();
     }
@@ -108,19 +113,21 @@ class AreaAggregationService
     /**
      * Delete all aggregated counts if the median window size differs from config.
      */
-    protected function deleteRowsWithInvalidWindowSize(Area $area): void
+    protected function deleteRowsWithInvalidWindowSize(Area $area): int
     {
         $counts = $area->aggregatedCounts;
         if ($counts->isEmpty()) {
-            return;
+            return 0;
         }
 
         $configWindowSize = (float) config('peoplecount.aggregation.granularity_minutes');
         $medianWindowSize = $this->calculateMedianWindowSize($counts);
 
         if ($medianWindowSize !== $configWindowSize) {
-            $area->aggregatedCounts()->get()->each->delete();
+            return $area->aggregatedCounts()->delete();
         }
+
+        return 0;
     }
 
     /**
@@ -179,7 +186,7 @@ class AreaAggregationService
      * @param  Collection<int, array<string, mixed>>  $resetTimes
      * @return LazyCollection<int, LazyCollection<int, array<string, mixed>>>
      */
-    protected function getAggregationWindowChunks(Area $area, Collection $resetTimes, ?Carbon $recalculateFrom): LazyCollection
+    protected function getAggregationWindowChunks(Area $area, Collection $resetTimes, Carbon $recalculateFrom): LazyCollection
     {
         return $this->generateAggregationWindows($area, $resetTimes, $recalculateFrom)
             ->chunk(self::WINDOW_CHUNK_SIZE);
@@ -189,7 +196,7 @@ class AreaAggregationService
      * @param  Collection<int, array<string, mixed>>  $resetTimes
      * @return LazyCollection<int, array<string, mixed>>
      */
-    protected function generateAggregationWindows(Area $area, Collection $resetTimes, ?Carbon $recalculateFrom): LazyCollection
+    protected function generateAggregationWindows(Area $area, Collection $resetTimes, Carbon $recalculateFrom): LazyCollection
     {
         $windowConfig = $this->getWindowConfiguration($area);
         $sortedResetTimes = $resetTimes->sortBy('at');
@@ -205,7 +212,7 @@ class AreaAggregationService
                     continue;
                 }
 
-                if ($recalculateFrom && $window['start']->lessThan($recalculateFrom)) {
+                if ($window['start']->lessThan($recalculateFrom)) {
                     continue;
                 }
 
@@ -499,7 +506,7 @@ class AreaAggregationService
     }
 
     /**
-     * @return array{recalculate_from: Carbon|null, initial_count: int}
+     * @return array{recalculate_from: Carbon, initial_count: int}
      */
     protected function getAggregationCheckpoint(Area $area, ?Carbon $runWatermark = null): array
     {
@@ -509,11 +516,11 @@ class AreaAggregationService
             ->get(['id', 'area_id', 'period_start', 'period_end', 'count']);
 
         $previousCount = $latestCounts->get(1);
-        $recalculateFrom = $latestCounts->get(0)?->period_start;
+        $recalculateFrom = $latestCounts->get(0)->period_start ?? $area->event->starts_at;
         $initialCount = $previousCount ? $previousCount->count : 0;
         $lateRecalculateFrom = $area->exists ? $this->getLateArrivalRecalculateFrom($area, $runWatermark) : null;
 
-        if ($lateRecalculateFrom && (! $recalculateFrom || $lateRecalculateFrom->lessThan($recalculateFrom))) {
+        if ($lateRecalculateFrom && $lateRecalculateFrom->lessThan($recalculateFrom)) {
             $recalculateFrom = $lateRecalculateFrom;
             $initialCount = $this->getInitialCountBefore($area, $recalculateFrom);
         }

--- a/tests/Feature/Peoplecount/AggregateAreaTest.php
+++ b/tests/Feature/Peoplecount/AggregateAreaTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use App\Jobs\AggregateAreaCounts;
+use App\Models\Peoplecount\Area;
+use App\Models\Peoplecount\AreaAggregatedCount;
 use App\Models\Peoplecount\AreaRecurringReset;
 use App\Models\Peoplecount\AreaSingleReset;
 use App\Models\Peoplecount\Assignment;
+use App\Services\Peoplecount\AreaAggregationService;
 use Illuminate\Support\Carbon;
 
 it('correctly calculates the total event numbers', function () {
@@ -113,6 +116,55 @@ it('correctly calculates the total event numbers with different aggregation gran
     // assert
     expect($area->aggregatedCounts()->latest('period_end')->first()->count)->toBe($expectedCount);
 })->with([1, 5, 10, 15, 30, 60, 180, 24 * 60 + 10]);
+
+it('rebuilds from event start when aggregates are empty even with stale watermark', function () {
+    $eventStart = Carbon::parse('2025-08-02 10:00:00')->utc();
+    $setup = setupAggregationScenario([
+        'granularity_minutes' => 10,
+        'event_start' => $eventStart,
+        'event_end' => $eventStart->copy()->addHour(),
+        'now' => $eventStart->copy()->addMinutes(31),
+        'interval_counts' => [
+            ['ts_from' => $eventStart, 'ts_to' => $eventStart->copy()->addMinutes(10), 'count_in' => 5, 'received_at' => $eventStart->copy()->addMinutes(10)],
+            ['ts_from' => $eventStart->copy()->addMinutes(20), 'ts_to' => $eventStart->copy()->addMinutes(30), 'count_in' => 3, 'received_at' => $eventStart->copy()->addMinutes(30)],
+        ],
+    ]);
+
+    $setup['area']->forceFill(['data_watermark' => $eventStart->copy()->addMinutes(15)])->save();
+
+    AggregateAreaCounts::dispatch();
+
+    assertWindowCount($setup['area'], '2025-08-02 10:00:00', '2025-08-02 10:10:00', 5);
+    assertWindowCount($setup['area'], '2025-08-02 10:20:00', '2025-08-02 10:30:00', 8);
+});
+
+it('clears data watermark when invalid aggregate rows are deleted', function () {
+    $eventStart = Carbon::parse('2025-08-02 10:00:00')->utc();
+    $setup = setupAggregationScenario([
+        'event_start' => $eventStart,
+        'event_end' => $eventStart->copy()->addHour(),
+    ]);
+
+    $setup['area']->forceFill(['data_watermark' => $eventStart->copy()->addMinutes(15)])->save();
+    AreaAggregatedCount::factory()->create([
+        'area_id' => $setup['area']->id,
+        'period_start' => $eventStart,
+        'period_end' => $eventStart->copy()->addMinutes(10),
+        'checksum' => str_repeat('0', 64),
+    ]);
+
+    $deleteInvalidRows = Closure::bind(
+        function (AreaAggregationService $service, Area $area, string $checksum): void {
+            $service->deleteInvalidAggregationRows($area, $checksum);
+        },
+        null,
+        AreaAggregationService::class,
+    );
+
+    $deleteInvalidRows(app(AreaAggregationService::class), $setup['area']->refresh(), str_repeat('1', 64));
+
+    expect($setup['area']->refresh()->data_watermark)->toBeNull();
+});
 
 it('correctly aggregates with single reset at start', function ($offset) {
     // arrange

--- a/tests/Integration/Services/Peoplecount/AreaAggregationServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/AreaAggregationServiceTest.php
@@ -142,10 +142,12 @@ describe('updateAggregatedCounts method', function () {
 
         // Mock for deleteRowsWithInvalidChecksum - this verifies deleteInvalidAggregationRows is called
         $builderMock = Mockery::mock(Builder::class);
-        $builderMock->shouldReceive('delete')->once(); // This expectation will fail if deleteInvalidAggregationRows is not called
+        $builderMock->shouldReceive('delete')->once()->andReturn(1); // This expectation will fail if deleteInvalidAggregationRows is not called
         $relationshipMock->shouldReceive('where')->with('checksum', '!=', hex2bin('abc123'))->andReturn($builderMock);
 
         $area->shouldReceive('aggregatedCounts')->andReturn($relationshipMock);
+        $area->shouldReceive('forceFill')->once()->with(['data_watermark' => null])->andReturnSelf();
+        $area->shouldReceive('save')->once()->andReturnTrue();
 
         $this->service->updateAggregatedCounts($area);
 
@@ -331,7 +333,7 @@ describe('generateAggregationWindows method', function () {
         $area->shouldReceive('getAttribute')->with('event')->andReturn($event);
         $resetTimes = collect();
 
-        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, $resetTimes, null)->collect();
+        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, $resetTimes, Carbon::parse('2024-08-15 10:00:00'))->collect();
 
         expect($result)->toHaveCount(6); // 60 minutes / 10 minute windows = 6 windows
         expect($result->first()['start']->format('H:i'))->toBe('10:00');
@@ -462,7 +464,7 @@ describe('generateAggregationWindows future filtering', function () {
         $event->shouldReceive('getAttribute')->with('ends_at')->andReturn(Carbon::parse('2024-08-15 16:10:00'));
         $area->shouldReceive('getAttribute')->with('event')->andReturn($event);
 
-        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, collect(), null)->collect();
+        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, collect(), Carbon::parse('2024-08-15 12:00:00'))->collect();
 
         expect($result)->toHaveCount(15);
         expect($result->first()['start']->format('H:i'))->toBe('12:00');
@@ -489,7 +491,7 @@ describe('deleteInvalidAggregationRows method', function () {
 
         // Mock for deleteRowsWithInvalidChecksum - first call
         $builderMock1 = Mockery::mock(Builder::class);
-        $builderMock1->shouldReceive('delete')->once();
+        $builderMock1->shouldReceive('delete')->once()->andReturn(1);
 
         $relationshipMock1 = Mockery::mock(HasMany::class)->shouldIgnoreMissing();
         $relationshipMock1->shouldReceive('where')->with('checksum', '!=', hex2bin('abc123'))->andReturn($builderMock1);
@@ -500,6 +502,8 @@ describe('deleteInvalidAggregationRows method', function () {
         // No get() expectation needed since median matches config and delete won't be called
 
         $area->shouldReceive('aggregatedCounts')->andReturn($relationshipMock1, $relationshipMock2);
+        $area->shouldReceive('forceFill')->once()->with(['data_watermark' => null])->andReturnSelf();
+        $area->shouldReceive('save')->once()->andReturnTrue();
 
         // Mock for deleteRowsWithInvalidWindowSize - median matches config
         $count->shouldReceive('getAttribute')->with('period_start')->andReturn(Carbon::parse('2024-08-15 10:00:00'));
@@ -518,25 +522,21 @@ describe('deleteInvalidAggregationRows method', function () {
 
         // Mock for deleteRowsWithInvalidChecksum - first call
         $builderMock1 = Mockery::mock(Builder::class);
-        $builderMock1->shouldReceive('delete')->once();
+        $builderMock1->shouldReceive('delete')->once()->andReturn(1);
 
         $relationshipMock1 = Mockery::mock(HasMany::class)->shouldIgnoreMissing();
         $relationshipMock1->shouldReceive('where')->with('checksum', '!=', hex2bin('abc123'))->andReturn($builderMock1);
 
-        // Mock for deleteRowsWithInvalidWindowSize - second call (median differs from config, so get()->each->delete())
-        // Create a real collection with the mock model so each->delete() works properly
-        $realCollection = new EloquentCollection([$count]);
-
         $relationshipMock2 = Mockery::mock(HasMany::class)->shouldIgnoreMissing();
-        $relationshipMock2->shouldReceive('get')->once()->andReturn($realCollection);
+        $relationshipMock2->shouldReceive('delete')->once()->andReturn(1);
 
         $area->shouldReceive('aggregatedCounts')->andReturn($relationshipMock1, $relationshipMock2);
+        $area->shouldReceive('forceFill')->twice()->with(['data_watermark' => null])->andReturnSelf();
+        $area->shouldReceive('save')->twice()->andReturnTrue();
 
         // Mock for deleteRowsWithInvalidWindowSize - median differs from config (15 minutes vs 10)
         $count->shouldReceive('getAttribute')->with('period_start')->andReturn(Carbon::parse('2024-08-15 10:00:00'));
         $count->shouldReceive('getAttribute')->with('period_end')->andReturn(Carbon::parse('2024-08-15 10:15:00'));
-        $count->shouldReceive('delete')->once();
-
         $result = ($this->callProtectedMethod)('deleteInvalidAggregationRows', $area, 'abc123');
 
         expect($result)->toBeNull();
@@ -550,12 +550,12 @@ describe('deleteRowsWithInvalidChecksum method', function () {
         $builderMock = Mockery::mock(Builder::class);
 
         $relationshipMock->shouldReceive('where')->with('checksum', '!=', hex2bin('abc123'))->andReturn($builderMock);
-        $builderMock->shouldReceive('delete')->once();
+        $builderMock->shouldReceive('delete')->once()->andReturn(1);
         $area->shouldReceive('aggregatedCounts')->andReturn($relationshipMock);
 
         $result = ($this->callProtectedMethod)('deleteRowsWithInvalidChecksum', $area, 'abc123');
 
-        expect($result)->toBeNull();
+        expect($result)->toBe(1);
     });
 });
 
@@ -567,7 +567,7 @@ describe('deleteRowsWithInvalidWindowSize method', function () {
 
         $result = ($this->callProtectedMethod)('deleteRowsWithInvalidWindowSize', $area);
 
-        expect($result)->toBeNull();
+        expect($result)->toBe(0);
     });
 
     it('deletes all counts when median window size differs from config', function () {
@@ -577,21 +577,16 @@ describe('deleteRowsWithInvalidWindowSize method', function () {
         $count = Mockery::mock(AreaAggregatedCount::class);
         $count->shouldReceive('getAttribute')->with('period_start')->andReturn(Carbon::parse('2024-08-15 10:00:00'));
         $count->shouldReceive('getAttribute')->with('period_end')->andReturn(Carbon::parse('2024-08-15 10:15:00'));
-        $count->shouldReceive('delete')->once();
         $counts = new EloquentCollection([$count]);
         $area->shouldReceive('getAttribute')->with('aggregatedCounts')->andReturn($counts);
 
-        // Mock relationship for get()->each->delete() pattern
-        // Create a real collection with the mock model so each->delete() works properly
-        $realCollection = new EloquentCollection([$count]);
-
         $relationshipMock = Mockery::mock(HasMany::class)->shouldIgnoreMissing();
-        $relationshipMock->shouldReceive('get')->once()->andReturn($realCollection);
+        $relationshipMock->shouldReceive('delete')->once()->andReturn(1);
         $area->shouldReceive('aggregatedCounts')->once()->andReturn($relationshipMock);
 
         $result = ($this->callProtectedMethod)('deleteRowsWithInvalidWindowSize', $area);
 
-        expect($result)->toBeNull();
+        expect($result)->toBe(1);
     });
 
     it('does not delete when median window size matches config', function () {
@@ -609,7 +604,7 @@ describe('deleteRowsWithInvalidWindowSize method', function () {
 
         $result = ($this->callProtectedMethod)('deleteRowsWithInvalidWindowSize', $area);
 
-        expect($result)->toBeNull();
+        expect($result)->toBe(0);
     });
 });
 
@@ -624,7 +619,7 @@ describe('getAggregationWindowChunks method', function () {
         $event->shouldReceive('getAttribute')->with('ends_at')->andReturn(Carbon::parse('2024-08-15 10:10:00'));
         $area->shouldReceive('getAttribute')->with('event')->andReturn($event);
 
-        $result = ($this->callProtectedMethod)('getAggregationWindowChunks', $area, $resetTimes, null);
+        $result = ($this->callProtectedMethod)('getAggregationWindowChunks', $area, $resetTimes, Carbon::parse('2024-08-15 10:00:00'));
 
         expect($result)->toBeInstanceOf(LazyCollection::class);
         expect($result->first())->toBeInstanceOf(LazyCollection::class);
@@ -640,7 +635,7 @@ describe('getAggregationWindowChunks method', function () {
         $event->shouldReceive('getAttribute')->with('ends_at')->andReturn(Carbon::parse('2024-08-15 10:10:00'));
         $area->shouldReceive('getAttribute')->with('event')->andReturn($event);
 
-        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, $resetTimes, null)->collect();
+        $result = ($this->callProtectedMethod)('generateAggregationWindows', $area, $resetTimes, Carbon::parse('2024-08-15 10:00:00'))->collect();
 
         expect($result)->toBeInstanceOf(Collection::class);
         expect($result)->toHaveCount(1); // 10 minute window
@@ -860,6 +855,9 @@ describe('writeAggregatedCounts method', function () {
 describe('getAggregationCheckpoint method', function () {
     it('returns default checkpoint when fewer than two existing counts exist', function () {
         $area = Mockery::mock(Area::class);
+        $event = Mockery::mock(Event::class);
+        $event->shouldReceive('getAttribute')->with('starts_at')->andReturn(Carbon::parse('2024-08-15 10:00:00'));
+        $area->shouldReceive('getAttribute')->with('event')->andReturn($event);
 
         // Create a proper HasMany relationship mock that can handle method chaining
         $relationshipMock = Mockery::mock(HasMany::class)->shouldIgnoreMissing();
@@ -871,19 +869,18 @@ describe('getAggregationCheckpoint method', function () {
 
         $result = ($this->callProtectedMethod)('getAggregationCheckpoint', $area);
 
-        expect($result)->toBe([
-            'recalculate_from' => null,
-            'initial_count' => 0,
-        ]);
+        expect($result['recalculate_from']->format('H:i'))->toBe('10:00');
+        expect($result['initial_count'])->toBe(0);
     });
 
     it('returns recalculation start and initial count from existing counts', function () {
         $area = Mockery::mock(Area::class);
-        $latestCount = Mockery::mock(AreaAggregatedCount::class);
-        $latestCount->shouldReceive('getAttribute')->with('period_start')->andReturn(Carbon::parse('2024-08-15 10:10:00'));
-
-        $previousCount = Mockery::mock(AreaAggregatedCount::class);
-        $previousCount->shouldReceive('getAttribute')->with('count')->andReturn(25);
+        $latestCount = new AreaAggregatedCount([
+            'period_start' => Carbon::parse('2024-08-15 10:10:00'),
+        ]);
+        $previousCount = new AreaAggregatedCount([
+            'count' => 25,
+        ]);
 
         // Create a proper HasMany relationship mock that can handle method chaining
         $relationshipMock = Mockery::mock(HasMany::class)->shouldIgnoreMissing();


### PR DESCRIPTION
Fixes area aggregate rebuilds after configuration changes. Before this change, checksum/window-size changes deleted invalid aggregate rows but left `data_watermark` behind; the next run saw an empty aggregate table, treated rows after the old watermark as late arrivals, and started recalculating from that later sensor timestamp with count `0` instead of from event start. That produced aggregate histories whose first row began too late, so all following cumulative counts used the wrong base.

Now the checkpoint always has a concrete lower bound: existing latest aggregate row or event start. Late-arrival recalculation can only move the checkpoint earlier, never forward from an empty table, and deleting invalid aggregate rows clears `data_watermark` so rebuilt histories do not inherit stale ingest state.

## Details

- [AreaAggregationService.php](https://github.com/musikfestwochen/musikfestapp/blob/fix/aggregation-window-checkpoint-calculation/app/Services/Peoplecount/AreaAggregationService.php) - makes `recalculate_from` non-null, prevents stale watermark from moving empty-table rebuilds forward, and clears area watermark when invalid aggregates are deleted.
- [AggregateAreaTest.php](https://github.com/musikfestwochen/musikfestapp/blob/fix/aggregation-window-checkpoint-calculation/tests/Feature/Peoplecount/AggregateAreaTest.php) - covers empty aggregate rebuilds with stale watermark and watermark clearing.
- [AreaAggregationServiceTest.php](https://github.com/musikfestwochen/musikfestapp/blob/fix/aggregation-window-checkpoint-calculation/tests/Integration/Services/Peoplecount/AreaAggregationServiceTest.php) - updates protected-method coverage for non-null checkpoints and delete row counts.

## Notes

After deploy, affected area aggregate rows should be truncated once so existing suffix-only aggregate histories rebuild cleanly under the corrected checkpoint logic.

---
**«Be present above all else.»**
_Naval Ravikant_