### PR TITLE
Improve user organization roles handling

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Admin\UserShowRequest;
 use App\Http\Requests\Admin\UserStoreRequest;
 use App\Http\Requests\Admin\UserUpdateRequest;
 use App\Models\User;
+use App\Services\OrganizationService;
 use App\Services\UserService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Str;
@@ -29,7 +30,7 @@ class UserController extends Controller
         $userService = resolve(UserService::class);
 
         return Inertia::render('admin/Users', [
-            'users' => $userService->getUsers(),
+            'users' => $userService->getUsersWithOrganizationCount(),
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -73,8 +74,11 @@ class UserController extends Controller
      */
     public function edit(UserEditRequest $request, User $user): Response
     {
+        $organizationService = resolve(OrganizationService::class);
+
         return Inertia::render('admin/EditUser', [
-            'user' => $user,
+            'organizations' => $organizationService->getOrganizations(),
+            'user' => $user->load('organizations:id'),
         ]);
     }
 
@@ -83,7 +87,13 @@ class UserController extends Controller
      */
     public function update(UserUpdateRequest $request, User $user): RedirectResponse
     {
-        $user->update($request->validated());
+        $validated = $request->validated();
+
+        $user->update(collect($validated)->except('organization_ids')->all());
+
+        if (array_key_exists('organization_ids', $validated)) {
+            resolve(UserService::class)->syncOrganizations($user, $validated['organization_ids']);
+        }
 
         return to_route('admin.users.index')->with('status', 'User '.$user->name.' updated successfully.');
     }

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -16,7 +16,6 @@ use App\Models\Organization;
 use App\Models\User;
 use App\Services\UserService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -25,10 +24,8 @@ class UserController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(UserIndexRequest $request, Organization $organization): Response
+    public function index(UserIndexRequest $request, UserService $userService, Organization $organization): Response
     {
-        $userService = resolve(UserService::class);
-
         return Inertia::render('orgmgmt/Users', [
             'organization' => $organization,
             'users' => $userService->getUsers(),
@@ -39,22 +36,14 @@ class UserController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(UserStoreRequest $request, Organization $organization): RedirectResponse
+    public function store(UserStoreRequest $request, UserService $userService, Organization $organization): RedirectResponse
     {
-        $user = User::query()->create(
-            array_merge($request->validated(), ['password' => Str::random()])
-        );
-
-        // attach user to organization
-        $user->organizations()->attach($organization->id);
-
-        // Give User default role
-        $user->assignRole('PeopleCountViewer');
+        $user = $userService->createOrAttachToOrganization($organization, $request->payload());
 
         return to_route('orgmgmt.users.index', [
             'organization' => $organization,
         ])
-            ->with('status', 'User '.$user->name.' created successfully.');
+            ->with('status', 'User '.$user->name.' added successfully.');
     }
 
     /**
@@ -111,11 +100,11 @@ class UserController extends Controller
      *
      * @param  UserDestroyRequest  $request  Required for authorization, even if not explicitly used in method body
      */
-    public function destroy(UserDestroyRequest $request, Organization $organization, User $user): RedirectResponse
+    public function destroy(UserDestroyRequest $request, UserService $userService, Organization $organization, User $user): RedirectResponse
     {
         $name = $user->name;
 
-        resolve(UserService::class)->removeFromOrganization($user, $organization);
+        $userService->removeFromOrganization($user, $organization);
 
         return to_route('orgmgmt.users.index', [
             'organization' => $organization,

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -38,7 +38,7 @@ class UserController extends Controller
      */
     public function store(UserStoreRequest $request, UserService $userService, Organization $organization): RedirectResponse
     {
-        $user = $userService->createOrAttachToOrganization($organization, $request->payload());
+        $user = $userService->createOrAttachToOrganization($organization, $request->payload(), $request->roleNames());
 
         return to_route('orgmgmt.users.index', [
             'organization' => $organization,
@@ -86,9 +86,9 @@ class UserController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UserUpdateRequest $request, Organization $organization, User $user): RedirectResponse
+    public function update(UserUpdateRequest $request, UserService $userService, Organization $organization, User $user): RedirectResponse
     {
-        $user->update($request->validated());
+        $userService->updateForOrganization($organization, $user, $request->payload(), $request->roleNames());
 
         return to_route('orgmgmt.users.index', [
             'organization' => $organization,

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -110,19 +110,15 @@ class UserController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  UserDestroyRequest  $request  Required for authorization, even if not explicitly used in method body
-     *
-     * @todo: Do not delete user if they belong to an organization, then only remove the organization association.
      */
     public function destroy(UserDestroyRequest $request, Organization $organization, User $user): RedirectResponse
     {
-        // save user name for redirect message
         $name = $user->name;
 
-        // delete user
-        $user->delete();
+        resolve(UserService::class)->removeFromOrganization($user, $organization);
 
         return to_route('orgmgmt.users.index', [
             'organization' => $organization,
-        ])->with('status', 'User '.$name.' deleted successfully.');
+        ])->with('status', 'User '.$name.' removed successfully.');
     }
 }

--- a/app/Http/Controllers/Orgmgmt/UserController.php
+++ b/app/Http/Controllers/Orgmgmt/UserController.php
@@ -49,10 +49,12 @@ class UserController extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(UserCreateRequest $request, Organization $organization): Response
+    public function create(UserCreateRequest $request, UserService $userService, Organization $organization): Response
     {
         return Inertia::render('orgmgmt/NewUser', [
             'organization' => $organization,
+            'availableRoles' => $userService->availableOrganizationRoles(),
+            'selectedRoles' => ['PeopleCountViewer'],
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -75,11 +77,13 @@ class UserController extends Controller
      *
      * @param  UserEditRequest  $request  Required for authorization, even if not explicitly used in method body
      */
-    public function edit(UserEditRequest $request, Organization $organization, User $user): Response
+    public function edit(UserEditRequest $request, UserService $userService, Organization $organization, User $user): Response
     {
         return Inertia::render('orgmgmt/EditUser', [
             'organization' => $organization,
             'user' => $user,
+            'availableRoles' => $userService->availableOrganizationRoles(),
+            'selectedRoles' => $userService->getOrganizationRoleNames($user, $organization),
         ]);
     }
 

--- a/app/Http/Requests/Admin/UserUpdateRequest.php
+++ b/app/Http/Requests/Admin/UserUpdateRequest.php
@@ -34,4 +34,17 @@ use Illuminate\Foundation\Http\FormRequest;
             'organization_ids.*' => ['integer', 'exists:organizations,id'],
         ];
     }
+
+    protected function prepareForValidation(): void
+    {
+        if (! array_key_exists('phone', $this->all())) {
+            return;
+        }
+
+        $phone = $this->input('phone');
+
+        if (is_string($phone) || $phone === null) {
+            $this->merge(['phone' => User::normalizePhone($phone)]);
+        }
+    }
 }

--- a/app/Http/Requests/Admin/UserUpdateRequest.php
+++ b/app/Http/Requests/Admin/UserUpdateRequest.php
@@ -30,6 +30,8 @@ use Illuminate\Foundation\Http\FormRequest;
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.($this->route('user')->id ?? '')],
             'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'.($this->route('user')->id ?? '')],
+            'organization_ids' => ['sometimes', 'array'],
+            'organization_ids.*' => ['integer', 'exists:organizations,id'],
         ];
     }
 }

--- a/app/Http/Requests/Orgmgmt/UserStoreRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserStoreRequest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UserStoreRequest extends FormRequest
 {
@@ -30,7 +31,18 @@ class UserStoreRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', $this->uniquePhoneForEmailUser()],
+            'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notChangingOwnRoles()],
+            'roles.*' => ['string', 'distinct', Rule::notIn(['SuperAdmin', 'Admin']), Rule::exists('roles', 'name')],
         ];
+    }
+
+    protected function notChangingOwnRoles(): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail): void {
+            if ($this->user()?->email === $this->string('email')->toString()) {
+                $fail('You cannot change your own roles.');
+            }
+        };
     }
 
     protected function prepareForValidation(): void
@@ -77,5 +89,19 @@ class UserStoreRequest extends FormRequest
             'email' => $validated['email'],
             'phone' => $validated['phone'] ?? null,
         ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function roleNames(): array
+    {
+        $roles = $this->validated('roles');
+
+        if (! is_array($roles)) {
+            return ['PeopleCountViewer'];
+        }
+
+        return array_values(array_filter($roles, is_string(...)));
     }
 }

--- a/app/Http/Requests/Orgmgmt/UserStoreRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserStoreRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Orgmgmt;
 
+use App\Models\User;
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -26,8 +28,54 @@ class UserStoreRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'phone' => ['nullable', 'string', 'max:20', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:20', $this->uniquePhoneForEmailUser()],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $phone = $this->input('phone');
+
+        if (is_string($phone) || $phone === null) {
+            $this->merge(['phone' => User::normalizePhone($phone)]);
+        }
+    }
+
+    protected function uniquePhoneForEmailUser(): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail): void {
+            if (! is_string($value) || $value === '') {
+                return;
+            }
+
+            $existingUserId = User::query()
+                ->where('email', $this->string('email')->toString())
+                ->value('id');
+
+            $duplicatePhone = User::query()->where('phone', $value);
+
+            if ($existingUserId !== null) {
+                $duplicatePhone->whereKeyNot($existingUserId);
+            }
+
+            if ($duplicatePhone->exists()) {
+                $fail('The phone has already been taken.');
+            }
+        };
+    }
+
+    /**
+     * @return array{name: string, email: string, phone?: string|null}
+     */
+    public function payload(): array
+    {
+        $validated = $this->validated();
+
+        return [
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'phone' => $validated['phone'] ?? null,
         ];
     }
 }

--- a/app/Http/Requests/Orgmgmt/UserStoreRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserStoreRequest.php
@@ -32,7 +32,7 @@ class UserStoreRequest extends FormRequest
             'email' => ['required', 'string', 'email', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', $this->uniquePhoneForEmailUser()],
             'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notChangingOwnRoles()],
-            'roles.*' => ['string', 'distinct', Rule::notIn(['SuperAdmin', 'Admin']), Rule::exists('roles', 'name')],
+            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'OrganizationAdmin'])],
         ];
     }
 

--- a/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
@@ -32,7 +32,7 @@ use Illuminate\Validation\Rule;
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.($this->route('user')->id ?? '')],
             'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'.($this->route('user')->id ?? '')],
             'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notUpdatingOwnRoles()],
-            'roles.*' => ['string', 'distinct', Rule::notIn(['SuperAdmin', 'Admin']), Rule::exists('roles', 'name')],
+            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'OrganizationAdmin'])],
         ];
     }
 

--- a/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Requests\Orgmgmt;
 
 use AllowDynamicProperties;
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 #[AllowDynamicProperties] class UserUpdateRequest extends FormRequest
 {
@@ -29,6 +31,50 @@ use Illuminate\Foundation\Http\FormRequest;
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.($this->route('user')->id ?? '')],
             'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'.($this->route('user')->id ?? '')],
+            'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notUpdatingOwnRoles()],
+            'roles.*' => ['string', 'distinct', Rule::notIn(['SuperAdmin', 'Admin']), Rule::exists('roles', 'name')],
         ];
+    }
+
+    protected function notUpdatingOwnRoles(): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail): void {
+            if ($this->user()?->is($this->route('user'))) {
+                $fail('You cannot change your own roles.');
+            }
+        };
+    }
+
+    /**
+     * @return array{name: string, email: string, phone?: string|null}
+     */
+    public function payload(): array
+    {
+        $validated = $this->validated();
+
+        $payload = [
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+        ];
+
+        if (array_key_exists('phone', $validated)) {
+            $payload['phone'] = $validated['phone'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    public function roleNames(): ?array
+    {
+        $roles = $this->validated('roles');
+
+        if (! is_array($roles)) {
+            return null;
+        }
+
+        return array_values(array_filter($roles, is_string(...)));
     }
 }

--- a/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Orgmgmt;
 
 use AllowDynamicProperties;
+use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -34,6 +35,19 @@ use Illuminate\Validation\Rule;
             'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notUpdatingOwnRoles()],
             'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'OrganizationAdmin'])],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (! array_key_exists('phone', $this->all())) {
+            return;
+        }
+
+        $phone = $this->input('phone');
+
+        if (is_string($phone) || $phone === null) {
+            $this->merge(['phone' => User::normalizePhone($phone)]);
+        }
     }
 
     protected function notUpdatingOwnRoles(): Closure

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -87,14 +87,18 @@ class User extends Authenticatable implements MustVerifyEmail
     protected function phone(): Attribute
     {
         return Attribute::make(set: function (?string $value): array {
-            $cleaned = $value !== null ? trim($value) : null;
-            if (in_array($cleaned, [null, '', '0'], true)) {
-                return ['phone' => null];
-            }
-
-            $cleaned = preg_replace('/[\s\-()\.]+/', '', $cleaned);
-
-            return ['phone' => $cleaned];
+            return ['phone' => self::normalizePhone($value)];
         });
+    }
+
+    public static function normalizePhone(?string $value): ?string
+    {
+        $cleaned = $value !== null ? trim($value) : null;
+
+        if (in_array($cleaned, [null, '', '0'], true)) {
+            return null;
+        }
+
+        return preg_replace('/[\s\-()\.]+/', '', $cleaned);
     }
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -61,13 +61,12 @@ class UserService
     }
 
     /**
-     * Create a user or attach an existing user to an organization.
-     *
      * @param  array{name: string, email: string, phone?: string|null}  $data
+     * @param  array<int, string>  $roleNames
      */
-    public function createOrAttachToOrganization(Organization $organization, array $data): User
+    public function createOrAttachToOrganization(Organization $organization, array $data, array $roleNames = ['PeopleCountViewer']): User
     {
-        return DB::transaction(function () use ($organization, $data): User {
+        return DB::transaction(function () use ($organization, $data, $roleNames): User {
             $user = User::query()->firstOrCreate(
                 ['email' => $data['email']],
                 [
@@ -78,10 +77,42 @@ class UserService
             );
 
             $user->organizations()->syncWithoutDetaching([$organization->id]);
-            $this->assignDefaultOrganizationRole($user, $organization);
+            $this->syncOrganizationRoles($user, $organization, $roleNames);
 
             return $user;
         });
+    }
+
+    /**
+     * @param  array{name: string, email: string, phone?: string|null}  $data
+     * @param  array<int, string>|null  $roleNames
+     */
+    public function updateForOrganization(Organization $organization, User $user, array $data, ?array $roleNames): void
+    {
+        DB::transaction(function () use ($organization, $user, $data, $roleNames): void {
+            $user->update($data);
+
+            if ($roleNames !== null) {
+                $this->syncOrganizationRoles($user, $organization, $roleNames);
+            }
+        });
+    }
+
+    /**
+     * @param  array<int, string>  $roleNames
+     */
+    public function syncOrganizationRoles(User $user, Organization $organization, array $roleNames): void
+    {
+        $previousOrganizationId = getPermissionsOrgId();
+
+        try {
+            setPermissionsOrgId($organization->id);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+            $user->syncRoles($roleNames);
+        } finally {
+            setPermissionsOrgId($previousOrganizationId);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+        }
     }
 
     /**
@@ -130,20 +161,6 @@ class UserService
             $user->unsetRelation('roles')->unsetRelation('permissions');
             $user->syncRoles([]);
             $user->syncPermissions([]);
-        } finally {
-            setPermissionsOrgId($previousOrganizationId);
-            $user->unsetRelation('roles')->unsetRelation('permissions');
-        }
-    }
-
-    protected function assignDefaultOrganizationRole(User $user, Organization $organization): void
-    {
-        $previousOrganizationId = getPermissionsOrgId();
-
-        try {
-            setPermissionsOrgId($organization->id);
-            $user->unsetRelation('roles')->unsetRelation('permissions');
-            $user->assignRole('PeopleCountViewer');
         } finally {
             setPermissionsOrgId($previousOrganizationId);
             $user->unsetRelation('roles')->unsetRelation('permissions');

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -51,6 +51,29 @@ class UserService
     }
 
     /**
+     * @return Collection<int, User>
+     */
+    public function getUsersWithOrganizationCount(): Collection
+    {
+        return User::query()->withCount('organizations')->get();
+    }
+
+    /**
+     * @param  array<int, int>  $organizationIds
+     */
+    public function syncOrganizations(User $user, array $organizationIds): void
+    {
+        $currentOrganizationIds = $user->organizations()->pluck('organizations.id')->all();
+        $removedOrganizationIds = array_diff($currentOrganizationIds, $organizationIds);
+
+        foreach ($removedOrganizationIds as $organizationId) {
+            $this->removeOrganizationAccess($user, Organization::query()->whereKey($organizationId)->firstOrFail());
+        }
+
+        $user->organizations()->sync($organizationIds);
+    }
+
+    /**
      * Remove a user from an organization.
      *
      * @return bool True when the user was deleted, false when only detached.

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -8,6 +8,8 @@ use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class UserService
 {
@@ -59,6 +61,30 @@ class UserService
     }
 
     /**
+     * Create a user or attach an existing user to an organization.
+     *
+     * @param  array{name: string, email: string, phone?: string|null}  $data
+     */
+    public function createOrAttachToOrganization(Organization $organization, array $data): User
+    {
+        return DB::transaction(function () use ($organization, $data): User {
+            $user = User::query()->firstOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'phone' => $data['phone'] ?? null,
+                    'password' => Str::random(),
+                ],
+            );
+
+            $user->organizations()->syncWithoutDetaching([$organization->id]);
+            $this->assignDefaultOrganizationRole($user, $organization);
+
+            return $user;
+        });
+    }
+
+    /**
      * @param  array<int, int>  $organizationIds
      */
     public function syncOrganizations(User $user, array $organizationIds): void
@@ -104,6 +130,20 @@ class UserService
             $user->unsetRelation('roles')->unsetRelation('permissions');
             $user->syncRoles([]);
             $user->syncPermissions([]);
+        } finally {
+            setPermissionsOrgId($previousOrganizationId);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+        }
+    }
+
+    protected function assignDefaultOrganizationRole(User $user, Organization $organization): void
+    {
+        $previousOrganizationId = getPermissionsOrgId();
+
+        try {
+            setPermissionsOrgId($organization->id);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+            $user->assignRole('PeopleCountViewer');
         } finally {
             setPermissionsOrgId($previousOrganizationId);
             $user->unsetRelation('roles')->unsetRelation('permissions');

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -10,9 +10,43 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
 
 class UserService
 {
+    /**
+     * @return array<int, array{name: string, display_name: string|null, description: string|null}>
+     */
+    public function availableOrganizationRoles(): array
+    {
+        $roleNames = ['PeopleCountViewer', 'OrganizationAdmin'];
+        $roles = Role::query()
+            ->whereIn('name', $roleNames)
+            ->get(['name', 'display_name', 'description'])
+            ->keyBy('name');
+
+        $availableRoles = [];
+
+        foreach ($roleNames as $roleName) {
+            $role = $roles->get($roleName);
+
+            if (! $role instanceof Role) {
+                continue;
+            }
+
+            $displayName = $role->getAttribute('display_name');
+            $description = $role->getAttribute('description');
+
+            $availableRoles[] = [
+                'name' => $roleName,
+                'display_name' => is_string($displayName) ? $displayName : null,
+                'description' => is_string($description) ? $description : null,
+            ];
+        }
+
+        return $availableRoles;
+    }
+
     /**
      * Fetch users. When an Organization is provided, limit to that org. Optionally select specific columns.
      * Otherwise, fall back to current permissions org context.
@@ -109,6 +143,24 @@ class UserService
             setPermissionsOrgId($organization->id);
             $user->unsetRelation('roles')->unsetRelation('permissions');
             $user->syncRoles($roleNames);
+        } finally {
+            setPermissionsOrgId($previousOrganizationId);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getOrganizationRoleNames(User $user, Organization $organization): array
+    {
+        $previousOrganizationId = getPermissionsOrgId();
+
+        try {
+            setPermissionsOrgId($organization->id);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+
+            return $user->getRoleNames()->values()->all();
         } finally {
             setPermissionsOrgId($previousOrganizationId);
             $user->unsetRelation('roles')->unsetRelation('permissions');

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -49,4 +49,41 @@ class UserService
 
         return $query->get();
     }
+
+    /**
+     * Remove a user from an organization.
+     *
+     * @return bool True when the user was deleted, false when only detached.
+     */
+    public function removeFromOrganization(User $user, Organization $organization): bool
+    {
+        $organizationCount = $user->organizations()->count();
+
+        $this->removeOrganizationAccess($user, $organization);
+
+        if ($organizationCount === 1) {
+            $user->delete();
+
+            return true;
+        }
+
+        $user->organizations()->detach($organization->id);
+
+        return false;
+    }
+
+    protected function removeOrganizationAccess(User $user, Organization $organization): void
+    {
+        $previousOrganizationId = getPermissionsOrgId();
+
+        try {
+            setPermissionsOrgId($organization->id);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+            $user->syncRoles([]);
+            $user->syncPermissions([]);
+        } finally {
+            setPermissionsOrgId($previousOrganizationId);
+            $user->unsetRelation('roles')->unsetRelation('permissions');
+        }
+    }
 }

--- a/database/migrations/2026_07_13_133929_add_metadata_to_roles_table.php
+++ b/database/migrations/2026_07_13_133929_add_metadata_to_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('display_name')->nullable()->after('name');
+            $table->text('description')->nullable()->after('display_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn(['display_name', 'description']);
+        });
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -19,7 +19,7 @@ class RolesAndPermissionsSeeder extends Seeder
         // Reset cached roles and permissions
         app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
 
-        Role::query()->firstOrCreate(['name' => 'SuperAdmin']);
+        $this->role('SuperAdmin', 'Super administrator', 'Can access and manage everything across all organizations.');
 
         // create permissions
         $modules = [
@@ -58,7 +58,7 @@ class RolesAndPermissionsSeeder extends Seeder
 
         // Create roles and assign created permissions
 
-        $adminRole = Role::query()->firstOrCreate(['name' => 'Admin']);
+        $adminRole = $this->role('Admin', 'Global administrator', 'Can manage users and organizations globally.');
         $adminRole->syncPermissions([
             'admin.users.*',
             'admin.organizations.*',
@@ -78,7 +78,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.widgets.area_count_history',
         ]);
 
-        $orgAdminRole = Role::query()->firstOrCreate(['name' => 'OrganizationAdmin']);
+        $orgAdminRole = $this->role('OrganizationAdmin', 'Organization administrator', 'Has all organization level permissions over all modules.');
         $orgAdminRole->syncPermissions([
             'orgmgmt.users.*',
             'peoplecount.sensors.*',
@@ -93,7 +93,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.widgets.area_count_history',
         ]);
 
-        $peoplecountViewerRole = Role::query()->firstOrCreate(['name' => 'PeopleCountViewer']);
+        $peoplecountViewerRole = $this->role('PeopleCountViewer', 'People count viewer', 'Can view people-count dashboards and data.');
         $peoplecountViewerRole->syncPermissions([
             'peoplecount.areas.index',
             'peoplecount.areas.show',
@@ -104,5 +104,13 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.widgets.most_active_sensors',
             'peoplecount.widgets.area_count_history',
         ]);
+    }
+
+    private function role(string $name, string $displayName, string $description): Role
+    {
+        return Role::query()->updateOrCreate(
+            ['name' => $name, 'guard_name' => 'web'],
+            ['display_name' => $displayName, 'description' => $description],
+        );
     }
 }

--- a/docs/diagrams/erd.md
+++ b/docs/diagrams/erd.md
@@ -7,7 +7,7 @@ Do not edit diagram block manually. Run `composer docs:erd`.
 <!-- mermaid-erd-start -->
 ```mermaid
 ---
-title: 22 tables · 158 columns
+title: 22 tables · 160 columns
 ---
 erDiagram
     model_has_permissions["model_has_permissions (4)"] {
@@ -192,13 +192,15 @@ erDiagram
         integer permission_id PK, FK
         integer role_id PK, FK
     }
-    roles["roles (6)"] {
+    roles["roles (8)"] {
         integer id PK
         integer organization_id "nullable"
         varchar name
         varchar guard_name
         datetime created_at "nullable"
         datetime updated_at "nullable"
+        varchar display_name "nullable"
+        text description "nullable"
     }
     users["users (10)"] {
         integer id PK

--- a/resources/js/components/ConfirmActionButton.vue
+++ b/resources/js/components/ConfirmActionButton.vue
@@ -30,6 +30,8 @@ const props = withDefaults(
     }>(),
     {
         method: 'delete',
+        icon: undefined,
+        only: undefined,
         variant: 'destructive',
         preserveScroll: true,
         preserveState: false,

--- a/resources/js/components/peoplecount/_tests_/DatetimeLocalInputs.test.ts
+++ b/resources/js/components/peoplecount/_tests_/DatetimeLocalInputs.test.ts
@@ -18,7 +18,12 @@ vi.mock('@inertiajs/vue3', () => ({
 }));
 
 const InputStub = defineComponent({
-    props: ['modelValue'],
+    props: {
+        modelValue: {
+            type: [String, Number],
+            default: '',
+        },
+    },
     emits: ['update:modelValue'],
     setup(props, { attrs, emit }) {
         return () =>

--- a/resources/js/components/users/UserForm.vue
+++ b/resources/js/components/users/UserForm.vue
@@ -4,17 +4,38 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Organization, User } from '@/types';
-import { useForm } from '@inertiajs/vue3';
+import { Organization, RoleOption, SharedData, User } from '@/types';
+import { useForm, usePage } from '@inertiajs/vue3';
 import { LoaderCircle } from 'lucide-vue-next';
+import { computed } from 'vue';
 
-const props = defineProps<{ user?: User; organization?: Organization; organizations?: Organization[] }>();
+const props = defineProps<{
+    user?: User;
+    organization?: Organization;
+    organizations?: Organization[];
+    availableRoles?: RoleOption[];
+    selectedRoles?: string[];
+}>();
 
-const form = useForm({
+const page = usePage<SharedData>();
+
+const editingSelf = computed(() => props.user?.id === page.props.auth.user.id);
+const showRoleField = computed(() => props.organization && !editingSelf.value);
+
+type UserFormData = {
+    name: string;
+    email: string;
+    phone: string;
+    organization_ids: number[];
+    roles: string[];
+};
+
+const form = useForm<UserFormData>({
     name: props.user?.name || '',
     email: props.user?.email || '',
     phone: props.user?.phone || '',
     organization_ids: props.user?.organizations?.map((organization) => organization.id) || [],
+    roles: props.selectedRoles || ['PeopleCountViewer'],
 });
 
 const toggleOrganization = (organizationId: number, checked: boolean) => {
@@ -23,15 +44,28 @@ const toggleOrganization = (organizationId: number, checked: boolean) => {
         : form.organization_ids.filter((selectedOrganizationId) => selectedOrganizationId !== organizationId);
 };
 
+const toggleRole = (roleName: string, checked: boolean) => {
+    form.roles = checked ? [...form.roles, roleName] : form.roles.filter((selectedRole) => selectedRole !== roleName);
+};
+
+const withoutRoles = (data: UserFormData) => {
+    const { roles, ...dataWithoutRoles } = data;
+    void roles;
+
+    return dataWithoutRoles;
+};
+
 const submit = () => {
     if (props.user && props.organization) {
-        form.put(route('orgmgmt.users.update', { user: props.user.id, organization: props.organization.slug }));
+        form.transform((data) => (showRoleField.value ? data : withoutRoles(data))).put(
+            route('orgmgmt.users.update', { user: props.user.id, organization: props.organization.slug }),
+        );
     } else if (props.user) {
-        form.put(route('admin.users.update', { id: props.user.id }));
+        form.transform(withoutRoles).put(route('admin.users.update', { id: props.user.id }));
     } else if (props.organization) {
         form.post(route('orgmgmt.users.store', { organization: props.organization.slug }));
     } else if (!props.user && !props.organization) {
-        form.post(route('admin.users.store'));
+        form.transform(withoutRoles).post(route('admin.users.store'));
     }
 };
 </script>
@@ -72,6 +106,20 @@ const submit = () => {
                     </label>
                 </div>
                 <InputError :message="form.errors.organization_ids" />
+            </div>
+
+            <div v-if="showRoleField" class="grid gap-2">
+                <Label>Roles</Label>
+                <div class="grid gap-3 rounded-md border p-3">
+                    <label v-for="role in props.availableRoles" :key="role.name" class="flex items-start gap-3 text-sm">
+                        <Checkbox :checked="form.roles.includes(role.name)" @update:checked="(checked) => toggleRole(role.name, checked === true)" />
+                        <span class="grid gap-1 leading-none">
+                            <span class="font-medium">{{ role.display_name || role.name }}</span>
+                            <span v-if="role.description" class="text-muted-foreground leading-snug">{{ role.description }}</span>
+                        </span>
+                    </label>
+                </div>
+                <InputError :message="form.errors.roles || form.errors['roles.0']" />
             </div>
 
             <Button :disabled="form.processing" class="mt-2 w-full" tabindex="5" type="submit">

--- a/resources/js/components/users/UserForm.vue
+++ b/resources/js/components/users/UserForm.vue
@@ -1,19 +1,27 @@
 <script lang="ts" setup>
 import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Organization, User } from '@/types';
 import { useForm } from '@inertiajs/vue3';
 import { LoaderCircle } from 'lucide-vue-next';
 
-const props = defineProps<{ user?: User; organization?: Organization }>();
+const props = defineProps<{ user?: User; organization?: Organization; organizations?: Organization[] }>();
 
 const form = useForm({
     name: props.user?.name || '',
     email: props.user?.email || '',
     phone: props.user?.phone || '',
+    organization_ids: props.user?.organizations?.map((organization) => organization.id) || [],
 });
+
+const toggleOrganization = (organizationId: number, checked: boolean) => {
+    form.organization_ids = checked
+        ? [...form.organization_ids, organizationId]
+        : form.organization_ids.filter((selectedOrganizationId) => selectedOrganizationId !== organizationId);
+};
 
 const submit = () => {
     if (props.user && props.organization) {
@@ -46,6 +54,24 @@ const submit = () => {
                 <Label for="phone">Phone number</Label>
                 <Input id="phone" v-model="form.phone" :tabindex="3" autocomplete="tel" placeholder="+41 79 123 45 67" type="tel" />
                 <InputError :message="form.errors.phone" />
+            </div>
+
+            <div v-if="props.user && props.organizations" class="grid gap-3">
+                <Label>Organizations</Label>
+                <div class="grid gap-2 rounded-md border p-3">
+                    <label
+                        v-for="availableOrganization in props.organizations"
+                        :key="availableOrganization.id"
+                        class="flex items-center gap-2 text-sm"
+                    >
+                        <Checkbox
+                            :checked="form.organization_ids.includes(availableOrganization.id)"
+                            @update:checked="(checked) => toggleOrganization(availableOrganization.id, checked === true)"
+                        />
+                        <span>{{ availableOrganization.name }}</span>
+                    </label>
+                </div>
+                <InputError :message="form.errors.organization_ids" />
             </div>
 
             <Button :disabled="form.processing" class="mt-2 w-full" tabindex="5" type="submit">

--- a/resources/js/components/users/UserForm.vue
+++ b/resources/js/components/users/UserForm.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
 const page = usePage<SharedData>();
 
 const editingSelf = computed(() => props.user?.id === page.props.auth.user.id);
-const showRoleField = computed(() => props.organization && !editingSelf.value);
+const showRoleField = computed(() => Boolean(props.organization) && !editingSelf.value);
 
 type UserFormData = {
     name: string;
@@ -74,19 +74,19 @@ const submit = () => {
         <div class="grid max-w-80 gap-6">
             <div class="grid gap-2">
                 <Label for="name">Name</Label>
-                <Input id="name" v-model="form.name" :tabindex="1" autocomplete="name" autofocus placeholder="Full name" required type="text" />
+                <Input id="name" v-model="form.name" :tabindex="1" autofocus placeholder="Full name" required type="text" />
                 <InputError :message="form.errors.name" />
             </div>
 
             <div class="grid gap-2">
                 <Label for="email">Email address</Label>
-                <Input id="email" v-model="form.email" :tabindex="2" autocomplete="email" placeholder="email@example.com" required type="email" />
+                <Input id="email" v-model="form.email" :tabindex="2" placeholder="email@example.com" required type="email" />
                 <InputError :message="form.errors.email" />
             </div>
 
             <div class="grid gap-2">
                 <Label for="phone">Phone number</Label>
-                <Input id="phone" v-model="form.phone" :tabindex="3" autocomplete="tel" placeholder="+41 79 123 45 67" type="tel" />
+                <Input id="phone" v-model="form.phone" :tabindex="3" placeholder="+41 79 123 45 67" type="tel" />
                 <InputError :message="form.errors.phone" />
             </div>
 
@@ -100,7 +100,7 @@ const submit = () => {
                     >
                         <Checkbox
                             :checked="form.organization_ids.includes(availableOrganization.id)"
-                            @update:checked="(checked) => toggleOrganization(availableOrganization.id, checked === true)"
+                            @update:checked="(checked) => toggleOrganization(availableOrganization.id, checked)"
                         />
                         <span>{{ availableOrganization.name }}</span>
                     </label>
@@ -112,7 +112,7 @@ const submit = () => {
                 <Label>Roles</Label>
                 <div class="grid gap-3 rounded-md border p-3">
                     <label v-for="role in props.availableRoles" :key="role.name" class="flex items-start gap-3 text-sm">
-                        <Checkbox :checked="form.roles.includes(role.name)" @update:checked="(checked) => toggleRole(role.name, checked === true)" />
+                        <Checkbox :checked="form.roles.includes(role.name)" @update:checked="(checked) => toggleRole(role.name, checked)" />
                         <span class="grid gap-1 leading-none">
                             <span class="font-medium">{{ role.display_name || role.name }}</span>
                             <span v-if="role.description" class="text-muted-foreground leading-snug">{{ role.description }}</span>

--- a/resources/js/components/users/columns.ts
+++ b/resources/js/components/users/columns.ts
@@ -61,6 +61,21 @@ export function usersColumns(organization?: Organization): ColumnDef<User>[] {
             enableSorting: true,
             enableHiding: true,
         },
+        ...(!organization
+            ? [
+                  {
+                      accessorKey: 'organizations_count',
+                      header: ({ column }) =>
+                          h(DataTableColumnHeader, {
+                              column,
+                              title: 'Organizations',
+                          }),
+                      cell: ({ row }) => h('div', {}, row.getValue('organizations_count') ?? 0),
+                      enableSorting: true,
+                      enableHiding: true,
+                  } satisfies ColumnDef<User>,
+              ]
+            : []),
         {
             id: 'actions',
             header: 'Actions',

--- a/resources/js/components/users/columns.ts
+++ b/resources/js/components/users/columns.ts
@@ -69,8 +69,8 @@ export function usersColumns(organization?: Organization): ColumnDef<User>[] {
                 const user = row.original;
                 // Use the can function from usePermissions composable
                 const { can } = usePermissions();
-                const canEdit = can('admin.users.edit') || can('orgmgmt.users.edit');
-                const canDelete = can('admin.users.destroy') || can('orgmgmt.users.destroy');
+                const canEdit = organization ? can('orgmgmt.users.edit') : can('admin.users.edit');
+                const canDelete = organization ? can('orgmgmt.users.destroy') : can('admin.users.destroy');
 
                 return h(
                     'div',
@@ -108,8 +108,10 @@ export function usersColumns(organization?: Organization): ColumnDef<User>[] {
                                     : route('admin.users.destroy', { user: user.id }),
                                 label: 'Delete',
                                 title: `Delete user ${user.name}?`,
-                                description: 'This user will be permanently deleted. This cannot be undone.',
-                                confirmLabel: 'Delete user',
+                                description: organization
+                                    ? 'This user will be removed from the organization. If this is their only organization, their account will be deleted.'
+                                    : 'This user will be permanently deleted. This cannot be undone.',
+                                confirmLabel: organization ? 'Remove user' : 'Delete user',
                                 icon: Trash2,
                             }),
                     ].filter(Boolean),

--- a/resources/js/layouts/orgmgmt/Layout.vue
+++ b/resources/js/layouts/orgmgmt/Layout.vue
@@ -9,7 +9,9 @@ interface Props {
     breadcrumbs?: BreadcrumbItemType[];
 }
 
-const { breadcrumbs } = defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+    breadcrumbs: () => [],
+});
 
 // Get organization from the page props
 const page = usePage();

--- a/resources/js/pages/admin/EditUser.vue
+++ b/resources/js/pages/admin/EditUser.vue
@@ -2,10 +2,10 @@
 import Heading from '@/components/Heading.vue';
 import UserForm from '@/components/users/UserForm.vue';
 import Layout from '@/layouts/admin/Layout.vue';
-import { BreadcrumbItem, User } from '@/types';
+import { BreadcrumbItem, Organization, User } from '@/types';
 import { Head } from '@inertiajs/vue3';
 
-const props = defineProps<{ user: User }>();
+const props = defineProps<{ user: User; organizations: Organization[] }>();
 
 const breadcrumbItems: BreadcrumbItem[] = [
     {
@@ -25,7 +25,7 @@ const breadcrumbItems: BreadcrumbItem[] = [
 
         <div class="px-4 py-6">
             <Heading description="Edit user details" title="Edit User" />
-            <UserForm :user="props.user" />
+            <UserForm :organizations="props.organizations" :user="props.user" />
         </div>
     </Layout>
 </template>

--- a/resources/js/pages/orgmgmt/EditUser.vue
+++ b/resources/js/pages/orgmgmt/EditUser.vue
@@ -2,12 +2,14 @@
 import Heading from '@/components/Heading.vue';
 import UserForm from '@/components/users/UserForm.vue';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
-import { BreadcrumbItem, Organization, User } from '@/types';
+import { BreadcrumbItem, Organization, RoleOption, User } from '@/types';
 import { Head } from '@inertiajs/vue3';
 
 const props = defineProps<{
     user: User;
     organization: Organization;
+    availableRoles: RoleOption[];
+    selectedRoles: string[];
 }>();
 
 const breadcrumbItems: BreadcrumbItem[] = [
@@ -32,7 +34,12 @@ const breadcrumbItems: BreadcrumbItem[] = [
 
         <div class="px-4 py-6">
             <Heading description="Edit user details" title="Edit User" />
-            <UserForm :organization="props.organization" :user="props.user" />
+            <UserForm
+                :available-roles="props.availableRoles"
+                :organization="props.organization"
+                :selected-roles="props.selectedRoles"
+                :user="props.user"
+            />
         </div>
     </Layout>
 </template>

--- a/resources/js/pages/orgmgmt/NewUser.vue
+++ b/resources/js/pages/orgmgmt/NewUser.vue
@@ -2,11 +2,13 @@
 import Heading from '@/components/Heading.vue';
 import UserForm from '@/components/users/UserForm.vue';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
-import { BreadcrumbItem, Organization } from '@/types';
+import { BreadcrumbItem, Organization, RoleOption } from '@/types';
 import { Head } from '@inertiajs/vue3';
 
 const props = defineProps<{
     organization: Organization;
+    availableRoles: RoleOption[];
+    selectedRoles: string[];
 }>();
 
 const breadcrumbItems: BreadcrumbItem[] = [
@@ -31,7 +33,7 @@ const breadcrumbItems: BreadcrumbItem[] = [
 
         <div class="px-4 py-6">
             <Heading description="Create a new user" title="Create User" />
-            <UserForm :organization="props.organization" />
+            <UserForm :available-roles="props.availableRoles" :organization="props.organization" :selected-roles="props.selectedRoles" />
         </div>
     </Layout>
 </template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -52,6 +52,12 @@ export interface User {
     area_single_resets?: PeoplecountAreaSingleReset[]; // Optional, for related area single resets created by this user
 }
 
+export interface RoleOption {
+    name: string;
+    display_name: string | null;
+    description: string | null;
+}
+
 export type BreadcrumbItemType = BreadcrumbItem;
 
 export interface Organization {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -47,6 +47,8 @@ export interface User {
     email_verified_at: string | null;
     created_at: string;
     updated_at: string;
+    organizations?: Organization[];
+    organizations_count?: number;
     area_single_resets?: PeoplecountAreaSingleReset[]; // Optional, for related area single resets created by this user
 }
 

--- a/tests/Feature/Admin/UserControllerTest.php
+++ b/tests/Feature/Admin/UserControllerTest.php
@@ -224,6 +224,20 @@ it('updates a user with phone', function () {
     ]);
 });
 
+it('rejects duplicate formatted phone when updating a user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    User::factory()->create(['phone' => '+41790000000']);
+    $user = User::factory()->create();
+
+    $this->actingAs($admin)
+        ->put(route('admin.users.update', $user), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'phone' => '+41 79 000 00 00',
+        ])
+        ->assertSessionHasErrors('phone');
+});
+
 it('syncs organizations when updating a user', function () {
     $admin = User::factory()->globalAdmin()->create();
     $oldOrganization = Organization::factory()->create();

--- a/tests/Feature/Admin/UserControllerTest.php
+++ b/tests/Feature/Admin/UserControllerTest.php
@@ -31,6 +31,20 @@ it('shows the user index page with all users', function () {
         );
 });
 
+it('shows organization counts on the user index page', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $organizations = Organization::factory()->count(2)->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach($organizations->pluck('id'));
+
+    $this->actingAs($admin)
+        ->get(route('admin.users.index'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page->component('admin/Users')
+            ->where('users.0.organizations_count', 0)
+            ->where('users.1.organizations_count', 2)
+        );
+});
+
 it('doesnt show the user index page to non-admin users', function () {
     $user = User::factory()->create();
 
@@ -145,6 +159,20 @@ it('shows the edit user page', function () {
         );
 });
 
+it('passes organizations to the edit user page', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $organization = Organization::factory()->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach($organization->id);
+
+    $this->actingAs($admin)
+        ->get(route('admin.users.edit', $user))
+        ->assertInertia(fn (AssertableInertia $page): AssertableJson => $page->component('admin/EditUser')
+            ->where('organizations.0.id', $organization->id)
+            ->where('user.organizations.0.id', $organization->id)
+        );
+});
+
 it('updates a user successfully', function () {
     $admin = User::factory()->globalAdmin()->create();
     $user = User::factory()->create();
@@ -194,6 +222,42 @@ it('updates a user with phone', function () {
         'email' => 'updated2@example.com',
         'phone' => '+41791234567',
     ]);
+});
+
+it('syncs organizations when updating a user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $oldOrganization = Organization::factory()->create();
+    $newOrganization = Organization::factory()->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach($oldOrganization->id);
+
+    $this->actingAs($admin)->put(route('admin.users.update', $user), [
+        'name' => $user->name,
+        'email' => $user->email,
+        'organization_ids' => [$newOrganization->id],
+    ]);
+
+    $this->assertDatabaseMissing('organization_user', [
+        'organization_id' => $oldOrganization->id,
+        'user_id' => $user->id,
+    ]);
+    $this->assertDatabaseHas('organization_user', [
+        'organization_id' => $newOrganization->id,
+        'user_id' => $user->id,
+    ]);
+});
+
+it('rejects unknown organizations when updating a user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $user = User::factory()->create();
+
+    $this->actingAs($admin)
+        ->put(route('admin.users.update', $user), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'organization_ids' => [999999],
+        ])
+        ->assertSessionHasErrors('organization_ids.0');
 });
 
 it('fails to update without name', function () {

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -3,6 +3,8 @@
 use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 uses(RefreshDatabase::class);
 
@@ -107,6 +109,71 @@ it('can delete a user for an organization', function () {
         ->delete(route('orgmgmt.users.destroy', ['organization' => $org->slug, 'user' => $user->id]));
     $response->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
     $this->assertDatabaseMissing('users', ['id' => $user->id, 'email' => 'delete-me@example.com']);
+});
+
+it('detaches an organization user who belongs to another organization', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach([$org->id, $otherOrg->id]);
+
+    $response = $this->actingAs($admin)
+        ->delete(route('orgmgmt.users.destroy', ['organization' => $org->slug, 'user' => $user->id]));
+
+    $response->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+    $this->assertDatabaseHas('users', ['id' => $user->id]);
+    $this->assertDatabaseMissing('organization_user', ['organization_id' => $org->id, 'user_id' => $user->id]);
+    $this->assertDatabaseHas('organization_user', ['organization_id' => $otherOrg->id, 'user_id' => $user->id]);
+});
+
+it('removes only current organization access when detaching an organization user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach([$org->id, $otherOrg->id]);
+    $viewerRole = Role::findByName('PeopleCountViewer');
+    $adminRole = Role::findByName('OrganizationAdmin');
+    $sensorPermission = Permission::findOrCreate('peoplecount.sensors.index');
+    $eventPermission = Permission::findOrCreate('peoplecount.events.index');
+
+    setPermissionsOrgId($org->id);
+    $user->assignRole($viewerRole);
+    $user->givePermissionTo($sensorPermission);
+
+    setPermissionsOrgId($otherOrg->id);
+    $user->assignRole($adminRole);
+    $user->givePermissionTo($eventPermission);
+
+    $this->actingAs($admin)
+        ->delete(route('orgmgmt.users.destroy', ['organization' => $org->slug, 'user' => $user->id]))
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $this->assertDatabaseMissing('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $viewerRole->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+    $this->assertDatabaseMissing('model_has_permissions', [
+        'organization_id' => $org->id,
+        'permission_id' => $sensorPermission->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $otherOrg->id,
+        'role_id' => $adminRole->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+    $this->assertDatabaseHas('model_has_permissions', [
+        'organization_id' => $otherOrg->id,
+        'permission_id' => $eventPermission->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
 });
 
 it('forbids non-admins from accessing orgmgmt users index', function () {

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -38,10 +38,10 @@ it('shows the create user form for an organization', function () {
             ->where('organization.id', $org->id)
             ->where('availableRoles.0.name', 'PeopleCountViewer')
             ->where('availableRoles.0.display_name', 'People count viewer')
-            ->where('availableRoles.0.description', 'Can view people-count dashboards and data for this organization.')
+            ->where('availableRoles.0.description', 'Can view people-count dashboards and data.')
             ->where('availableRoles.1.name', 'OrganizationAdmin')
             ->where('availableRoles.1.display_name', 'Organization administrator')
-            ->where('availableRoles.1.description', 'Can manage users and people-count setup for this organization.')
+            ->where('availableRoles.1.description', 'Has all organization level permissions over all modules.')
             ->where('selectedRoles', ['PeopleCountViewer'])
         );
 });

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -395,6 +395,22 @@ it('can update a user for an organization', function () {
     $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => $newName, 'phone' => '+41790000000']);
 });
 
+it('rejects duplicate formatted phone when updating an organization user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    User::factory()->create(['phone' => '+41790000000']);
+    $user = User::factory()->create();
+    $org->users()->attach($user->id);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $user->id]), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'phone' => '+41 79 000 00 00',
+        ])
+        ->assertSessionHasErrors('phone');
+});
+
 it('can delete a user for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -57,7 +57,7 @@ it('shows the edit user form for an organization user', function () {
 it('redirects show to edit for an organization user', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
-    $user = User::factory()->create();
+    $user = User::factory()->create(['phone' => '+41790000000']);
     $org->users()->attach($user->id);
 
     $response = $this->actingAs($admin)
@@ -162,6 +162,197 @@ it('assigns the default viewer role when attaching an existing user', function (
     ]);
 });
 
+it('assigns multiple roles when creating an organization user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $viewerRole = Role::findByName('PeopleCountViewer');
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => 'Role User',
+            'email' => 'role-user@example.com',
+            'roles' => ['PeopleCountViewer', 'OrganizationAdmin'],
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $user = User::query()->where('email', 'role-user@example.com')->firstOrFail();
+
+    foreach ([$viewerRole, $adminRole] as $role) {
+        $this->assertDatabaseHas('model_has_roles', [
+            'organization_id' => $org->id,
+            'role_id' => $role->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+    }
+
+    $this->assertDatabaseMissing('model_has_permissions', [
+        'organization_id' => $org->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('rejects global roles when creating an organization user', function (string $role): void {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => 'Global Role User',
+            'email' => 'global-role-user@example.com',
+            'roles' => [$role],
+        ])
+        ->assertSessionHasErrors('roles.0');
+})->with(['SuperAdmin', 'Admin']);
+
+it('prevents organization admins from changing their own roles when creating by their email', function () {
+    $org = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => $admin->name,
+            'email' => $admin->email,
+            'roles' => ['PeopleCountViewer'],
+        ])
+        ->assertSessionHasErrors('roles');
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $adminRole->id,
+        'model_id' => $admin->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('syncs multiple roles when updating an organization user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $user = User::factory()->create();
+    $org->users()->attach($user->id);
+    $viewerRole = Role::findByName('PeopleCountViewer');
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    setPermissionsOrgId($org->id);
+    $user->assignRole($viewerRole);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $user->id]), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'roles' => ['PeopleCountViewer', 'OrganizationAdmin'],
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    foreach ([$viewerRole, $adminRole] as $role) {
+        $this->assertDatabaseHas('model_has_roles', [
+            'organization_id' => $org->id,
+            'role_id' => $role->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+    }
+});
+
+it('rejects global roles when updating an organization user', function (string $role): void {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $user = User::factory()->create();
+    $org->users()->attach($user->id);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $user->id]), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'roles' => [$role],
+        ])
+        ->assertSessionHasErrors('roles.0');
+})->with(['SuperAdmin', 'Admin']);
+
+it('allows organization admins to assign organization admin to another user', function () {
+    $org = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $user = User::factory()->create();
+    $org->users()->attach($user->id);
+    $viewerRole = Role::findByName('PeopleCountViewer');
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    setPermissionsOrgId($org->id);
+    $user->assignRole($viewerRole);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $user->id]), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'roles' => ['PeopleCountViewer', 'OrganizationAdmin'],
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $adminRole->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('allows organization admins to remove organization admin from another user', function () {
+    $org = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $user = User::factory()->create();
+    $org->users()->attach($user->id);
+    $viewerRole = Role::findByName('PeopleCountViewer');
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    setPermissionsOrgId($org->id);
+    $user->assignRole([$viewerRole, $adminRole]);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $user->id]), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'roles' => ['PeopleCountViewer'],
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $viewerRole->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+    $this->assertDatabaseMissing('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $adminRole->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('prevents organization admins from changing their own roles', function () {
+    $org = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $adminRole = Role::findByName('OrganizationAdmin');
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $admin->id]), [
+            'name' => $admin->name,
+            'email' => $admin->email,
+            'roles' => ['PeopleCountViewer'],
+        ])
+        ->assertSessionHasErrors('roles');
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $adminRole->id,
+        'model_id' => $admin->id,
+        'model_type' => User::class,
+    ]);
+});
+
 it('rejects a new organization user with another users phone number', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -179,7 +370,7 @@ it('rejects a new organization user with another users phone number', function (
 it('can update a user for an organization', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
-    $user = User::factory()->create();
+    $user = User::factory()->create(['phone' => '+41790000000']);
     $org->users()->attach($user->id);
     $newName = 'Updated Name';
 
@@ -189,7 +380,7 @@ it('can update a user for an organization', function () {
             'email' => $user->email,
         ]);
     $response->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
-    $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => $newName]);
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => $newName, 'phone' => '+41790000000']);
 });
 
 it('can delete a user for an organization', function () {

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -125,3 +125,58 @@ it('forbids deleting your own user via orgmgmt', function () {
         ->delete(route('orgmgmt.users.destroy', ['organization' => $org->slug, 'user' => $user->id]));
     $response->assertForbidden();
 });
+
+it('does not expose users from other organizations through orgmgmt show', function () {
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $outsider = User::factory()->create();
+    $otherOrg->users()->attach($outsider->id);
+
+    $this->actingAs($admin)
+        ->get(route('orgmgmt.users.show', ['organization' => $org->slug, 'user' => $outsider->id]))
+        ->assertNotFound();
+});
+
+it('does not expose users from other organizations through orgmgmt edit', function () {
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $outsider = User::factory()->create();
+    $otherOrg->users()->attach($outsider->id);
+
+    $this->actingAs($admin)
+        ->get(route('orgmgmt.users.edit', ['organization' => $org->slug, 'user' => $outsider->id]))
+        ->assertNotFound();
+});
+
+it('does not update users from other organizations through orgmgmt', function () {
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $outsider = User::factory()->create(['name' => 'Original Name']);
+    $otherOrg->users()->attach($outsider->id);
+
+    $this->actingAs($admin)
+        ->put(route('orgmgmt.users.update', ['organization' => $org->slug, 'user' => $outsider->id]), [
+            'name' => 'Changed Name',
+            'email' => $outsider->email,
+        ])
+        ->assertNotFound();
+
+    $this->assertDatabaseHas('users', ['id' => $outsider->id, 'name' => 'Original Name']);
+});
+
+it('does not delete users from other organizations through orgmgmt', function () {
+    $org = Organization::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($org)->create();
+    $outsider = User::factory()->create();
+    $otherOrg->users()->attach($outsider->id);
+
+    $this->actingAs($admin)
+        ->delete(route('orgmgmt.users.destroy', ['organization' => $org->slug, 'user' => $outsider->id]))
+        ->assertNotFound();
+
+    $this->assertDatabaseHas('users', ['id' => $outsider->id]);
+});

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -81,6 +81,99 @@ it('can create a user for an organization', function () {
         ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), $userData);
     $response->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
     $this->assertDatabaseHas('users', ['email' => $userData['email']]);
+    $this->assertDatabaseHas('organization_user', ['organization_id' => $org->id, 'user_id' => User::query()->where('email', $userData['email'])->firstOrFail()->id]);
+});
+
+it('attaches an existing user when creating by email for an organization without updating them', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $existingUser = User::factory()->create([
+        'name' => 'Existing Name',
+        'email' => 'existing@example.com',
+        'phone' => '+41790000000',
+    ]);
+
+    $response = $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => 'Updated Existing',
+            'email' => 'existing@example.com',
+            'phone' => '+41 79 111 11 11',
+        ]);
+
+    $response->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+    expect(User::query()->where('email', 'existing@example.com')->count())->toBe(1);
+    $this->assertDatabaseHas('users', [
+        'id' => $existingUser->id,
+        'name' => 'Existing Name',
+        'phone' => '+41790000000',
+    ]);
+    $this->assertDatabaseHas('organization_user', ['organization_id' => $org->id, 'user_id' => $existingUser->id]);
+});
+
+it('attaches an unverified existing user when creating by email for an organization', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $existingUser = User::factory()->unverified()->create(['email' => 'unverified@example.com']);
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => $existingUser->name,
+            'email' => $existingUser->email,
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $this->assertDatabaseHas('organization_user', ['organization_id' => $org->id, 'user_id' => $existingUser->id]);
+});
+
+it('idempotently attaches an existing organization user when creating by email', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $existingUser = User::factory()->create(['email' => 'member@example.com']);
+    $existingUser->organizations()->attach($org->id);
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => $existingUser->name,
+            'email' => $existingUser->email,
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    expect($existingUser->organizations()->whereKey($org->id)->count())->toBe(1);
+});
+
+it('assigns the default viewer role when attaching an existing user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $existingUser = User::factory()->create(['email' => 'viewer@example.com']);
+    $viewerRole = Role::findByName('PeopleCountViewer');
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => $existingUser->name,
+            'email' => $existingUser->email,
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $viewerRole->id,
+        'model_id' => $existingUser->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('rejects a new organization user with another users phone number', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    User::factory()->create(['phone' => '+41790000000']);
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => 'Duplicate Phone',
+            'email' => 'new@example.com',
+            'phone' => '+41 79 000 00 00',
+        ])
+        ->assertSessionHasErrors('phone');
 });
 
 it('can update a user for an organization', function () {

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -36,6 +36,13 @@ it('shows the create user form for an organization', function () {
         ->assertInertia(fn ($page) => $page
             ->component('orgmgmt/NewUser')
             ->where('organization.id', $org->id)
+            ->where('availableRoles.0.name', 'PeopleCountViewer')
+            ->where('availableRoles.0.display_name', 'People count viewer')
+            ->where('availableRoles.0.description', 'Can view people-count dashboards and data for this organization.')
+            ->where('availableRoles.1.name', 'OrganizationAdmin')
+            ->where('availableRoles.1.display_name', 'Organization administrator')
+            ->where('availableRoles.1.description', 'Can manage users and people-count setup for this organization.')
+            ->where('selectedRoles', ['PeopleCountViewer'])
         );
 });
 
@@ -44,6 +51,8 @@ it('shows the edit user form for an organization user', function () {
     $org = Organization::factory()->create();
     $user = User::factory()->create();
     $org->users()->attach($user->id);
+    setPermissionsOrgId($org->id);
+    $user->assignRole('OrganizationAdmin');
 
     $this->actingAs($admin)
         ->get(route('orgmgmt.users.edit', ['organization' => $org->slug, 'user' => $user->id]))
@@ -51,6 +60,9 @@ it('shows the edit user form for an organization user', function () {
             ->component('orgmgmt/EditUser')
             ->where('organization.id', $org->id)
             ->where('user.id', $user->id)
+            ->where('availableRoles.0.name', 'PeopleCountViewer')
+            ->where('availableRoles.1.name', 'OrganizationAdmin')
+            ->where('selectedRoles', ['OrganizationAdmin'])
         );
 });
 

--- a/tests/Integration/Seeders/RolesAndPermissionsSeederTest.php
+++ b/tests/Integration/Seeders/RolesAndPermissionsSeederTest.php
@@ -11,7 +11,7 @@ it('seeds and updates role metadata', function () {
     $this->assertDatabaseHas('roles', [
         'name' => 'PeopleCountViewer',
         'display_name' => 'People count viewer',
-        'description' => 'Can view people-count dashboards and data for this organization.',
+        'description' => 'Can view people-count dashboards and data.',
     ]);
 
     Role::query()
@@ -26,6 +26,6 @@ it('seeds and updates role metadata', function () {
     $this->assertDatabaseHas('roles', [
         'name' => 'PeopleCountViewer',
         'display_name' => 'People count viewer',
-        'description' => 'Can view people-count dashboards and data for this organization.',
+        'description' => 'Can view people-count dashboards and data.',
     ]);
 });

--- a/tests/Integration/Seeders/RolesAndPermissionsSeederTest.php
+++ b/tests/Integration/Seeders/RolesAndPermissionsSeederTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+it('seeds and updates role metadata', function () {
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+    $this->assertDatabaseHas('roles', [
+        'name' => 'PeopleCountViewer',
+        'display_name' => 'People count viewer',
+        'description' => 'Can view people-count dashboards and data for this organization.',
+    ]);
+
+    Role::query()
+        ->where('name', 'PeopleCountViewer')
+        ->update([
+            'display_name' => 'Old title',
+            'description' => 'Old description',
+        ]);
+
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+    $this->assertDatabaseHas('roles', [
+        'name' => 'PeopleCountViewer',
+        'display_name' => 'People count viewer',
+        'description' => 'Can view people-count dashboards and data for this organization.',
+    ]);
+});

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -26,14 +26,14 @@ describe('availableOrganizationRoles', function () {
             'name' => 'PeopleCountViewer',
             'guard_name' => 'web',
             'display_name' => 'People count viewer',
-            'description' => 'Can view people-count dashboards and data for this organization.',
+            'description' => 'Can view people-count dashboards and data.',
         ]);
 
         expect($this->service->availableOrganizationRoles())->toBe([
             [
                 'name' => 'PeopleCountViewer',
                 'display_name' => 'People count viewer',
-                'description' => 'Can view people-count dashboards and data for this organization.',
+                'description' => 'Can view people-count dashboards and data.',
             ],
         ]);
     });

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -5,6 +5,8 @@ use App\Models\User;
 use App\Services\UserService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 uses(RefreshDatabase::class);
 
@@ -218,4 +220,79 @@ it('ignores permissions org context when explicit organization is provided', fun
     expect($result->pluck('id')->toArray())->toContain($userInA->id)
         ->and($result->pluck('id')->toArray())->not->toContain($userInB->id)
         ->and($result->count())->toBe(1);
+});
+
+describe('removeFromOrganization', function () {
+    it('deletes a user who only belongs to the organization', function () {
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create();
+        $user->organizations()->attach($organization->id);
+
+        $deleted = $this->service->removeFromOrganization($user, $organization);
+
+        expect($deleted)->toBeTrue();
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    });
+
+    it('detaches a user who belongs to other organizations', function () {
+        $organization = Organization::factory()->create();
+        $otherOrganization = Organization::factory()->create();
+        $user = User::factory()->create();
+        $user->organizations()->attach([$organization->id, $otherOrganization->id]);
+
+        $deleted = $this->service->removeFromOrganization($user, $organization);
+
+        expect($deleted)->toBeFalse();
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('organization_user', ['organization_id' => $organization->id, 'user_id' => $user->id]);
+        $this->assertDatabaseHas('organization_user', ['organization_id' => $otherOrganization->id, 'user_id' => $user->id]);
+    });
+
+    it('removes only the current organization roles and direct permissions when detaching', function () {
+        $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+        $organization = Organization::factory()->create();
+        $otherOrganization = Organization::factory()->create();
+        $user = User::factory()->create();
+        $user->organizations()->attach([$organization->id, $otherOrganization->id]);
+        $viewerRole = Role::findByName('PeopleCountViewer');
+        $adminRole = Role::findByName('OrganizationAdmin');
+        $sensorPermission = Permission::findOrCreate('peoplecount.sensors.index');
+        $eventPermission = Permission::findOrCreate('peoplecount.events.index');
+
+        setPermissionsOrgId($organization->id);
+        $user->assignRole($viewerRole);
+        $user->givePermissionTo($sensorPermission);
+
+        setPermissionsOrgId($otherOrganization->id);
+        $user->assignRole($adminRole);
+        $user->givePermissionTo($eventPermission);
+
+        $this->service->removeFromOrganization($user, $organization);
+
+        $this->assertDatabaseMissing('model_has_roles', [
+            'organization_id' => $organization->id,
+            'role_id' => $viewerRole->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+        $this->assertDatabaseMissing('model_has_permissions', [
+            'organization_id' => $organization->id,
+            'permission_id' => $sensorPermission->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+        $this->assertDatabaseHas('model_has_roles', [
+            'organization_id' => $otherOrganization->id,
+            'role_id' => $adminRole->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+        $this->assertDatabaseHas('model_has_permissions', [
+            'organization_id' => $otherOrganization->id,
+            'permission_id' => $eventPermission->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+    });
 });

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -358,6 +358,29 @@ describe('createOrAttachToOrganization', function () {
         $this->assertDatabaseHas('organization_user', ['organization_id' => $organization->id, 'user_id' => $user->id]);
     });
 
+    it('syncs roles when creating or attaching a user', function () {
+        $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+        $organization = Organization::factory()->create();
+        $viewerRole = Role::findByName('PeopleCountViewer');
+        $adminRole = Role::findByName('OrganizationAdmin');
+
+        $user = $this->service->createOrAttachToOrganization($organization, [
+            'name' => 'Role User',
+            'email' => 'role-user@example.com',
+            'phone' => null,
+        ], ['PeopleCountViewer', 'OrganizationAdmin']);
+
+        foreach ([$viewerRole, $adminRole] as $role) {
+            $this->assertDatabaseHas('model_has_roles', [
+                'organization_id' => $organization->id,
+                'role_id' => $role->id,
+                'model_id' => $user->id,
+                'model_type' => User::class,
+            ]);
+        }
+    });
+
     it('attaches an existing user by email without updating them', function () {
         $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
 

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -20,6 +20,25 @@ beforeEach(function () {
     $this->service = new UserService;
 });
 
+describe('availableOrganizationRoles', function () {
+    it('skips missing organization roles', function () {
+        Role::query()->create([
+            'name' => 'PeopleCountViewer',
+            'guard_name' => 'web',
+            'display_name' => 'People count viewer',
+            'description' => 'Can view people-count dashboards and data for this organization.',
+        ]);
+
+        expect($this->service->availableOrganizationRoles())->toBe([
+            [
+                'name' => 'PeopleCountViewer',
+                'display_name' => 'People count viewer',
+                'description' => 'Can view people-count dashboards and data for this organization.',
+            ],
+        ]);
+    });
+});
+
 describe('getUsers', function () {
     it('returns users', function () {
         setPermissionsOrgId(GLOBAL_ORG_ID);

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -296,3 +296,48 @@ describe('removeFromOrganization', function () {
         ]);
     });
 });
+
+describe('syncOrganizations', function () {
+    it('syncs user organizations without deleting the user', function () {
+        $oldOrganization = Organization::factory()->create();
+        $newOrganization = Organization::factory()->create();
+        $user = User::factory()->create();
+        $user->organizations()->attach($oldOrganization->id);
+
+        $this->service->syncOrganizations($user, [$newOrganization->id]);
+
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('organization_user', ['organization_id' => $oldOrganization->id, 'user_id' => $user->id]);
+        $this->assertDatabaseHas('organization_user', ['organization_id' => $newOrganization->id, 'user_id' => $user->id]);
+    });
+
+    it('removes access for detached organizations', function () {
+        $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+        $oldOrganization = Organization::factory()->create();
+        $newOrganization = Organization::factory()->create();
+        $user = User::factory()->create();
+        $user->organizations()->attach($oldOrganization->id);
+        $role = Role::findByName('PeopleCountViewer');
+        $permission = Permission::findOrCreate('peoplecount.sensors.index');
+
+        setPermissionsOrgId($oldOrganization->id);
+        $user->assignRole($role);
+        $user->givePermissionTo($permission);
+
+        $this->service->syncOrganizations($user, [$newOrganization->id]);
+
+        $this->assertDatabaseMissing('model_has_roles', [
+            'organization_id' => $oldOrganization->id,
+            'role_id' => $role->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+        $this->assertDatabaseMissing('model_has_permissions', [
+            'organization_id' => $oldOrganization->id,
+            'permission_id' => $permission->id,
+            'model_id' => $user->id,
+            'model_type' => User::class,
+        ]);
+    });
+});

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -341,3 +341,41 @@ describe('syncOrganizations', function () {
         ]);
     });
 });
+
+describe('createOrAttachToOrganization', function () {
+    it('creates a new user and attaches them to the organization', function () {
+        $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+        $organization = Organization::factory()->create();
+
+        $user = $this->service->createOrAttachToOrganization($organization, [
+            'name' => 'New User',
+            'email' => 'new-user@example.com',
+            'phone' => null,
+        ]);
+
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => 'new-user@example.com']);
+        $this->assertDatabaseHas('organization_user', ['organization_id' => $organization->id, 'user_id' => $user->id]);
+    });
+
+    it('attaches an existing user by email without updating them', function () {
+        $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create([
+            'name' => 'Existing User',
+            'email' => 'existing-user@example.com',
+            'phone' => '+41790000000',
+        ]);
+
+        $result = $this->service->createOrAttachToOrganization($organization, [
+            'name' => 'Updated User',
+            'email' => 'existing-user@example.com',
+            'phone' => '+41 79 222 22 22',
+        ]);
+
+        expect($result->is($user))->toBeTrue();
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'name' => 'Existing User', 'phone' => '+41790000000']);
+        $this->assertDatabaseHas('organization_user', ['organization_id' => $organization->id, 'user_id' => $user->id]);
+    });
+});

--- a/tests/Unit/Requests/Admin/UserUpdateRequestTest.php
+++ b/tests/Unit/Requests/Admin/UserUpdateRequestTest.php
@@ -46,6 +46,8 @@ it('has correct rules with user ID', function () {
         'name' => ['required', 'string', 'max:255'],
         'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,123'],
         'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,123'],
+        'organization_ids' => ['sometimes', 'array'],
+        'organization_ids.*' => ['integer', 'exists:organizations,id'],
     ]);
 });
 
@@ -66,5 +68,7 @@ it('has correct rules with null user', function () {
         'name' => ['required', 'string', 'max:255'],
         'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'],
         'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'],
+        'organization_ids' => ['sometimes', 'array'],
+        'organization_ids.*' => ['integer', 'exists:organizations,id'],
     ]);
 });

--- a/tests/Unit/Requests/Orgmgmt/UserStoreRequestTest.php
+++ b/tests/Unit/Requests/Orgmgmt/UserStoreRequestTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Http\Requests\Orgmgmt\UserStoreRequest;
-use App\Models\User;
 
 covers(UserStoreRequest::class);
 
@@ -10,11 +9,25 @@ beforeEach(function () {
 });
 
 it('has correct rules', function () {
-    expect($this->request->rules())->toBe([
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-        'phone' => ['nullable', 'string', 'max:20', 'unique:users'],
-    ]);
+    $rules = $this->request->rules();
+
+    expect($rules['name'])->toBe(['required', 'string', 'max:255'])
+        ->and($rules['email'])->toBe(['required', 'string', 'email', 'max:255'])
+        ->and($rules['phone'][0])->toBe('nullable')
+        ->and($rules['phone'][1])->toBe('string')
+        ->and($rules['phone'][2])->toBe('max:20')
+        ->and($rules['phone'][3])->toBeInstanceOf(Closure::class);
+});
+
+it('skips phone uniqueness validation when the phone is blank', function () {
+    $rules = $this->request->rules();
+    $messages = [];
+
+    $rules['phone'][3]('phone', '', function (string $message) use (&$messages): void {
+        $messages[] = $message;
+    });
+
+    expect($messages)->toBe([]);
 });
 
 it('authorizes when user can store users', function () {

--- a/tests/Unit/Requests/Orgmgmt/UserStoreRequestTest.php
+++ b/tests/Unit/Requests/Orgmgmt/UserStoreRequestTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Requests\Orgmgmt\UserStoreRequest;
+use App\Models\User;
 
 covers(UserStoreRequest::class);
 
@@ -16,7 +17,14 @@ it('has correct rules', function () {
         ->and($rules['phone'][0])->toBe('nullable')
         ->and($rules['phone'][1])->toBe('string')
         ->and($rules['phone'][2])->toBe('max:20')
-        ->and($rules['phone'][3])->toBeInstanceOf(Closure::class);
+        ->and($rules['phone'][3])->toBeInstanceOf(Closure::class)
+        ->and($rules['roles'][0])->toBe('sometimes')
+        ->and($rules['roles'][1])->toBe('array')
+        ->and($rules['roles'][2])->toBe('list')
+        ->and($rules['roles'][3])->toBe('min:1')
+        ->and($rules['roles'][4])->toBeInstanceOf(Closure::class)
+        ->and($rules['roles.*'][0])->toBe('string')
+        ->and($rules['roles.*'][1])->toBe('distinct');
 });
 
 it('skips phone uniqueness validation when the phone is blank', function () {

--- a/tests/Unit/Requests/Orgmgmt/UserUpdateRequestTest.php
+++ b/tests/Unit/Requests/Orgmgmt/UserUpdateRequestTest.php
@@ -43,11 +43,18 @@ it('has correct rules with user ID', function () {
         };
     });
 
-    expect($request->rules())->toBe([
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,123'],
-        'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,123'],
-    ]);
+    $rules = $request->rules();
+
+    expect($rules['name'])->toBe(['required', 'string', 'max:255'])
+        ->and($rules['email'])->toBe(['required', 'string', 'email', 'max:255', 'unique:users,email,123'])
+        ->and($rules['phone'])->toBe(['nullable', 'string', 'max:20', 'unique:users,phone,123'])
+        ->and($rules['roles'][0])->toBe('sometimes')
+        ->and($rules['roles'][1])->toBe('array')
+        ->and($rules['roles'][2])->toBe('list')
+        ->and($rules['roles'][3])->toBe('min:1')
+        ->and($rules['roles'][4])->toBeInstanceOf(Closure::class)
+        ->and($rules['roles.*'][0])->toBe('string')
+        ->and($rules['roles.*'][1])->toBe('distinct');
 });
 
 it('has correct rules with null user', function () {
@@ -63,9 +70,10 @@ it('has correct rules with null user', function () {
         };
     });
 
-    expect($request->rules())->toBe([
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'],
-        'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'],
-    ]);
+    $rules = $request->rules();
+
+    expect($rules['name'])->toBe(['required', 'string', 'max:255'])
+        ->and($rules['email'])->toBe(['required', 'string', 'email', 'max:255', 'unique:users,email,'])
+        ->and($rules['phone'])->toBe(['nullable', 'string', 'max:20', 'unique:users,phone,'])
+        ->and($rules['roles'][4])->toBeInstanceOf(Closure::class);
 });


### PR DESCRIPTION
Improves user management across global admin and organization admin flows: organization users can be safely attached by email, detached without losing cross-org access, and assigned organization roles from a readable checkbox UI. This also adds role metadata seeding so role labels/descriptions stay rollout-managed.

## User-facing improvements

- Global admins: before organization access was hard to see/change; now user edit shows and syncs memberships directly.
- Global admins: before duplicate formatted phone numbers could fail late; now updates validate them before save.
- Organization admins: before adding an existing person by email was brittle; now it safely attaches them to the organization.
- Organization admins: before removing a shared user could drop cross-org access; now it only removes access for current organization.
- Organization admins: before role assignment used opaque names; now readable checkboxes explain available organization roles.

## Details

- [UserService.php](https://github.com/musikfestwochen/musikfestapp/blob/feat/improve-user-roles-handling/app/Services/UserService.php) - centralizes org membership attach/detach, role sync, and role option data.
- [UserForm.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/improve-user-roles-handling/resources/js/components/users/UserForm.vue) - adds org-only role checkboxes and global admin organization assignment.
- [RolesAndPermissionsSeeder.php](https://github.com/musikfestwochen/musikfestapp/blob/feat/improve-user-roles-handling/database/seeders/RolesAndPermissionsSeeder.php) - keeps role display names/descriptions updated on rerun.

## Notes

This branch includes a roles table migration. After deploying, rerun the roles/permissions seeder so existing roles receive display metadata.

## Reviewer Setup

In this PR vs `origin/main`, changes were made in migrations, seeded role metadata, and frontend assets. You likely need to run:

```sh
php artisan migrate
php artisan db:seed --class=RolesAndPermissionsSeeder
npm run build
```

---
**«Life is available only in the present moment.»**
_Thich Nhat Hanh_