### PR TITLE
feat(stage-safety): ingest authenticated sensor readings

### DIFF
--- a/app/Enums/StageSafety/ReadingKind.php
+++ b/app/Enums/StageSafety/ReadingKind.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\StageSafety;
+
+enum ReadingKind: string
+{
+    case WindAverage = 'wind_average';
+    case WindGust = 'wind_gust';
+}

--- a/app/Http/Controllers/StageSafety/ReadingController.php
+++ b/app/Http/Controllers/StageSafety/ReadingController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\StageSafety;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StageSafety\ReadingStoreRequest;
+use App\Models\StageSafety\Sensor;
+use App\Services\StageSafety\ReadingService;
+use Illuminate\Http\JsonResponse;
+
+class ReadingController extends Controller
+{
+    public function store(ReadingStoreRequest $request, ReadingService $service): JsonResponse
+    {
+        $sensor = $request->user('sanctum');
+
+        /** @var Sensor $sensor */
+        $service->process($sensor, $request->validated());
+
+        return response()->json([
+            'message' => 'Wind readings processed successfully.',
+            'count' => 1,
+        ]);
+    }
+}

--- a/app/Http/Requests/StageSafety/ReadingStoreRequest.php
+++ b/app/Http/Requests/StageSafety/ReadingStoreRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\StageSafety;
+
+use App\Enums\StageSafety\ReadingKind;
+use App\Models\StageSafety\Sensor;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ReadingStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $sensor = $this->user('sanctum');
+
+        return $sensor instanceof Sensor
+            && $sensor->archived_at === null
+            && $sensor->tokenCan('*');
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'schema_version' => ['required', 'integer', Rule::in([1])],
+            'sensor_identifier' => ['required', 'string', 'regex:/\A[0-9A-F]{6}\z/'],
+            'observed_at' => [
+                'required',
+                'string',
+                'date',
+                'regex:/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+\-]\d{2}:\d{2})\z/',
+            ],
+            'payload' => ['required', 'array'],
+            'payload.kind' => ['required', 'string', Rule::in([
+                ReadingKind::WindAverage->value,
+                ReadingKind::WindGust->value,
+            ])],
+            'payload.value' => ['required', 'numeric:strict', 'min:0'],
+            'payload.unit' => ['required', 'string', Rule::in(['m/s'])],
+            'payload.window_seconds' => ['required', 'integer', 'min:0'],
+            'payload.battery_low' => ['required', 'boolean:strict'],
+            'payload.rssi_dbm' => ['sometimes', 'integer'],
+            'payload.cv' => ['sometimes', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Models/StageSafety/Reading.php
+++ b/app/Models/StageSafety/Reading.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\StageSafety;
+
+use App\Enums\StageSafety\ReadingKind;
+use Carbon\CarbonImmutable;
+use Database\Factories\StageSafety\ReadingFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $sensor_id
+ * @property ReadingKind $kind
+ * @property float $value
+ * @property string $unit
+ * @property CarbonImmutable $observed_at
+ * @property CarbonImmutable $received_at
+ * @property int|null $window_seconds
+ * @property bool|null $battery_low
+ * @property int|null $rssi_dbm
+ * @property int|null $cv
+ */
+#[Fillable([
+    'sensor_id',
+    'kind',
+    'value',
+    'unit',
+    'observed_at',
+    'received_at',
+    'window_seconds',
+    'battery_low',
+    'rssi_dbm',
+    'cv',
+])]
+#[Table(name: 'stage_safety_readings')]
+#[WithoutTimestamps]
+class Reading extends Model
+{
+    /** @use HasFactory<ReadingFactory> */
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<Sensor, $this>
+     */
+    public function sensor(): BelongsTo
+    {
+        return $this->belongsTo(Sensor::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'kind' => ReadingKind::class,
+            'value' => 'float',
+            'observed_at' => 'immutable_datetime',
+            'received_at' => 'immutable_datetime',
+            'window_seconds' => 'integer',
+            'battery_low' => 'boolean',
+            'rssi_dbm' => 'integer',
+            'cv' => 'integer',
+        ];
+    }
+}

--- a/app/Models/StageSafety/Sensor.php
+++ b/app/Models/StageSafety/Sensor.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
@@ -59,6 +60,14 @@ class Sensor extends Model
     public function organization(): BelongsTo
     {
         return $this->belongsTo(Organization::class);
+    }
+
+    /**
+     * @return HasMany<Reading, $this>
+     */
+    public function readings(): HasMany
+    {
+        return $this->hasMany(Reading::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Listeners\Permissions\PermissionAttachedListener;
 use App\Listeners\Permissions\PermissionDetachedListener;
 use App\Listeners\Permissions\RoleAttachedListener;
 use App\Listeners\Permissions\RoleDetachedListener;
+use App\Models\StageSafety\Sensor as StageSafetySensor;
 use App\Models\User;
 use App\Services\GlobalPermissionService;
 use App\Services\Peoplecount\AlertService;
@@ -18,9 +19,12 @@ use App\Services\Peoplecount\AssignmentService;
 use App\Services\Peoplecount\EventService;
 use App\Services\Peoplecount\IntervalCountService;
 use App\Services\Peoplecount\SensorService;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\Events\PermissionAttachedEvent;
@@ -52,10 +56,20 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-
         Model::automaticallyEagerLoadRelationships();
 
         URL::forceHttps(app()->isProduction());
+
+        RateLimiter::for('stage-safety-readings', function (Request $request): Limit {
+            $sensor = auth('sanctum')->user();
+            $tokenId = $sensor instanceof StageSafetySensor
+                ? $sensor->currentAccessToken()->getKey()
+                : null;
+
+            return Limit::perMinute(60)->by(
+                $tokenId === null ? 'ip:'.$request->ip() : 'token:'.$tokenId,
+            );
+        });
 
         Gate::before(function (User $user, string $ability): ?bool {
             return GlobalPermissionService::canGlobally($user, $ability);

--- a/app/Services/StageSafety/ReadingService.php
+++ b/app/Services/StageSafety/ReadingService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\StageSafety;
+
+use App\Enums\StageSafety\SensorType;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use Carbon\CarbonImmutable;
+use Illuminate\Validation\ValidationException;
+
+class ReadingService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function process(Sensor $sensor, array $data): void
+    {
+        if (SensorType::fromPair($sensor->manufacturer, $sensor->model) !== SensorType::BroadweighBwWss) {
+            throw ValidationException::withMessages([
+                'sensor' => ['The authenticated sensor model is not supported.'],
+            ]);
+        }
+
+        if ($data['sensor_identifier'] !== $sensor->identifier) {
+            throw ValidationException::withMessages([
+                'sensor_identifier' => ['The sensor identifier does not match the authenticated sensor.'],
+            ]);
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $data['payload'];
+        $observedAt = CarbonImmutable::parse((string) $data['observed_at'])->utc();
+        $receivedAt = CarbonImmutable::now('UTC');
+
+        Reading::query()->upsert([
+            [
+                'sensor_id' => $sensor->id,
+                'kind' => $payload['kind'],
+                'value' => $payload['value'],
+                'unit' => $payload['unit'],
+                'observed_at' => $observedAt->format('Y-m-d H:i:s'),
+                'received_at' => $receivedAt->format('Y-m-d H:i:s'),
+                'window_seconds' => $payload['window_seconds'],
+                'battery_low' => $payload['battery_low'],
+                'rssi_dbm' => $payload['rssi_dbm'] ?? null,
+                'cv' => $payload['cv'] ?? null,
+            ],
+        ], ['sensor_id', 'kind', 'observed_at'], [
+            'value',
+            'unit',
+            'received_at',
+            'window_seconds',
+            'battery_low',
+            'rssi_dbm',
+            'cv',
+        ]);
+    }
+}

--- a/database/factories/StageSafety/ReadingFactory.php
+++ b/database/factories/StageSafety/ReadingFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\StageSafety;
+
+use App\Enums\StageSafety\ReadingKind;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Reading>
+ */
+class ReadingFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $observedAt = fake()->dateTimeBetween('-1 hour');
+
+        return [
+            'sensor_id' => Sensor::factory(),
+            'kind' => fake()->randomElement(ReadingKind::cases()),
+            'value' => fake()->randomFloat(7, 0, 40),
+            'unit' => 'm/s',
+            'observed_at' => $observedAt,
+            'received_at' => fake()->dateTimeBetween($observedAt),
+            'window_seconds' => fake()->optional()->randomElement([0, 10, 60]),
+            'battery_low' => fake()->optional()->boolean(5),
+            'rssi_dbm' => fake()->optional()->numberBetween(-98, -30),
+            'cv' => fake()->optional()->numberBetween(55, 110),
+        ];
+    }
+}

--- a/database/migrations/2026_07_24_143829_create_stage_safety_readings_table.php
+++ b/database/migrations/2026_07_24_143829_create_stage_safety_readings_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stage_safety_readings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sensor_id')->constrained('stage_safety_sensors')->cascadeOnDelete();
+            $table->string('kind', 32);
+            $table->double('value');
+            $table->string('unit', 16);
+            $table->timestamp('observed_at');
+            $table->timestamp('received_at');
+            $table->unsignedInteger('window_seconds')->nullable();
+            $table->boolean('battery_low')->nullable();
+            $table->smallInteger('rssi_dbm')->nullable();
+            $table->unsignedSmallInteger('cv')->nullable();
+
+            $table->unique(
+                ['sensor_id', 'kind', 'observed_at'],
+                'stage_safety_reading_identity_unique',
+            );
+            $table->index(
+                ['sensor_id', 'observed_at'],
+                'stage_safety_reading_observed_index',
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stage_safety_readings');
+    }
+};

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -99,9 +99,10 @@ paths:
 
                 The bearer token identifies one physical Stage Safety sensor and carries Sanctum's
                 `*` full ability. The token must belong to an active Stage Safety sensor; other
-                principal types and archived sensors are rejected with `403`. The request body
-                carries no sensor or organization identifier; attribution always derives from the
-                authenticated token and its sensor's organization.
+                principal types and archived sensors are rejected with `403`. The request's
+                `sensor_identifier` must match the token-bound sensor as a configuration consistency
+                check. Attribution always derives from the authenticated token and its sensor's
+                organization; the identifier cannot select another sensor.
 
                 `observed_at` is the API client timestamp recorded when that frame was completely
                 received and CRC-validated. It is distinct from the server-side `received_at`
@@ -112,8 +113,8 @@ paths:
                 transmission, not an instantaneous peak. An average `value` is the average wind
                 speed over the configured sample window. Unit, data-tag mapping, and aggregation
                 windows come from API client configuration and are not uniquely encoded in a
-                radio value frame. Wind values are normalized to metres per second by the
-                application.
+                radio value frame. The gateway converts its configured source unit before sending;
+                the API accepts and stores metres per second only.
             security:
                 - sensorToken: []
             parameters:
@@ -129,9 +130,10 @@ paths:
                                 summary: BW-WSS gust frame with radio diagnostics
                                 value:
                                     schema_version: 1
-                                    observed_at: '2026-07-23T12:00:00.123Z'
+                                    sensor_identifier: ABC123
+                                    observed_at: '2026-07-23T12:00:00Z'
                                     payload:
-                                        kind: gust
+                                        kind: wind_gust
                                         value: 2.6744547
                                         unit: m/s
                                         window_seconds: 10
@@ -261,8 +263,13 @@ components:
         TimestampWithTimezone:
             type: string
             format: date-time
-            pattern: '(?:Z|[+-]\d{2}:?\d{2})$'
+            pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$'
             description: RFC 3339 timestamp with `Z` or an explicit numeric UTC offset.
+        TimestampWithTimezoneSeconds:
+            type: string
+            format: date-time
+            pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$'
+            description: RFC 3339 timestamp at whole-second precision with `Z` or an explicit numeric UTC offset.
         PeoplecountProcessedResponse:
             type: object
             additionalProperties: false
@@ -300,22 +307,27 @@ components:
                     type: string
         BroadweighWindReadingRequest:
             type: object
-            additionalProperties: false
+            additionalProperties: true
             required:
                 - schema_version
+                - sensor_identifier
                 - observed_at
                 - payload
             properties:
                 schema_version:
                     type: integer
                     const: 1
+                sensor_identifier:
+                    type: string
+                    pattern: '^[0-9A-F]{6}$'
+                    description: Must exactly match the identifier of the sensor bound to the bearer token. It verifies configuration but does not determine attribution.
                 observed_at:
-                    $ref: '#/components/schemas/TimestampWithTimezone'
+                    $ref: '#/components/schemas/TimestampWithTimezoneSeconds'
                 payload:
                     $ref: '#/components/schemas/BroadweighWindPayload'
         BroadweighWindPayload:
             type: object
-            additionalProperties: false
+            additionalProperties: true
             required:
                 - kind
                 - value
@@ -326,22 +338,17 @@ components:
                 kind:
                     type: string
                     enum:
-                        - average
-                        - gust
-                    description: Reading kind carried by this radio value frame.
+                        - wind_average
+                        - wind_gust
+                    description: Explicit wind reading kind carried by this radio value frame.
                 value:
                     type: number
                     minimum: 0
-                    description: Wind speed expressed in `unit`. A gust value is the maximum rolling-window average since the preceding transmission.
+                    description: Wind speed in metres per second. A gust value is the maximum rolling-window average since the preceding transmission.
                 unit:
                     type: string
-                    enum:
-                        - m/s
-                        - km/h
-                        - mph
-                        - fps
-                        - kn
-                    description: Unit selected in the API client configuration.
+                    const: m/s
+                    description: Canonical API unit. The gateway converts its configured source unit before sending.
                 window_seconds:
                     type: integer
                     minimum: 0

--- a/docs/diagrams/erd.md
+++ b/docs/diagrams/erd.md
@@ -7,7 +7,7 @@ Do not edit diagram block manually. Run `composer docs:erd`.
 <!-- mermaid-erd-start -->
 ```mermaid
 ---
-title: 23 tables · 172 columns
+title: 24 tables · 183 columns
 ---
 erDiagram
     model_has_permissions["model_has_permissions (4)"] {
@@ -202,6 +202,19 @@ erDiagram
         varchar display_name "nullable"
         text description "nullable"
     }
+    stage_safety_readings["stage_safety_readings (11)"] {
+        integer id PK
+        integer sensor_id FK
+        varchar kind
+        double value
+        varchar unit
+        datetime observed_at
+        datetime received_at
+        integer window_seconds "nullable"
+        tinyint battery_low "nullable"
+        integer rssi_dbm "nullable"
+        integer cv "nullable"
+    }
     stage_safety_sensors["stage_safety_sensors (12)"] {
         integer id PK
         integer organization_id FK
@@ -257,6 +270,7 @@ erDiagram
     roles ||--o{ role_has_permissions : "pivot, has many via role_id, cascade delete"
     permissions ||--o{ role_has_permissions : "pivot, has many via permission_id, cascade delete"
     organizations |o--o{ roles : "guessed has many via organization_id"
+    stage_safety_sensors ||--o{ stage_safety_readings : "has many via sensor_id, cascade delete"
     organizations ||--o{ stage_safety_sensors : "has many via organization_id, cascade delete"
 %% Unmapped polymorphic relations (add to config 'mermaid-erd.polymorphic_relationships'):
 %%   model_has_permissions.model (model_type + model_id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,24 +1249,6 @@
                 "@swc/helpers": "^0.5.0"
             }
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@isaacs/fs-minipass": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1460,9 +1442,9 @@
             }
         },
         "node_modules/@one-ini/wasm": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.2.1.tgz",
+            "integrity": "sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1473,17 +1455,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@playwright/test": {
@@ -3549,13 +3520,13 @@
             }
         },
         "node_modules/abbrev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+            "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/acorn": {
@@ -3886,16 +3857,16 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -5188,63 +5159,33 @@
             "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
             "license": "ISC"
         },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/editorconfig": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
-            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-3.0.2.tgz",
+            "integrity": "sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@one-ini/wasm": "0.1.1",
-                "commander": "^10.0.0",
-                "minimatch": "^9.0.1",
-                "semver": "^7.5.3"
+                "@one-ini/wasm": "0.2.1",
+                "commander": "^14.0.3",
+                "minimatch": "~10.2.4",
+                "semver": "^7.7.4"
             },
             "bin": {
                 "editorconfig": "bin/editorconfig"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=20"
             }
         },
-        "node_modules/editorconfig/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+        "node_modules/editorconfig/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/editorconfig/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": ">=20"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -5258,13 +5199,6 @@
             "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.10.2.tgz",
             "integrity": "sha512-Yx3ORtbAFrXelYkAy2g0eYyVY8QG0XEmGdQXmy0eithKKjbWRfl3Xe884lfkszfBF6UKyIy4LwfcZ3AZc8oxFw==",
             "license": "EPL-2.0"
-        },
-        "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
@@ -5883,23 +5817,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -6082,22 +5999,18 @@
             "license": "MIT"
         },
         "node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
+            "engines": {
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -6114,39 +6027,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/global-prefix": {
@@ -6550,16 +6430,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6778,22 +6648,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
         "node_modules/jiti": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -6805,17 +6659,17 @@
             }
         },
         "node_modules/js-beautify": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
-            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-2.0.3.tgz",
+            "integrity": "sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "config-chain": "^1.1.13",
-                "editorconfig": "^1.0.4",
-                "glob": "^10.4.2",
-                "js-cookie": "^3.0.5",
-                "nopt": "^7.2.1"
+                "editorconfig": "^3.0.2",
+                "glob": "^13.0.6",
+                "js-cookie": "^3.0.8",
+                "nopt": "^10.0.1"
             },
             "bin": {
                 "css-beautify": "js/bin/css-beautify.js",
@@ -7374,11 +7228,14 @@
             "license": "MIT"
         },
         "node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
-            "license": "ISC"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/lucide": {
             "version": "1.25.0",
@@ -7777,19 +7634,19 @@
             }
         },
         "node_modules/nopt": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+            "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "abbrev": "^2.0.0"
+                "abbrev": "^5.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/nth-check": {
@@ -7942,13 +7799,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8013,17 +7863,17 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.18"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -9079,19 +8929,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -9234,60 +9071,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/string-width-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/strip-ansi": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -9301,20 +9084,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/strip-ansi/node_modules/ansi-regex": {
@@ -10262,91 +10031,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "lightningcss-linux-x64-gnu": "^1.33.0"
     },
     "overrides": {
+        "js-beautify": "2.0.3",
         "shell-quote": "1.10.0"
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Peoplecount\IntervalCountController;
+use App\Http\Controllers\StageSafety\ReadingController;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
@@ -11,6 +12,10 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('interval-count', [IntervalCountController::class, 'store'])
             ->name('interval-count.store');
     });
+
+    Route::post('stage-safety/readings', [ReadingController::class, 'store'])
+        ->middleware('throttle:stage-safety-readings')
+        ->name('stage-safety.readings.store');
 });
 
 Route::post('/webcron', function () {

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -154,6 +154,7 @@ it('tests if no unwanted routes are exposed', function () {
 
         // API Routes
         ['method' => 'POST', 'uri' => 'api/peoplecount/interval-count'],
+        ['method' => 'POST', 'uri' => 'api/stage-safety/readings'],
         ['method' => 'POST', 'uri' => 'api/webcron'],
 
         // Laravel Sanctum routes

--- a/tests/Feature/StageSafety/ReadingControllerTest.php
+++ b/tests/Feature/StageSafety/ReadingControllerTest.php
@@ -1,0 +1,307 @@
+<?php
+
+use App\Enums\StageSafety\ReadingKind;
+use App\Models\Organization;
+use App\Models\Peoplecount\Sensor as PeoplecountSensor;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+afterEach(function () {
+    CarbonImmutable::setTestNow();
+});
+
+function stageSafetyReadingPayload(array $overrides = [], string $sensorIdentifier = 'ABC123'): array
+{
+    return array_replace_recursive([
+        'schema_version' => 1,
+        'sensor_identifier' => $sensorIdentifier,
+        'observed_at' => '2026-07-23T12:00:00Z',
+        'payload' => [
+            'kind' => 'wind_gust',
+            'value' => 2.6744547,
+            'unit' => 'm/s',
+            'window_seconds' => 10,
+            'battery_low' => false,
+            'rssi_dbm' => -70,
+            'cv' => 103,
+        ],
+    ], $overrides);
+}
+
+function stageSafetyReadingToken(Sensor $sensor, array $abilities = ['*']): string
+{
+    return $sensor->createToken('stage-safety-reading-test', $abilities)->plainTextToken;
+}
+
+function stageSafetyReadingHeaders(string $token): array
+{
+    return ['Authorization' => 'Bearer '.$token];
+}
+
+it('persists a token-bound m/s reading with client and server timestamps', function () {
+    CarbonImmutable::setTestNow('2026-07-23T12:01:00Z');
+    $sensor = Sensor::factory()->create();
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(['observed_at' => '2026-07-23T14:00:00+02:00'], $sensor->identifier),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($sensor)),
+    )->assertOk()->assertExactJson([
+        'message' => 'Wind readings processed successfully.',
+        'count' => 1,
+    ]);
+
+    $reading = Reading::query()->sole();
+
+    expect($reading->sensor->is($sensor))->toBeTrue()
+        ->and($sensor->readings()->sole()->is($reading))->toBeTrue()
+        ->and($reading->kind)->toBe(ReadingKind::WindGust)
+        ->and($reading->value)->toBe(2.6744547)
+        ->and($reading->unit)->toBe('m/s')
+        ->and($reading->observed_at->format('Y-m-d H:i:s'))->toBe('2026-07-23 12:00:00')
+        ->and($reading->received_at->format('Y-m-d H:i:s'))->toBe('2026-07-23 12:01:00')
+        ->and($reading->window_seconds)->toBe(10)
+        ->and($reading->battery_low)->toBeFalse()
+        ->and($reading->rssi_dbm)->toBe(-70)
+        ->and($reading->cv)->toBe(103);
+});
+
+it('ignores extra identity and payload fields', function () {
+    $authenticatedSensor = Sensor::factory()->create();
+    $otherSensor = Sensor::factory()->for(Organization::factory())->create();
+    $payload = stageSafetyReadingPayload([
+        'sensor_id' => $otherSensor->id,
+        'organization_id' => $otherSensor->organization_id,
+        'ignored' => 'value',
+        'payload' => [
+            'sensor_id' => $otherSensor->id,
+            'organization_id' => $otherSensor->organization_id,
+            'ignored' => 'value',
+        ],
+    ], $authenticatedSensor->identifier);
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        $payload,
+        stageSafetyReadingHeaders(stageSafetyReadingToken($authenticatedSensor)),
+    )->assertOk();
+
+    expect(Reading::query()->sole()->sensor_id)->toBe($authenticatedSensor->id)
+        ->and(Reading::query()->whereBelongsTo($otherSensor)->exists())->toBeFalse();
+});
+
+it('stores average and gust frames independently', function () {
+    $sensor = Sensor::factory()->create();
+    $headers = stageSafetyReadingHeaders(stageSafetyReadingToken($sensor));
+
+    $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload([
+        'payload' => ['kind' => ReadingKind::WindAverage->value, 'window_seconds' => 60],
+    ], $sensor->identifier), $headers)->assertOk();
+    $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier), $headers)->assertOk();
+
+    expect($sensor->readings()->count())->toBe(2)
+        ->and($sensor->readings()->pluck('kind')->all())
+        ->toEqualCanonicalizing([ReadingKind::WindAverage, ReadingKind::WindGust]);
+});
+
+it('allows measurement-specific metadata to be absent in shared persistence', function () {
+    $reading = Reading::factory()->create([
+        'window_seconds' => null,
+        'battery_low' => null,
+    ]);
+
+    expect($reading->window_seconds)->toBeNull()
+        ->and($reading->battery_low)->toBeNull();
+});
+
+it('idempotently updates a replayed frame', function () {
+    CarbonImmutable::setTestNow('2026-07-23T12:01:00Z');
+    $sensor = Sensor::factory()->create();
+    $headers = stageSafetyReadingHeaders(stageSafetyReadingToken($sensor));
+
+    $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier), $headers)->assertOk();
+
+    CarbonImmutable::setTestNow('2026-07-23T12:02:00Z');
+    $replay = stageSafetyReadingPayload([
+        'payload' => [
+            'value' => 3.5,
+            'window_seconds' => 20,
+            'battery_low' => true,
+            'rssi_dbm' => null,
+            'cv' => null,
+        ],
+    ], $sensor->identifier);
+    unset($replay['payload']['rssi_dbm'], $replay['payload']['cv']);
+
+    $this->postJson(route('stage-safety.readings.store'), $replay, $headers)->assertOk();
+
+    $reading = Reading::query()->sole();
+
+    expect($reading->value)->toBe(3.5)
+        ->and($reading->window_seconds)->toBe(20)
+        ->and($reading->battery_low)->toBeTrue()
+        ->and($reading->rssi_dbm)->toBeNull()
+        ->and($reading->cv)->toBeNull()
+        ->and($reading->received_at->format('Y-m-d H:i:s'))->toBe('2026-07-23 12:02:00');
+});
+
+it('keeps identical frame identities separate across sensors', function () {
+    $firstSensor = Sensor::factory()->create();
+    $secondSensor = Sensor::factory()->create();
+
+    foreach ([$firstSensor, $secondSensor] as $sensor) {
+        $this->postJson(
+            route('stage-safety.readings.store'),
+            stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier),
+            stageSafetyReadingHeaders(stageSafetyReadingToken($sensor)),
+        )->assertOk();
+        $this->app['auth']->forgetGuards();
+    }
+
+    expect(Reading::query()->count())->toBe(2);
+});
+
+it('rejects missing and invalid authentication', function () {
+    $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload())
+        ->assertUnauthorized();
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(),
+        stageSafetyReadingHeaders('invalid-token'),
+    )->assertUnauthorized();
+
+    expect(Reading::query()->exists())->toBeFalse();
+});
+
+it('rejects non-Stage-Safety principals', function () {
+    $peoplecountSensor = PeoplecountSensor::factory()->create();
+    $user = User::factory()->create();
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(),
+        stageSafetyReadingHeaders($peoplecountSensor->createToken('test')->plainTextToken),
+    )->assertForbidden();
+    $this->app['auth']->forgetGuards();
+    $this->actingAs($user)
+        ->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload())
+        ->assertForbidden();
+
+    expect(Reading::query()->exists())->toBeFalse();
+});
+
+it('rejects archived sensors and tokens without full ability', function () {
+    $archivedSensor = Sensor::factory()->create();
+    $archivedToken = stageSafetyReadingToken($archivedSensor);
+    $archivedSensor->update(['archived_at' => now()]);
+    $limitedSensor = Sensor::factory()->create();
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: $archivedSensor->identifier),
+        stageSafetyReadingHeaders($archivedToken),
+    )->assertForbidden();
+    $this->app['auth']->forgetGuards();
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: $limitedSensor->identifier),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($limitedSensor, ['readings:write'])),
+    )->assertForbidden();
+
+    expect(Reading::query()->exists())->toBeFalse();
+});
+
+it('rejects unsupported authenticated sensor models', function () {
+    $sensor = Sensor::factory()->create(['model' => 'unsupported']);
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($sensor)),
+    )->assertUnprocessable()->assertJsonValidationErrors('sensor');
+});
+
+it('rejects an identifier that does not match the token-bound sensor', function () {
+    $sensor = Sensor::factory()->create(['identifier' => 'DEF456']);
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: 'ABC123'),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($sensor)),
+    )->assertUnprocessable()->assertJsonValidationErrors('sensor_identifier');
+
+    expect(Reading::query()->exists())->toBeFalse();
+});
+
+it('rejects malformed reading fields', function (string $field, mixed $value) {
+    $sensor = Sensor::factory()->create();
+    $payload = stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier);
+    data_set($payload, $field, $value);
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        $payload,
+        stageSafetyReadingHeaders(stageSafetyReadingToken($sensor)),
+    )->assertUnprocessable()->assertJsonValidationErrors($field);
+
+    expect(Reading::query()->exists())->toBeFalse();
+})->with([
+    'schema version' => ['schema_version', 2],
+    'sensor identifier' => ['sensor_identifier', 'abc123'],
+    'timestamp without timezone' => ['observed_at', '2026-07-23 12:00:00'],
+    'human-readable timestamp' => ['observed_at', 'July 23 2026 12:00:00Z'],
+    'timestamp offset without colon' => ['observed_at', '2026-07-23T12:00:00+0200'],
+    'invalid timestamp' => ['observed_at', 'not-a-dateZ'],
+    'fractional timestamp' => ['observed_at', '2026-07-23T12:00:00.123Z'],
+    'reading kind' => ['payload.kind', 'peak'],
+    'numeric string' => ['payload.value', '2.5'],
+    'negative value' => ['payload.value', -0.1],
+    'non-canonical unit' => ['payload.unit', 'km/h'],
+    'negative window' => ['payload.window_seconds', -1],
+    'non-integer window' => ['payload.window_seconds', 1.5],
+    'non-boolean battery state' => ['payload.battery_low', 1],
+    'non-integer RSSI' => ['payload.rssi_dbm', -70.5],
+    'negative CV' => ['payload.cv', -1],
+]);
+
+it('applies standard route throttling', function () {
+    $sensor = Sensor::factory()->create();
+    $headers = stageSafetyReadingHeaders(stageSafetyReadingToken($sensor));
+
+    foreach (range(1, 60) as $request) {
+        $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload([
+            'observed_at' => sprintf('2026-07-23T12:00:%02dZ', $request - 1),
+        ], $sensor->identifier), $headers)->assertOk();
+    }
+
+    $this->postJson(route('stage-safety.readings.store'), stageSafetyReadingPayload(sensorIdentifier: $sensor->identifier), $headers)
+        ->assertTooManyRequests();
+});
+
+it('gives each sensor token an independent rate limit', function () {
+    $firstSensor = Sensor::factory()->create();
+    $secondSensor = Sensor::factory()->create();
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: $firstSensor->identifier),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($firstSensor)),
+    )->assertOk()->assertHeader('X-RateLimit-Remaining', '59');
+
+    $this->app['auth']->forgetGuards();
+
+    $this->postJson(
+        route('stage-safety.readings.store'),
+        stageSafetyReadingPayload(sensorIdentifier: $secondSensor->identifier),
+        stageSafetyReadingHeaders(stageSafetyReadingToken($secondSensor)),
+    )->assertOk()->assertHeader('X-RateLimit-Remaining', '59');
+});
+
+it('uses authentication and standard throttle middleware', function () {
+    test()->assertRouteUsesMiddleware(
+        'stage-safety.readings.store',
+        ['auth:sanctum', 'throttle:stage-safety-readings'],
+    );
+});

--- a/tests/Integration/Services/StageSafety/ReadingServiceTest.php
+++ b/tests/Integration/Services/StageSafety/ReadingServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use App\Services\StageSafety\ReadingService;
+use Illuminate\Validation\ValidationException;
+
+covers(ReadingService::class);
+
+it('persists a supported wind reading', function () {
+    $sensor = Sensor::factory()->create();
+
+    (new ReadingService)->process($sensor, [
+        'sensor_identifier' => $sensor->identifier,
+        'observed_at' => '2026-07-23T12:00:00Z',
+        'payload' => [
+            'kind' => 'wind_average',
+            'value' => 2.5,
+            'unit' => 'm/s',
+            'window_seconds' => 60,
+            'battery_low' => false,
+        ],
+    ]);
+
+    $reading = Reading::query()->sole();
+
+    expect($reading->sensor_id)->toBe($sensor->id)
+        ->and($reading->value)->toBe(2.5)
+        ->and($reading->unit)->toBe('m/s');
+});
+
+it('rejects unsupported sensor models', function () {
+    $sensor = Sensor::factory()->create(['model' => 'unsupported']);
+
+    expect(fn () => (new ReadingService)->process($sensor, []))
+        ->toThrow(ValidationException::class, 'The authenticated sensor model is not supported.');
+});
+
+it('rejects a mismatched sensor identifier', function () {
+    $sensor = Sensor::factory()->create(['identifier' => 'DEF456']);
+
+    expect(fn () => (new ReadingService)->process($sensor, ['sensor_identifier' => 'ABC123']))
+        ->toThrow(ValidationException::class, 'The sensor identifier does not match the authenticated sensor.');
+});

--- a/tests/Unit/Models/StageSafety/ReadingTest.php
+++ b/tests/Unit/Models/StageSafety/ReadingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Enums\StageSafety\ReadingKind;
+use App\Models\StageSafety\Reading;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+covers(Reading::class);
+
+it('defines its table, fillable fields, casts, and sensor relationship', function () {
+    $reading = new Reading;
+
+    expect($reading->getTable())->toBe('stage_safety_readings')
+        ->and($reading->usesTimestamps())->toBeFalse()
+        ->and($reading->getFillable())->toEqualCanonicalizing([
+            'sensor_id',
+            'kind',
+            'value',
+            'unit',
+            'observed_at',
+            'received_at',
+            'window_seconds',
+            'battery_low',
+            'rssi_dbm',
+            'cv',
+        ])
+        ->and($reading->getCasts())->toMatchArray([
+            'kind' => ReadingKind::class,
+            'value' => 'float',
+            'observed_at' => 'immutable_datetime',
+            'received_at' => 'immutable_datetime',
+            'window_seconds' => 'integer',
+            'battery_low' => 'boolean',
+            'rssi_dbm' => 'integer',
+            'cv' => 'integer',
+        ])
+        ->and($reading->sensor())->toBeInstanceOf(BelongsTo::class);
+});

--- a/tests/Unit/Models/StageSafety/SensorTest.php
+++ b/tests/Unit/Models/StageSafety/SensorTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\StageSafety\Sensor;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -34,4 +35,8 @@ it('uses API tokens and soft deletes', function () {
 
 it('belongs to an organization', function () {
     expect((new Sensor)->organization())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has many readings', function () {
+    expect((new Sensor)->readings())->toBeInstanceOf(HasMany::class);
 });

--- a/tests/Unit/Requests/StageSafety/ReadingStoreRequestTest.php
+++ b/tests/Unit/Requests/StageSafety/ReadingStoreRequestTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Http\Requests\StageSafety\ReadingStoreRequest;
+use App\Models\StageSafety\Sensor;
+use Illuminate\Validation\Rules\In;
+use Laravel\Sanctum\PersonalAccessToken;
+
+covers(ReadingStoreRequest::class);
+
+it('defines the BW-WSS envelope and payload rules', function () {
+    $rules = (new ReadingStoreRequest)->rules();
+
+    expect($rules)->toHaveKeys([
+        'schema_version',
+        'sensor_identifier',
+        'observed_at',
+        'payload',
+        'payload.kind',
+        'payload.value',
+        'payload.unit',
+        'payload.window_seconds',
+        'payload.battery_low',
+        'payload.rssi_dbm',
+        'payload.cv',
+    ])->and($rules['schema_version'][2])->toBeInstanceOf(In::class)
+        ->and($rules['sensor_identifier'])->toBe(['required', 'string', 'regex:/\A[0-9A-F]{6}\z/'])
+        ->and($rules['payload.kind'][2])->toBeInstanceOf(In::class)
+        ->and($rules['payload.value'])->toBe(['required', 'numeric:strict', 'min:0'])
+        ->and($rules['payload.unit'][2])->toBeInstanceOf(In::class)
+        ->and($rules['payload.window_seconds'])->toBe(['required', 'integer', 'min:0'])
+        ->and($rules['payload.battery_low'])->toBe(['required', 'boolean:strict']);
+});
+
+it('authorizes only active Stage Safety sensors with full token ability', function (object $principal, bool $expected) {
+    $request = new ReadingStoreRequest;
+    $request->setUserResolver(fn (?string $guard = null): object => $principal);
+
+    expect($request->authorize())->toBe($expected);
+})->with([
+    'active full token' => fn (): array => [stageSafetyRequestSensor(null, ['*']), true],
+    'archived sensor' => fn (): array => [stageSafetyRequestSensor(now(), ['*']), false],
+    'limited token' => fn (): array => [stageSafetyRequestSensor(null, ['readings:write']), false],
+    'wrong principal' => fn (): array => [new stdClass, false],
+]);
+
+function stageSafetyRequestSensor(mixed $archivedAt, array $abilities): Sensor
+{
+    $token = new PersonalAccessToken;
+    $token->abilities = $abilities;
+    $sensor = new Sensor;
+    $sensor->archived_at = $archivedAt;
+
+    return $sensor->withAccessToken($token);
+}


### PR DESCRIPTION
Adds a retry-safe Stage Safety ingestion boundary for BW-WSS readings. Sensor tokens now authorize one active sensor, while the required physical identifier catches swapped-token configuration before any reading is persisted.

## Details

- [ReadingStoreRequest.php](https://github.com/musikfestwochen/musikfestapp/blob/feat/ingest-stage-safety-wind-readings/app/Http/Requests/StageSafety/ReadingStoreRequest.php) - validates strict versioned payloads, whole-second RFC 3339 timestamps, sensor principals, and canonical wind fields
- [ReadingService.php](https://github.com/musikfestwochen/musikfestapp/blob/feat/ingest-stage-safety-wind-readings/app/Services/StageSafety/ReadingService.php) - verifies token-bound sensor identity and performs database-backed idempotent upserts
- [openapi.yaml](https://github.com/musikfestwochen/musikfestapp/blob/feat/ingest-stage-safety-wind-readings/docs/api/openapi.yaml) - publishes gateway contract for `wind_average` and `wind_gust` readings in m/s

## Notes

Gateway clients must send matching `sensor_identifier`, whole-second `observed_at`, explicit wind kind, and `unit: m/s`. Test suite maintains 100% code and type coverage; OpenAPI validation, PHPStan, and strict MkDocs build pass. E2E remains blocked by known local web-server startup issue.

## Reviewer Setup

This PR adds Stage Safety reading persistence. Run:

```sh
php artisan migrate
```

Fixes #187

---
**«I have not failed. I've just found 10,000 ways that won't work.»**
_Thomas Edison_
