### PR TITLE
fix(stage-safety): support legacy MariaDB timestamps

### DIFF
--- a/.github/workflows/mariadb-migration-tests.yml
+++ b/.github/workflows/mariadb-migration-tests.yml
@@ -8,11 +8,16 @@ permissions:
 
 jobs:
   mariadb-migration-tests:
+    name: MariaDB ${{ matrix.mariadb }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb: ['10.6', 'lts']
 
     services:
       mariadb:
-        image: mariadb:lts
+        image: mariadb:${{ matrix.mariadb }}
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: musikfestapp_test
@@ -57,6 +62,10 @@ jobs:
             echo "Waiting for MariaDB to be ready..."
             sleep 2
           done
+
+      # Match production's legacy behavior, where later TIMESTAMP columns may receive zero-date defaults.
+      - name: Enable Legacy Timestamp Defaults
+        run: php artisan tinker --execute='DB::statement("SET GLOBAL explicit_defaults_for_timestamp = OFF"); throw_unless((int) DB::scalar("SELECT @@GLOBAL.explicit_defaults_for_timestamp") === 0);'
 
       - name: Run Migration Tests
         run: |

--- a/database/migrations/2026_07_24_143829_create_stage_safety_readings_table.php
+++ b/database/migrations/2026_07_24_143829_create_stage_safety_readings_table.php
@@ -14,8 +14,8 @@ return new class extends Migration
             $table->string('kind', 32);
             $table->double('value');
             $table->string('unit', 16);
-            $table->timestamp('observed_at');
-            $table->timestamp('received_at');
+            $table->dateTime('observed_at');
+            $table->dateTime('received_at');
             $table->unsignedInteger('window_seconds')->nullable();
             $table->boolean('battery_low')->nullable();
             $table->smallInteger('rssi_dbm')->nullable();


### PR DESCRIPTION
Follow-up to #198. Fixes Stage Safety migration failure on MariaDB 10.6 with legacy timestamp defaults, and tests both production MariaDB line and current LTS.

## Reviewer Setup

```sh
php artisan migrate
```

---
**«Happiness is not something readymade. It comes from your own actions.»**
_Dalai Lama_