### PR TITLE
feat(stage-safety): add monitoring views and dashboard widgets

### DIFF
--- a/app/Enums/StageSafety/SensorHealthStatus.php
+++ b/app/Enums/StageSafety/SensorHealthStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\StageSafety;
+
+enum SensorHealthStatus: string
+{
+    case Fresh = 'fresh';
+    case Stale = 'stale';
+    case NeverSeen = 'never_seen';
+    case Archived = 'archived';
+}

--- a/app/Http/Controllers/StageSafety/SensorController.php
+++ b/app/Http/Controllers/StageSafety/SensorController.php
@@ -49,11 +49,11 @@ class SensorController extends Controller
         return response()->json($result, 201)->header('Cache-Control', 'no-store, private');
     }
 
-    public function show(SensorShowRequest $request, Organization $organization, Sensor $stageSafetySensor): RedirectResponse
+    public function show(SensorShowRequest $request, Organization $organization, Sensor $stageSafetySensor): Response
     {
-        return to_route('stage-safety.sensors.edit', [
+        return Inertia::render('stage-safety/Sensor', [
             'organization' => $organization,
-            'stageSafetySensor' => $stageSafetySensor,
+            'sensor' => $stageSafetySensor,
         ]);
     }
 

--- a/app/Http/Controllers/StageSafety/SensorMonitoringController.php
+++ b/app/Http/Controllers/StageSafety/SensorMonitoringController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\StageSafety;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StageSafety\SensorMonitoringIndexRequest;
+use App\Models\Organization;
+use App\Models\StageSafety\Sensor;
+use App\Services\StageSafety\MonitoringService;
+use Illuminate\Http\JsonResponse;
+
+class SensorMonitoringController extends Controller
+{
+    public function index(
+        SensorMonitoringIndexRequest $request,
+        Organization $organization,
+        Sensor $stageSafetySensor,
+        MonitoringService $monitoringService,
+    ): JsonResponse {
+        [$from, $to] = $request->range();
+
+        return response()->json($monitoringService->sensorMonitoring($organization, $stageSafetySensor, $from, $to));
+    }
+}

--- a/app/Http/Controllers/Widgets/StageSafetyCurrentWindWidgetController.php
+++ b/app/Http/Controllers/Widgets/StageSafetyCurrentWindWidgetController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Widgets;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Widgets\StageSafety\CurrentWindIndexRequest;
+use App\Models\Organization;
+use App\Services\StageSafety\MonitoringService;
+use Illuminate\Http\JsonResponse;
+
+class StageSafetyCurrentWindWidgetController extends Controller
+{
+    public function index(CurrentWindIndexRequest $request, Organization $organization, MonitoringService $monitoringService): JsonResponse
+    {
+        return response()->json($monitoringService->currentWind($organization));
+    }
+}

--- a/app/Http/Controllers/Widgets/StageSafetySensorHealthWidgetController.php
+++ b/app/Http/Controllers/Widgets/StageSafetySensorHealthWidgetController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Widgets;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Widgets\StageSafety\SensorHealthIndexRequest;
+use App\Models\Organization;
+use App\Services\StageSafety\MonitoringService;
+use Illuminate\Http\JsonResponse;
+
+class StageSafetySensorHealthWidgetController extends Controller
+{
+    public function index(SensorHealthIndexRequest $request, Organization $organization, MonitoringService $monitoringService): JsonResponse
+    {
+        return response()->json($monitoringService->sensorHealth($organization));
+    }
+}

--- a/app/Http/Controllers/Widgets/StageSafetyWindHistoryWidgetController.php
+++ b/app/Http/Controllers/Widgets/StageSafetyWindHistoryWidgetController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Widgets;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
+use App\Models\Organization;
+use App\Services\StageSafety\MonitoringService;
+use Illuminate\Http\JsonResponse;
+
+class StageSafetyWindHistoryWidgetController extends Controller
+{
+    public function index(WindHistoryIndexRequest $request, Organization $organization, MonitoringService $monitoringService): JsonResponse
+    {
+        [$from, $to] = $request->range();
+
+        return response()->json($monitoringService->windHistory($organization, $from, $to));
+    }
+}

--- a/app/Http/Requests/Orgmgmt/UserStoreRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserStoreRequest.php
@@ -32,7 +32,7 @@ class UserStoreRequest extends FormRequest
             'email' => ['required', 'string', 'email', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', $this->uniquePhoneForEmailUser()],
             'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notChangingOwnRoles()],
-            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'OrganizationAdmin'])],
+            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'StageSafetyViewer', 'OrganizationAdmin'])],
         ];
     }
 

--- a/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
+++ b/app/Http/Requests/Orgmgmt/UserUpdateRequest.php
@@ -33,7 +33,7 @@ use Illuminate\Validation\Rule;
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.($this->route('user')->id ?? '')],
             'phone' => ['nullable', 'string', 'max:20', 'unique:users,phone,'.($this->route('user')->id ?? '')],
             'roles' => ['sometimes', 'array', 'list', 'min:1', $this->notUpdatingOwnRoles()],
-            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'OrganizationAdmin'])],
+            'roles.*' => ['string', 'distinct', Rule::in(['PeopleCountViewer', 'StageSafetyViewer', 'OrganizationAdmin'])],
         ];
     }
 

--- a/app/Http/Requests/StageSafety/SensorMonitoringIndexRequest.php
+++ b/app/Http/Requests/StageSafety/SensorMonitoringIndexRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\StageSafety;
+
+use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
+
+class SensorMonitoringIndexRequest extends WindHistoryIndexRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('stage-safety.sensors.show');
+    }
+}

--- a/app/Http/Requests/Widgets/StageSafety/CurrentWindIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/CurrentWindIndexRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Widgets\StageSafety;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CurrentWindIndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('stage-safety.monitoring.view');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Widgets/StageSafety/SensorHealthIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/SensorHealthIndexRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Widgets\StageSafety;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SensorHealthIndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('stage-safety.monitoring.view');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Widgets/StageSafety/WindHistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/WindHistoryIndexRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Widgets\StageSafety;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\Validator;
+
+class WindHistoryIndexRequest extends FormRequest
+{
+    public const int MAX_RANGE_HOURS = 24;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('stage-safety.monitoring.view');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
+            'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if ($validator->errors()->isNotEmpty()) {
+                return;
+            }
+
+            [$from, $to] = $this->range();
+
+            if ($from->diffInSeconds($to, false) > self::MAX_RANGE_HOURS * 3600) {
+                $validator->errors()->add('to', 'The time range must not exceed '.self::MAX_RANGE_HOURS.' hours.');
+            }
+        }];
+    }
+
+    /**
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    public function range(): array
+    {
+        $now = Date::now();
+        $from = $this->validated('from');
+        $to = $this->validated('to');
+
+        return [
+            is_string($from) ? Date::parse($from) : $now->copy()->subHour(),
+            is_string($to) ? Date::parse($to) : $now,
+        ];
+    }
+}

--- a/app/Models/StageSafety/Sensor.php
+++ b/app/Models/StageSafety/Sensor.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Models\StageSafety;
 
+use App\Enums\StageSafety\ReadingKind;
 use App\Models\Organization;
 use Database\Factories\StageSafety\SensorFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
@@ -26,6 +29,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $location
  * @property int $stale_after_seconds
  * @property Carbon|null $archived_at
+ * @property-read Reading|null $latestWindAverage
+ * @property-read Reading|null $latestWindGust
  */
 #[Fillable([
     'organization_id',
@@ -68,6 +73,30 @@ class Sensor extends Model
     public function readings(): HasMany
     {
         return $this->hasMany(Reading::class);
+    }
+
+    /**
+     * @return HasOne<Reading, $this>
+     */
+    public function latestWindAverage(): HasOne
+    {
+        return $this->hasOne(Reading::class)
+            ->ofMany([
+                'observed_at' => 'max',
+                'id' => 'max',
+            ], fn (Builder $query): Builder => $query->where('kind', ReadingKind::WindAverage->value));
+    }
+
+    /**
+     * @return HasOne<Reading, $this>
+     */
+    public function latestWindGust(): HasOne
+    {
+        return $this->hasOne(Reading::class)
+            ->ofMany([
+                'observed_at' => 'max',
+                'id' => 'max',
+            ], fn (Builder $query): Builder => $query->where('kind', ReadingKind::WindGust->value));
     }
 
     /**

--- a/app/Services/StageSafety/MonitoringService.php
+++ b/app/Services/StageSafety/MonitoringService.php
@@ -9,6 +9,7 @@ use App\Models\Organization;
 use App\Models\StageSafety\Reading;
 use App\Models\StageSafety\Sensor;
 use Carbon\CarbonInterface;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -111,6 +112,43 @@ class MonitoringService
             'from' => $from->toIso8601String(),
             'to' => $to->toIso8601String(),
             'sensors' => $sensors,
+        ];
+    }
+
+    /**
+     * @return array{generated_at: string, current: array<string, mixed>, history: array<string, mixed>}
+     */
+    public function sensorMonitoring(Organization $organization, Sensor $sensor, CarbonInterface $from, CarbonInterface $to): array
+    {
+        throw_if(
+            $sensor->organization_id !== $organization->id,
+            AuthorizationException::class,
+            'You are not authorized to monitor this sensor.',
+        );
+
+        $now = Date::now();
+        $sensor->loadMissing(['latestWindAverage', 'latestWindGust']);
+        $readings = $sensor->readings()
+            ->whereBetween('observed_at', [$from, $to])
+            ->oldest('observed_at')
+            ->orderBy('kind')
+            ->get()
+            ->map(fn (Reading $reading): array => $this->historyReadingPayload($reading))
+            ->values()
+            ->all();
+
+        return [
+            'generated_at' => $now->toIso8601String(),
+            'current' => $this->currentSensorPayload($sensor, $now),
+            'history' => [
+                'generated_at' => $now->toIso8601String(),
+                'from' => $from->toIso8601String(),
+                'to' => $to->toIso8601String(),
+                'sensors' => [[
+                    'sensor' => $this->sensorPayload($sensor),
+                    'readings' => array_values($readings),
+                ]],
+            ],
         ];
     }
 

--- a/app/Services/StageSafety/MonitoringService.php
+++ b/app/Services/StageSafety/MonitoringService.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\StageSafety;
+
+use App\Enums\StageSafety\SensorHealthStatus;
+use App\Models\Organization;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Date;
+
+class MonitoringService
+{
+    /**
+     * @return array{generated_at: string, sensors: list<array<string, mixed>>}
+     */
+    public function currentWind(Organization $organization): array
+    {
+        $now = Date::now();
+        $sensors = array_values($this->activeSensorsWithLatestReadings($organization)
+            ->filter(fn (Sensor $sensor): bool => $this->status($sensor, $now) === SensorHealthStatus::Fresh)
+            ->map(fn (Sensor $sensor): array => $this->currentSensorPayload($sensor, $now))
+            ->values()
+            ->all());
+
+        return [
+            'generated_at' => $now->toIso8601String(),
+            'sensors' => $sensors,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     generated_at: string,
+     *     total: int,
+     *     all_fresh: bool,
+     *     fresh: list<array<string, mixed>>,
+     *     stale: list<array<string, mixed>>,
+     *     never_seen: list<array<string, mixed>>
+     * }
+     */
+    public function sensorHealth(Organization $organization): array
+    {
+        $now = Date::now();
+        $groups = [
+            SensorHealthStatus::Fresh->value => [],
+            SensorHealthStatus::Stale->value => [],
+            SensorHealthStatus::NeverSeen->value => [],
+        ];
+
+        foreach ($this->activeSensorsWithLatestReadings($organization) as $sensor) {
+            $status = $this->status($sensor, $now);
+            $groups[$status->value][] = [
+                ...$this->sensorPayload($sensor),
+                'status' => $status->value,
+                'latest_observed_at' => $this->latestObservedAt($sensor)?->toIso8601String(),
+            ];
+        }
+
+        $total = array_sum(array_map(count(...), $groups));
+
+        return [
+            'generated_at' => $now->toIso8601String(),
+            'total' => $total,
+            'all_fresh' => $total > 0 && count($groups[SensorHealthStatus::Fresh->value]) === $total,
+            'fresh' => $groups[SensorHealthStatus::Fresh->value],
+            'stale' => $groups[SensorHealthStatus::Stale->value],
+            'never_seen' => $groups[SensorHealthStatus::NeverSeen->value],
+        ];
+    }
+
+    /**
+     * @return array{
+     *     generated_at: string,
+     *     from: string,
+     *     to: string,
+     *     sensors: list<array{sensor: array<string, mixed>, readings: list<array<string, mixed>>}>
+     * }
+     */
+    public function windHistory(Organization $organization, CarbonInterface $from, CarbonInterface $to): array
+    {
+        $sensors = array_values($organization->stageSafetySensors()
+            ->whereNull('archived_at')
+            ->whereHas('readings', fn (Builder $query): Builder => $query
+                ->whereBetween('observed_at', [$from, $to]))
+            ->with(['readings' => function (Relation $relation) use ($from, $to): void {
+                $relation->getQuery()
+                    ->whereBetween('observed_at', [$from, $to])
+                    ->oldest('observed_at')
+                    ->orderBy('kind');
+            }])
+            ->orderBy('id')
+            ->get()
+            ->map(fn (Sensor $sensor): array => [
+                'sensor' => $this->sensorPayload($sensor),
+                'readings' => array_values($sensor->readings
+                    ->map(fn (Reading $reading): array => $this->historyReadingPayload($reading))
+                    ->values()
+                    ->all()),
+            ])
+            ->values()
+            ->all());
+
+        return [
+            'generated_at' => Date::now()->toIso8601String(),
+            'from' => $from->toIso8601String(),
+            'to' => $to->toIso8601String(),
+            'sensors' => $sensors,
+        ];
+    }
+
+    public function status(Sensor $sensor, ?CarbonInterface $now = null): SensorHealthStatus
+    {
+        if ($sensor->archived_at !== null) {
+            return SensorHealthStatus::Archived;
+        }
+
+        $sensor->loadMissing(['latestWindAverage', 'latestWindGust']);
+        $latestObservedAt = $this->latestObservedAt($sensor);
+
+        if (! $latestObservedAt instanceof CarbonInterface) {
+            return SensorHealthStatus::NeverSeen;
+        }
+
+        $now ??= Date::now();
+
+        return $this->isFresh($latestObservedAt, $sensor, $now)
+            ? SensorHealthStatus::Fresh
+            : SensorHealthStatus::Stale;
+    }
+
+    /**
+     * @return Collection<int, Sensor>
+     */
+    protected function activeSensorsWithLatestReadings(Organization $organization): Collection
+    {
+        return $organization->stageSafetySensors()
+            ->whereNull('archived_at')
+            ->with(['latestWindAverage', 'latestWindGust'])
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function currentSensorPayload(Sensor $sensor, CarbonInterface $now): array
+    {
+        return [
+            'sensor' => $this->sensorPayload($sensor),
+            'status' => $this->status($sensor, $now)->value,
+            'latest_observed_at' => $this->latestObservedAt($sensor)?->toIso8601String(),
+            'wind_average' => $this->currentReadingPayload($sensor, $sensor->latestWindAverage, $now),
+            'wind_gust' => $this->currentReadingPayload($sensor, $sensor->latestWindGust, $now),
+        ];
+    }
+
+    /**
+     * @return array{id: int, identifier: string, name: string|null, location: string|null, stale_after_seconds: int}
+     */
+    protected function sensorPayload(Sensor $sensor): array
+    {
+        return [
+            'id' => $sensor->id,
+            'identifier' => $sensor->identifier,
+            'name' => $sensor->name,
+            'location' => $sensor->location,
+            'stale_after_seconds' => $sensor->stale_after_seconds,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function currentReadingPayload(Sensor $sensor, ?Reading $reading, CarbonInterface $now): ?array
+    {
+        if (! $reading instanceof Reading) {
+            return null;
+        }
+
+        $status = $this->isFresh($reading->observed_at, $sensor, $now)
+            ? SensorHealthStatus::Fresh
+            : SensorHealthStatus::Stale;
+
+        return [
+            ...$this->historyReadingPayload($reading),
+            'status' => $status->value,
+            'received_at' => $reading->received_at->toIso8601String(),
+            'receipt_delay_seconds' => (int) $reading->observed_at->diffInSeconds($reading->received_at, false),
+        ];
+    }
+
+    /**
+     * @return array{kind: string, value: float, unit: string, observed_at: string, window_seconds: int|null}
+     */
+    protected function historyReadingPayload(Reading $reading): array
+    {
+        return [
+            'kind' => $reading->kind->value,
+            'value' => $reading->value,
+            'unit' => $reading->unit,
+            'observed_at' => $reading->observed_at->toIso8601String(),
+            'window_seconds' => $reading->window_seconds,
+        ];
+    }
+
+    protected function latestObservedAt(Sensor $sensor): ?CarbonInterface
+    {
+        $averageObservedAt = $sensor->latestWindAverage?->observed_at;
+        $gustObservedAt = $sensor->latestWindGust?->observed_at;
+
+        if ($averageObservedAt === null) {
+            return $gustObservedAt;
+        }
+
+        if ($gustObservedAt === null) {
+            return $averageObservedAt;
+        }
+
+        return $averageObservedAt->getTimestamp() >= $gustObservedAt->getTimestamp()
+            ? $averageObservedAt
+            : $gustObservedAt;
+    }
+
+    protected function isFresh(CarbonInterface $observedAt, Sensor $sensor, CarbonInterface $now): bool
+    {
+        $observedTimestamp = $observedAt->getTimestamp();
+        $nowTimestamp = $now->getTimestamp();
+
+        return $observedTimestamp <= $nowTimestamp
+            && $observedTimestamp >= $nowTimestamp - $sensor->stale_after_seconds;
+    }
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -19,7 +19,7 @@ class UserService
      */
     public function availableOrganizationRoles(): array
     {
-        $roleNames = ['PeopleCountViewer', 'OrganizationAdmin'];
+        $roleNames = ['PeopleCountViewer', 'StageSafetyViewer', 'OrganizationAdmin'];
         $roles = Role::query()
             ->whereIn('name', $roleNames)
             ->get(['name', 'display_name', 'description'])

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -49,6 +49,7 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::findOrCreate('peoplecount.widgets.sensor_health');
         Permission::findOrCreate('peoplecount.widgets.most_active_sensors');
         Permission::findOrCreate('peoplecount.widgets.area_count_history');
+        Permission::findOrCreate('stage-safety.monitoring.view');
 
         // add admin package permissions
         Permission::findOrCreate('admin.logs');
@@ -74,6 +75,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.area_resets.*',
             'peoplecount.alerts.*',
             'stage-safety.sensors.*',
+            'stage-safety.monitoring.view',
             'peoplecount.widgets.active_area_counts',
             'peoplecount.widgets.sensor_health',
             'peoplecount.widgets.most_active_sensors',
@@ -90,6 +92,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.area_resets.*',
             'peoplecount.alerts.*',
             'stage-safety.sensors.*',
+            'stage-safety.monitoring.view',
             'peoplecount.widgets.active_area_counts',
             'peoplecount.widgets.sensor_health',
             'peoplecount.widgets.most_active_sensors',
@@ -106,6 +109,13 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.widgets.sensor_health',
             'peoplecount.widgets.most_active_sensors',
             'peoplecount.widgets.area_count_history',
+        ]);
+
+        $stageSafetyViewerRole = $this->role('StageSafetyViewer', 'Stage Safety viewer', 'Can view Stage Safety monitoring data.');
+        $stageSafetyViewerRole->syncPermissions([
+            'stage-safety.sensors.index',
+            'stage-safety.sensors.show',
+            'stage-safety.monitoring.view',
         ]);
     }
 

--- a/resources/js/components/stage-safety/CurrentWindDisplay.vue
+++ b/resources/js/components/stage-safety/CurrentWindDisplay.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { Badge } from '@/components/ui/badge';
+import type { StageSafetyCurrentReading, StageSafetyCurrentSensor } from '@/types';
+import { getRelativeTime } from '@/utils/dateTimeHelpers';
+import { formatWindSpeed } from '@/utils/stageSafety';
+import { Wind } from 'lucide-vue-next';
+
+defineProps<{
+    sensors: StageSafetyCurrentSensor[];
+}>();
+
+function sensorName(item: StageSafetyCurrentSensor): string {
+    return item.sensor.name || item.sensor.identifier;
+}
+
+function readingLabel(label: string, reading: StageSafetyCurrentReading | null, sensorStatus: StageSafetyCurrentSensor['status']): string {
+    return sensorStatus === 'fresh' && reading?.status === 'fresh' ? label : `Last known ${label.toLowerCase()}`;
+}
+
+function statusVariant(status: StageSafetyCurrentSensor['status']): 'default' | 'secondary' | 'destructive' | 'outline' {
+    if (status === 'fresh') return 'default';
+    if (status === 'stale') return 'destructive';
+    if (status === 'archived') return 'outline';
+    return 'secondary';
+}
+</script>
+
+<template>
+    <div class="grid gap-4" :class="sensors.length > 1 ? 'xl:grid-cols-2' : ''">
+        <article v-for="item in sensors" :key="item.sensor.id" class="bg-muted/25 rounded-xl border p-4 sm:p-6">
+            <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <h3 class="truncate font-semibold">{{ sensorName(item) }}</h3>
+                        <Badge :variant="statusVariant(item.status)">{{ item.status.replace('_', ' ') }}</Badge>
+                    </div>
+                    <p class="text-muted-foreground mt-1 truncate text-sm">
+                        {{ item.sensor.location || item.sensor.identifier }}
+                    </p>
+                </div>
+                <Wind class="text-primary size-6 shrink-0" aria-hidden="true" />
+            </div>
+
+            <div class="mt-6 grid grid-cols-2 divide-x">
+                <div class="pr-4 text-center">
+                    <p class="text-primary text-4xl font-semibold tracking-tight sm:text-5xl">
+                        {{ item.wind_average ? formatWindSpeed(item.wind_average.value) : '—' }}
+                        <span v-if="item.wind_average" class="text-lg font-medium">km/h</span>
+                    </p>
+                    <p class="text-muted-foreground mt-2 text-sm">{{ readingLabel('Average', item.wind_average, item.status) }}</p>
+                </div>
+                <div class="pl-4 text-center">
+                    <p class="text-3xl font-semibold tracking-tight sm:text-4xl">
+                        {{ item.wind_gust ? formatWindSpeed(item.wind_gust.value) : '—' }}
+                        <span v-if="item.wind_gust" class="text-base font-medium">km/h</span>
+                    </p>
+                    <p class="text-muted-foreground mt-2 text-sm">{{ readingLabel('Gust', item.wind_gust, item.status) }}</p>
+                    <p v-if="item.wind_gust?.window_seconds" class="text-muted-foreground mt-1 text-xs">
+                        {{ item.wind_gust.window_seconds }} second period
+                    </p>
+                </div>
+            </div>
+
+            <p class="text-muted-foreground mt-5 text-right text-xs">
+                {{ item.latest_observed_at ? `Observed ${getRelativeTime(new Date(item.latest_observed_at))}` : 'Never observed' }}
+            </p>
+        </article>
+    </div>
+</template>

--- a/resources/js/components/stage-safety/CurrentWindWidget.vue
+++ b/resources/js/components/stage-safety/CurrentWindWidget.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import CurrentWindDisplay from '@/components/stage-safety/CurrentWindDisplay.vue';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { Organization, StageSafetyCurrentWindPayload } from '@/types';
+import { useHttp } from '@inertiajs/vue3';
+import { useIntervalFn } from '@vueuse/core';
+import { ref } from 'vue';
+
+const props = defineProps<{ organization: Organization }>();
+const request = useHttp<Record<string, never>, StageSafetyCurrentWindPayload>({});
+const data = ref<StageSafetyCurrentWindPayload | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+async function fetchCurrentWind(): Promise<void> {
+    if (request.processing) return;
+
+    try {
+        error.value = null;
+        data.value = await request.get(route('stage-safety.current-wind.index', { organization: props.organization.slug }));
+    } catch {
+        error.value = 'Failed to load current wind.';
+    } finally {
+        loading.value = false;
+    }
+}
+
+useIntervalFn(fetchCurrentWind, 10_000, { immediateCallback: true });
+</script>
+
+<template>
+    <Card class="flex h-full flex-col lg:col-span-2">
+        <CardHeader>
+            <CardTitle>Current Wind</CardTitle>
+        </CardHeader>
+        <CardContent class="flex flex-1 flex-col">
+            <div
+                v-if="error"
+                role="alert"
+                class="mb-4 rounded-md bg-red-50 p-2 text-center text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400"
+            >
+                {{ error }}
+            </div>
+            <div v-if="loading && !data" class="grid gap-4 sm:grid-cols-2">
+                <Skeleton class="h-48 w-full rounded-xl" />
+                <Skeleton class="hidden h-48 w-full rounded-xl sm:block" />
+            </div>
+            <div v-else-if="!data?.sensors.length" class="text-muted-foreground flex min-h-48 items-center justify-center text-center">
+                No sensors currently report fresh wind data.
+            </div>
+            <CurrentWindDisplay v-else :sensors="data.sensors" />
+        </CardContent>
+    </Card>
+</template>

--- a/resources/js/components/stage-safety/SensorHealthWidget.vue
+++ b/resources/js/components/stage-safety/SensorHealthWidget.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { Organization, StageSafetyHealthSensor, StageSafetySensorHealthPayload } from '@/types';
+import { getRelativeTime } from '@/utils/dateTimeHelpers';
+import { useHttp } from '@inertiajs/vue3';
+import { useIntervalFn } from '@vueuse/core';
+import { CircleCheck, CircleHelp, TriangleAlert } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+const props = defineProps<{ organization: Organization }>();
+const request = useHttp<Record<string, never>, StageSafetySensorHealthPayload>({});
+const data = ref<StageSafetySensorHealthPayload | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+const issues = computed(() => [...(data.value?.stale ?? []), ...(data.value?.never_seen ?? [])]);
+
+async function fetchHealth(): Promise<void> {
+    if (request.processing) return;
+
+    try {
+        error.value = null;
+        data.value = await request.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
+    } catch {
+        error.value = 'Failed to load sensor health.';
+    } finally {
+        loading.value = false;
+    }
+}
+
+function sensorName(sensor: StageSafetyHealthSensor): string {
+    return sensor.name || sensor.identifier;
+}
+
+useIntervalFn(fetchHealth, 10_000, { immediateCallback: true });
+</script>
+
+<template>
+    <Card class="flex h-full flex-col">
+        <CardHeader class="flex flex-row items-center justify-between gap-3 space-y-0">
+            <CardTitle>Sensor Health</CardTitle>
+            <Badge v-if="data?.all_fresh" class="bg-green-600 hover:bg-green-600">Good</Badge>
+            <Badge v-else-if="data?.total" variant="destructive">Attention</Badge>
+        </CardHeader>
+        <CardContent class="flex flex-1 flex-col">
+            <div
+                v-if="error"
+                role="alert"
+                class="mb-4 rounded-md bg-red-50 p-2 text-center text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400"
+            >
+                {{ error }}
+            </div>
+            <div v-if="loading && !data" class="space-y-3">
+                <Skeleton class="h-10 w-full" />
+                <Skeleton class="h-16 w-full" />
+                <Skeleton class="h-16 w-full" />
+            </div>
+            <div v-else-if="!data?.total" class="text-muted-foreground flex min-h-48 items-center justify-center text-center">
+                No active Stage Safety sensors configured.
+            </div>
+            <div v-else class="flex flex-1 flex-col gap-4">
+                <div class="grid grid-cols-3 gap-2 text-center">
+                    <div class="rounded-lg border p-2">
+                        <p class="text-xl font-semibold text-green-600 dark:text-green-400">{{ data.fresh.length }}</p>
+                        <p class="text-muted-foreground text-xs">Fresh</p>
+                    </div>
+                    <div class="rounded-lg border p-2">
+                        <p class="text-destructive text-xl font-semibold">{{ data.stale.length }}</p>
+                        <p class="text-muted-foreground text-xs">Stale</p>
+                    </div>
+                    <div class="rounded-lg border p-2">
+                        <p class="text-xl font-semibold">{{ data.never_seen.length }}</p>
+                        <p class="text-muted-foreground text-xs">Never seen</p>
+                    </div>
+                </div>
+
+                <div v-if="data.all_fresh" class="flex flex-1 items-center justify-center gap-2 text-sm text-green-700 dark:text-green-400">
+                    <CircleCheck class="size-5" />
+                    All sensors report fresh data
+                </div>
+
+                <ul v-else class="divide-y rounded-lg border">
+                    <li v-for="sensor in issues" :key="sensor.id" class="flex items-center gap-3 p-3 text-sm">
+                        <TriangleAlert v-if="sensor.status === 'stale'" class="text-destructive size-4 shrink-0" />
+                        <CircleHelp v-else class="text-muted-foreground size-4 shrink-0" />
+                        <div class="min-w-0 flex-1">
+                            <p class="truncate font-medium">{{ sensorName(sensor) }}</p>
+                            <p class="text-muted-foreground text-xs">
+                                {{
+                                    sensor.latest_observed_at ? `Observed ${getRelativeTime(new Date(sensor.latest_observed_at))}` : 'Never observed'
+                                }}
+                            </p>
+                        </div>
+                        <Badge :variant="sensor.status === 'stale' ? 'destructive' : 'secondary'">{{ sensor.status.replace('_', ' ') }}</Badge>
+                    </li>
+                </ul>
+            </div>
+        </CardContent>
+    </Card>
+</template>

--- a/resources/js/components/stage-safety/WindHistoryChart.vue
+++ b/resources/js/components/stage-safety/WindHistoryChart.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, componentToString, type ChartConfig } from '@/components/ui/chart';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { StageSafetyReadingKind, StageSafetyWindHistoryPayload } from '@/types';
+import { metersPerSecondToKilometersPerHour } from '@/utils/stageSafety';
+import { CurveType } from '@unovis/ts';
+import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { computed } from 'vue';
+
+interface ChartDataPoint {
+    date: Date;
+    [key: string]: Date | number | undefined;
+}
+
+interface ChartSeries {
+    key: string;
+    label: string;
+    color: string;
+    dash?: number[];
+    data: SeriesPoint[];
+}
+
+interface SeriesPoint {
+    date: Date;
+    value: number;
+}
+
+const props = defineProps<{
+    data: StageSafetyWindHistoryPayload | null;
+    loading: boolean;
+    error: string | null;
+    timeRange: string;
+}>();
+
+const emit = defineEmits<{
+    'update:timeRange': [value: string];
+}>();
+
+const SENSOR_COLORS = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
+const timeRangeOptions = [
+    { value: '1h', label: 'Last hour' },
+    { value: '3h', label: 'Last 3 hours' },
+    { value: '6h', label: 'Last 6 hours' },
+    { value: '12h', label: 'Last 12 hours' },
+    { value: '24h', label: 'Last 24 hours' },
+];
+
+const selectedRange = computed({
+    get: () => props.timeRange,
+    set: (value: string) => emit('update:timeRange', value),
+});
+
+function sensorName(sensor: StageSafetyWindHistoryPayload['sensors'][number]['sensor']): string {
+    return sensor.name || sensor.identifier;
+}
+
+function seriesKey(sensorId: number, kind: StageSafetyReadingKind): string {
+    return `sensor_${sensorId}_${kind}`;
+}
+
+const chartSeries = computed<ChartSeries[]>(() =>
+    (props.data?.sensors ?? []).flatMap((item, index) => {
+        const color = SENSOR_COLORS[index % SENSOR_COLORS.length];
+        const series: ChartSeries[] = [];
+        const readings = (kind: StageSafetyReadingKind): SeriesPoint[] =>
+            item.readings
+                .filter((reading) => reading.kind === kind)
+                .map((reading) => ({
+                    date: new Date(reading.observed_at),
+                    value: metersPerSecondToKilometersPerHour(reading.value),
+                }));
+        const averageReadings = readings('wind_average');
+        const gustReadings = readings('wind_gust');
+
+        if (averageReadings.length) {
+            series.push({
+                key: seriesKey(item.sensor.id, 'wind_average'),
+                label: `${sensorName(item.sensor)} average`,
+                color,
+                data: averageReadings,
+            });
+        }
+        if (gustReadings.length) {
+            series.push({
+                key: seriesKey(item.sensor.id, 'wind_gust'),
+                label: `${sensorName(item.sensor)} gust`,
+                color,
+                dash: [6, 3],
+                data: gustReadings,
+            });
+        }
+
+        return series;
+    }),
+);
+
+const chartConfig = computed<ChartConfig>(() =>
+    Object.fromEntries(chartSeries.value.map((series) => [series.key, { label: series.label, color: series.color }])),
+);
+
+const chartData = computed<ChartDataPoint[]>(() => {
+    const buckets = new Map<number, ChartDataPoint>();
+
+    for (const item of props.data?.sensors ?? []) {
+        for (const reading of item.readings) {
+            const timestamp = new Date(reading.observed_at).getTime();
+            const row = buckets.get(timestamp) ?? { date: new Date(timestamp) };
+            row[seriesKey(item.sensor.id, reading.kind)] = metersPerSecondToKilometersPerHour(reading.value);
+            buckets.set(timestamp, row);
+        }
+    }
+
+    return Array.from(buckets.values()).sort((left, right) => left.date.getTime() - right.date.getTime());
+});
+
+const hasData = computed(() => chartData.value.length > 0);
+const seriesColors = computed(() => chartSeries.value.map((series) => series.color));
+
+function formatTickDate(value: number): string {
+    return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+</script>
+
+<template>
+    <Card class="col-span-full flex min-w-0 flex-col">
+        <CardHeader class="flex flex-col gap-3 pb-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
+            <div>
+                <CardTitle>Wind History</CardTitle>
+                <p class="text-muted-foreground mt-1 text-sm">Average and gust speed in km/h</p>
+            </div>
+            <Select v-model="selectedRange">
+                <SelectTrigger class="w-full sm:w-[160px]">
+                    <SelectValue placeholder="Select range" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem v-for="option in timeRangeOptions" :key="option.value" :value="option.value">
+                        {{ option.label }}
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+        </CardHeader>
+        <CardContent class="flex min-w-0 flex-1 flex-col">
+            <div
+                v-if="error"
+                role="alert"
+                class="mb-4 rounded-md bg-red-50 p-2 text-center text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400"
+            >
+                {{ error }}
+            </div>
+
+            <div v-if="loading && !hasData" class="flex h-[280px] items-center justify-center sm:h-[350px]">
+                <Skeleton class="h-full w-full" />
+            </div>
+
+            <div v-else-if="!hasData" class="text-muted-foreground flex h-[280px] items-center justify-center text-center sm:h-[350px]">
+                No wind readings for selected time range.
+            </div>
+
+            <div v-else class="flex flex-1 flex-col">
+                <p class="sr-only" aria-live="polite">
+                    Wind history chart with {{ chartSeries.length }} series across {{ data?.sensors.length ?? 0 }} sensors.
+                </p>
+                <ChartContainer
+                    :config="chartConfig"
+                    class="h-[280px] w-full min-w-0 sm:h-[350px]"
+                    role="img"
+                    aria-label="Wind history in kilometers per hour"
+                >
+                    <VisXYContainer :data="chartData" :margin="{ top: 8, right: 8, bottom: 24, left: 38 }">
+                        <VisLine
+                            v-for="series in chartSeries"
+                            :key="series.key"
+                            :data="series.data"
+                            :x="(point: SeriesPoint) => point.date.getTime()"
+                            :y="(point: SeriesPoint) => point.value"
+                            :color="series.color"
+                            :curve-type="CurveType.MonotoneX"
+                            :line-width="2"
+                            :line-dash-array="series.dash"
+                        />
+                        <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
+                        <VisAxis
+                            type="y"
+                            :tick-line="false"
+                            :domain-line="false"
+                            :grid-line="true"
+                            :tick-format="(value: number) => Math.round(value).toString()"
+                        />
+                        <ChartTooltip />
+                        <ChartCrosshair
+                            :template="
+                                componentToString(chartConfig, ChartTooltipContent, {
+                                    indicator: 'line',
+                                    labelFormatter: (value: number | Date) =>
+                                        new Date(typeof value === 'number' ? value : value.getTime()).toLocaleString([], {
+                                            month: 'short',
+                                            day: 'numeric',
+                                            hour: '2-digit',
+                                            minute: '2-digit',
+                                        }),
+                                })
+                            "
+                            :color="seriesColors"
+                        />
+                    </VisXYContainer>
+                </ChartContainer>
+
+                <div class="mt-4 flex flex-wrap gap-x-5 gap-y-2 border-t pt-3 text-sm">
+                    <div v-for="series in chartSeries" :key="`legend-${series.key}`" class="flex items-center gap-2">
+                        <svg width="24" height="8" :style="{ color: series.color }" aria-hidden="true">
+                            <line
+                                x1="0"
+                                y1="4"
+                                x2="24"
+                                y2="4"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                :stroke-dasharray="series.dash?.join(',') ?? 'none'"
+                            />
+                        </svg>
+                        <span>{{ series.label }}</span>
+                    </div>
+                </div>
+            </div>
+        </CardContent>
+    </Card>
+</template>

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import WindHistoryChart from '@/components/stage-safety/WindHistoryChart.vue';
+import type { Organization, StageSafetyWindHistoryPayload } from '@/types';
+import { useHttp } from '@inertiajs/vue3';
+import { useIntervalFn } from '@vueuse/core';
+import { ref, watch } from 'vue';
+
+const props = defineProps<{ organization: Organization }>();
+const request = useHttp<{ from: string; to: string }, StageSafetyWindHistoryPayload>({ from: '', to: '' });
+const data = ref<StageSafetyWindHistoryPayload | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const timeRange = ref('1h');
+let refreshQueued = false;
+
+function timeParams(): { from: string; to: string } {
+    const to = new Date();
+    const from = new Date(to.getTime() - Number.parseInt(timeRange.value) * 60 * 60 * 1000);
+    return { from: from.toISOString(), to: to.toISOString() };
+}
+
+async function fetchHistory(): Promise<void> {
+    if (request.processing) {
+        refreshQueued = true;
+        return;
+    }
+
+    const requestedRange = timeRange.value;
+    Object.assign(request, timeParams());
+
+    try {
+        error.value = null;
+        const response = await request.get(route('stage-safety.wind-history.index', { organization: props.organization.slug }));
+        if (requestedRange === timeRange.value) data.value = response;
+    } catch {
+        error.value = 'Failed to load wind history.';
+    } finally {
+        loading.value = false;
+        if (refreshQueued) {
+            refreshQueued = false;
+            void fetchHistory();
+        }
+    }
+}
+
+watch(timeRange, () => {
+    data.value = null;
+    loading.value = true;
+    void fetchHistory();
+});
+
+useIntervalFn(fetchHistory, 30_000, { immediateCallback: true });
+</script>
+
+<template>
+    <WindHistoryChart v-model:time-range="timeRange" :data="data" :loading="loading" :error="error" />
+</template>

--- a/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
+++ b/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import CurrentWindDisplay from '../CurrentWindDisplay.vue';
+
+describe('CurrentWindDisplay', () => {
+    it('renders multiple sensors in km/h and labels stale readings as last known', () => {
+        const wrapper = mount(CurrentWindDisplay, {
+            props: {
+                sensors: [
+                    {
+                        sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: 'Roof', stale_after_seconds: 300 },
+                        status: 'archived',
+                        latest_observed_at: '2026-07-25T11:59:00Z',
+                        wind_average: {
+                            kind: 'wind_average',
+                            value: 5,
+                            unit: 'm/s',
+                            status: 'fresh',
+                            observed_at: '2026-07-25T11:59:00Z',
+                            received_at: '2026-07-25T11:59:01Z',
+                            receipt_delay_seconds: 1,
+                            window_seconds: 10,
+                        },
+                        wind_gust: null,
+                    },
+                    {
+                        sensor: { id: 2, identifier: 'DEF456', name: 'Town Hall', location: null, stale_after_seconds: 300 },
+                        status: 'fresh',
+                        latest_observed_at: '2026-07-25T11:59:30Z',
+                        wind_average: null,
+                        wind_gust: {
+                            kind: 'wind_gust',
+                            value: 8.0556,
+                            unit: 'm/s',
+                            status: 'stale',
+                            observed_at: '2026-07-25T11:50:00Z',
+                            received_at: '2026-07-25T11:50:01Z',
+                            receipt_delay_seconds: 1,
+                            window_seconds: 10,
+                        },
+                    },
+                ],
+            },
+        });
+
+        expect(wrapper.text()).toContain('Main Stage');
+        expect(wrapper.text()).toContain('Town Hall');
+        expect(wrapper.text()).toContain('18');
+        expect(wrapper.text()).toContain('29');
+        expect(wrapper.text()).toContain('Last known average');
+        expect(wrapper.text()).toContain('Last known gust');
+    });
+});

--- a/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
+++ b/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
@@ -1,0 +1,148 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CurrentWindWidget from '../CurrentWindWidget.vue';
+import SensorHealthWidget from '../SensorHealthWidget.vue';
+import WindHistoryWidget from '../WindHistoryWidget.vue';
+
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn(), from: '', to: '' },
+    useIntervalFn: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
+}));
+
+vi.mock('@vueuse/core', () => ({
+    useIntervalFn: mocks.useIntervalFn,
+}));
+
+const organization = { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' };
+
+describe('Stage Safety monitoring widgets', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+        mocks.request.processing = false;
+        mocks.request.from = '';
+        mocks.request.to = '';
+        mocks.request.get = mocks.get;
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
+        mocks.useIntervalFn.mockImplementation((callback: () => Promise<void>) => {
+            void callback();
+            return { pause: vi.fn(), resume: vi.fn(), isActive: true };
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('loads current wind through its endpoint every ten seconds', async () => {
+        mocks.get.mockResolvedValue({ generated_at: '', sensors: [] });
+        const wrapper = mount(CurrentWindWidget, { props: { organization } });
+        await flushPromises();
+
+        expect(mocks.get).toHaveBeenCalledWith('stage-safety.current-wind.index');
+        expect(mocks.useIntervalFn).toHaveBeenCalledWith(expect.any(Function), 10_000, { immediateCallback: true });
+        expect(wrapper.text()).toContain('No sensors currently report fresh wind data');
+    });
+
+    it('does not overlap current wind requests', async () => {
+        mocks.request.processing = true;
+        mount(CurrentWindWidget, { props: { organization } });
+        await flushPromises();
+
+        expect(mocks.get).not.toHaveBeenCalled();
+    });
+
+    it('shows a current wind request error', async () => {
+        mocks.get.mockRejectedValue(new Error('network'));
+        const wrapper = mount(CurrentWindWidget, { props: { organization } });
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('Failed to load current wind');
+    });
+
+    it('loads and renders stale sensor health', async () => {
+        mocks.get.mockResolvedValue({
+            generated_at: '',
+            total: 1,
+            all_fresh: false,
+            fresh: [],
+            stale: [
+                {
+                    id: 1,
+                    identifier: 'ABC123',
+                    name: 'Main Stage',
+                    location: null,
+                    stale_after_seconds: 300,
+                    status: 'stale',
+                    latest_observed_at: '2026-07-25T11:00:00Z',
+                },
+            ],
+            never_seen: [],
+        });
+        const wrapper = mount(SensorHealthWidget, { props: { organization } });
+        await flushPromises();
+
+        expect(mocks.get).toHaveBeenCalledWith('stage-safety.sensor-health.index');
+        expect(mocks.useIntervalFn).toHaveBeenCalledWith(expect.any(Function), 10_000, { immediateCallback: true });
+        expect(wrapper.text()).toContain('Main Stage');
+        expect(wrapper.text()).toContain('stale');
+    });
+
+    it('loads bounded history independently every thirty seconds', async () => {
+        mocks.get.mockResolvedValue({
+            generated_at: '',
+            from: '2026-07-25T11:00:00Z',
+            to: '2026-07-25T12:00:00Z',
+            sensors: [],
+        });
+        mount(WindHistoryWidget, {
+            props: { organization },
+            global: { stubs: { WindHistoryChart: true } },
+        });
+        await flushPromises();
+
+        expect(mocks.get).toHaveBeenCalledWith('stage-safety.wind-history.index');
+        expect(mocks.request.from).toBe('2026-07-25T11:00:00.000Z');
+        expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+        expect(mocks.useIntervalFn).toHaveBeenCalledWith(expect.any(Function), 30_000, { immediateCallback: true });
+    });
+
+    it('queues a changed history range while a request is active', async () => {
+        let resolveFirst!: (value: { generated_at: string; from: string; to: string; sensors: never[] }) => void;
+        mocks.get
+            .mockImplementationOnce(() => {
+                mocks.request.processing = true;
+                return new Promise((resolve) => {
+                    resolveFirst = resolve;
+                });
+            })
+            .mockResolvedValue({ generated_at: '', from: '', to: '', sensors: [] });
+        const wrapper = mount(WindHistoryWidget, {
+            props: { organization },
+            global: {
+                stubs: {
+                    WindHistoryChart: {
+                        emits: ['update:timeRange'],
+                        template: '<button data-testid="range" @click="$emit(\'update:timeRange\', \'6h\')">range</button>',
+                    },
+                },
+            },
+        });
+        await wrapper.find('[data-testid="range"]').trigger('click');
+        mocks.request.processing = false;
+        resolveFirst({ generated_at: '', from: '', to: '', sensors: [] });
+        await flushPromises();
+
+        expect(mocks.get).toHaveBeenCalledTimes(2);
+        expect(mocks.request.from).toBe('2026-07-25T06:00:00.000Z');
+    });
+});

--- a/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
@@ -1,0 +1,94 @@
+import type { StageSafetyWindHistoryPayload } from '@/types';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import WindHistoryChart from '../WindHistoryChart.vue';
+
+vi.mock('@unovis/vue', () => ({
+    VisXYContainer: { template: '<div><slot /></div>' },
+    VisLine: { props: ['data'], template: '<div class="series-line" :data-count="data.length" />' },
+    VisAxis: { template: '<div />' },
+    VisTooltip: { template: '<div />' },
+    VisCrosshair: { template: '<div />' },
+}));
+
+const chartStubs = {
+    Select: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template: '<select data-testid="range" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+    },
+    SelectTrigger: { template: '<div><slot /></div>' },
+    SelectValue: { template: '<div />' },
+    SelectContent: { template: '<div><slot /></div>' },
+    SelectItem: { props: ['value'], template: '<option :value="value"><slot /></option>' },
+    ChartContainer: { template: '<div><slot /></div>' },
+    ChartTooltip: { template: '<div />' },
+    ChartCrosshair: { template: '<div />' },
+};
+
+const history: StageSafetyWindHistoryPayload = {
+    generated_at: '2026-07-25T12:00:00Z',
+    from: '2026-07-25T11:00:00Z',
+    to: '2026-07-25T12:00:00Z',
+    sensors: [
+        {
+            sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: null, stale_after_seconds: 300 },
+            readings: [
+                { kind: 'wind_average', value: 5, unit: 'm/s', observed_at: '2026-07-25T11:30:00Z', window_seconds: 10 },
+                { kind: 'wind_average', value: 6, unit: 'm/s', observed_at: '2026-07-25T11:40:00Z', window_seconds: 10 },
+                { kind: 'wind_gust', value: 8, unit: 'm/s', observed_at: '2026-07-25T11:30:00Z', window_seconds: 10 },
+            ],
+        },
+        {
+            sensor: { id: 2, identifier: 'DEF456', name: null, location: null, stale_after_seconds: 300 },
+            readings: [{ kind: 'wind_average', value: 4, unit: 'm/s', observed_at: '2026-07-25T11:35:00Z', window_seconds: 10 }],
+        },
+    ],
+};
+
+describe('WindHistoryChart', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders one legend for all sensor average and gust series', () => {
+        const wrapper = mount(WindHistoryChart, {
+            props: { data: history, loading: false, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+
+        expect(wrapper.text()).toContain('Main Stage average');
+        expect(wrapper.text()).toContain('Main Stage gust');
+        expect(wrapper.text()).toContain('DEF456 average');
+        expect(wrapper.findAll('.series-line').map((line) => line.attributes('data-count'))).toEqual(['2', '1', '1']);
+    });
+
+    it('emits selected time range', async () => {
+        const wrapper = mount(WindHistoryChart, {
+            props: { data: history, loading: false, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+
+        await wrapper.find('[data-testid="range"]').setValue('6h');
+
+        expect(wrapper.emitted('update:timeRange')).toEqual([['6h']]);
+    });
+
+    it('renders useful loading and empty states', () => {
+        const loading = mount(WindHistoryChart, {
+            props: { data: null, loading: true, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+        const empty = mount(WindHistoryChart, {
+            props: { data: { ...history, sensors: [] }, loading: false, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+
+        expect(loading.find('.animate-pulse').exists()).toBe(true);
+        expect(empty.text()).toContain('No wind readings');
+    });
+});

--- a/resources/js/components/stage-safety/sensors/SensorsTable.vue
+++ b/resources/js/components/stage-safety/sensors/SensorsTable.vue
@@ -14,24 +14,17 @@ const props = defineProps<{
 
 const { can } = usePermissions();
 const columns = sensorColumns(props.organization);
+const rowHref = can('stage-safety.sensors.show')
+    ? (sensor: StageSafetySensor) =>
+          route('stage-safety.sensors.show', {
+              organization: props.organization.slug,
+              stageSafetySensor: sensor.id,
+          })
+    : undefined;
 </script>
 
 <template>
-    <DataTable
-        :columns="columns"
-        :data="sensors"
-        :row-href="
-            (sensor) =>
-                can('stage-safety.sensors.edit')
-                    ? route('stage-safety.sensors.edit', {
-                          organization: organization.slug,
-                          stageSafetySensor: sensor.id,
-                      })
-                    : null
-        "
-        filter-column="name"
-        search-placeholder="Search Stage Safety sensors..."
-    >
+    <DataTable :columns="columns" :data="sensors" :row-href="rowHref" filter-column="name" search-placeholder="Search Stage Safety sensors...">
         <template #actions>
             <Button v-if="can('stage-safety.sensors.create')" as-child size="sm">
                 <Link :href="route('stage-safety.sensors.create', { organization: organization.slug })">

--- a/resources/js/components/ui/chart/ChartTooltipContent.vue
+++ b/resources/js/components/ui/chart/ChartTooltipContent.vue
@@ -94,7 +94,7 @@ const tooltipLabel = computed(() => {
                 {{ itemConfig?.label || value }}
               </span>
             </div>
-            <span v-if="value" class="text-foreground font-mono font-medium tabular-nums">
+            <span v-if="value !== undefined && value !== null" class="text-foreground font-mono font-medium tabular-nums">
               {{ value.toLocaleString() }}
             </span>
           </div>

--- a/resources/js/pages/orgmgmt/Dashboard.vue
+++ b/resources/js/pages/orgmgmt/Dashboard.vue
@@ -3,6 +3,9 @@ import ActiveAreaCountsWidget from '@/components/peoplecount/ActiveAreaCountsWid
 import AreaCountHistoryWidget from '@/components/peoplecount/AreaCountHistoryWidget.vue';
 import MostActiveSensorsWidget from '@/components/peoplecount/MostActiveSensorsWidget.vue';
 import SensorHealthStatusWidget from '@/components/peoplecount/SensorHealthStatusWidget.vue';
+import CurrentWindWidget from '@/components/stage-safety/CurrentWindWidget.vue';
+import SensorHealthWidget from '@/components/stage-safety/SensorHealthWidget.vue';
+import WindHistoryWidget from '@/components/stage-safety/WindHistoryWidget.vue';
 import { usePermissions } from '@/composables/usePermissions';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
 import { type BreadcrumbItem, Organization } from '@/types';
@@ -14,6 +17,14 @@ const props = defineProps<{
 }>();
 
 const { can } = usePermissions();
+const canViewPeoplecountWidgets = computed(() =>
+    [
+        'peoplecount.widgets.active_area_counts',
+        'peoplecount.widgets.sensor_health',
+        'peoplecount.widgets.most_active_sensors',
+        'peoplecount.widgets.area_count_history',
+    ].some((permission) => can(permission)),
+);
 
 const breadcrumbs = computed((): BreadcrumbItem[] => [
     {
@@ -34,12 +45,24 @@ const breadcrumbs = computed((): BreadcrumbItem[] => [
             <div class="mb-4">
                 <h1 class="text-2xl font-bold">{{ props.organization.name }} Dashboard</h1>
             </div>
-            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                <ActiveAreaCountsWidget v-if="can('peoplecount.widgets.active_area_counts')" :organization="organization" />
-                <SensorHealthStatusWidget v-if="can('peoplecount.widgets.sensor_health')" :organization="organization" />
-                <MostActiveSensorsWidget v-if="can('peoplecount.widgets.most_active_sensors')" :organization="organization" />
-                <AreaCountHistoryWidget v-if="can('peoplecount.widgets.area_count_history')" :organization="organization" />
-            </div>
+            <section v-if="can('stage-safety.monitoring.view')" class="space-y-4">
+                <h2 class="text-lg font-semibold">Stage Safety</h2>
+                <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    <CurrentWindWidget :organization="organization" />
+                    <SensorHealthWidget :organization="organization" />
+                    <WindHistoryWidget :organization="organization" />
+                </div>
+            </section>
+
+            <section v-if="canViewPeoplecountWidgets" class="space-y-4">
+                <h2 class="text-lg font-semibold">People Count</h2>
+                <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    <ActiveAreaCountsWidget v-if="can('peoplecount.widgets.active_area_counts')" :organization="organization" />
+                    <SensorHealthStatusWidget v-if="can('peoplecount.widgets.sensor_health')" :organization="organization" />
+                    <MostActiveSensorsWidget v-if="can('peoplecount.widgets.most_active_sensors')" :organization="organization" />
+                    <AreaCountHistoryWidget v-if="can('peoplecount.widgets.area_count_history')" :organization="organization" />
+                </div>
+            </section>
         </div>
     </Layout>
 </template>

--- a/resources/js/pages/orgmgmt/_tests_/Dashboard.test.ts
+++ b/resources/js/pages/orgmgmt/_tests_/Dashboard.test.ts
@@ -1,0 +1,42 @@
+import { shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Dashboard from '../Dashboard.vue';
+
+const mocks = vi.hoisted(() => ({ can: vi.fn() }));
+
+vi.mock('@/composables/usePermissions', () => ({
+    usePermissions: () => ({ can: mocks.can }),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ Head: { template: '<div />' } }));
+
+describe('organization dashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not mount Stage Safety widgets without monitoring permission', () => {
+        mocks.can.mockReturnValue(false);
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(wrapper.text()).not.toContain('Stage Safety');
+        expect(wrapper.find('current-wind-widget-stub').exists()).toBe(false);
+    });
+
+    it('mounts all Stage Safety widgets with monitoring permission', () => {
+        mocks.can.mockImplementation((permission: string) => permission === 'stage-safety.monitoring.view');
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(wrapper.text()).toContain('Stage Safety');
+        expect(wrapper.text()).not.toContain('People Count');
+        expect(wrapper.find('current-wind-widget-stub').exists()).toBe(true);
+        expect(wrapper.find('sensor-health-widget-stub').exists()).toBe(true);
+        expect(wrapper.find('wind-history-widget-stub').exists()).toBe(true);
+    });
+});

--- a/resources/js/pages/stage-safety/Sensor.vue
+++ b/resources/js/pages/stage-safety/Sensor.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import Heading from '@/components/Heading.vue';
+import CurrentWindDisplay from '@/components/stage-safety/CurrentWindDisplay.vue';
+import WindHistoryChart from '@/components/stage-safety/WindHistoryChart.vue';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePermissions } from '@/composables/usePermissions';
+import Layout from '@/layouts/orgmgmt/Layout.vue';
+import type { BreadcrumbItem, Organization, StageSafetySensor, StageSafetySensorMonitoringPayload } from '@/types';
+import { Head, Link, useHttp } from '@inertiajs/vue3';
+import { useIntervalFn } from '@vueuse/core';
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps<{
+    organization: Organization;
+    sensor: StageSafetySensor;
+}>();
+
+const { can } = usePermissions();
+const request = useHttp<{ from: string; to: string }, StageSafetySensorMonitoringPayload>({ from: '', to: '' });
+const monitoring = ref<StageSafetySensorMonitoringPayload | null>(null);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const timeRange = ref('1h');
+let refreshQueued = false;
+
+const title = props.sensor.name || props.sensor.identifier;
+const currentSensors = computed(() => (monitoring.value ? [monitoring.value.current] : []));
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: props.organization.name,
+        href: route('organization.dashboard', { organization: props.organization.slug }),
+    },
+    {
+        title: 'Stage Safety Sensors',
+        href: route('stage-safety.sensors.index', { organization: props.organization.slug }),
+    },
+    {
+        title,
+        href: route('stage-safety.sensors.show', { organization: props.organization.slug, stageSafetySensor: props.sensor.id }),
+    },
+];
+
+function timeParams(): { from: string; to: string } {
+    const to = new Date();
+    const from = new Date(to.getTime() - Number.parseInt(timeRange.value) * 60 * 60 * 1000);
+    return { from: from.toISOString(), to: to.toISOString() };
+}
+
+async function fetchMonitoring(): Promise<void> {
+    if (request.processing) {
+        refreshQueued = true;
+        return;
+    }
+
+    const requestedRange = timeRange.value;
+    Object.assign(request, timeParams());
+
+    try {
+        error.value = null;
+        const response = await request.get(
+            route('stage-safety.sensors.monitoring.index', {
+                organization: props.organization.slug,
+                stageSafetySensor: props.sensor.id,
+            }),
+        );
+        if (requestedRange === timeRange.value) monitoring.value = response;
+    } catch {
+        error.value = 'Failed to load sensor monitoring data.';
+    } finally {
+        loading.value = false;
+        if (refreshQueued) {
+            refreshQueued = false;
+            void fetchMonitoring();
+        }
+    }
+}
+
+watch(timeRange, () => {
+    monitoring.value = null;
+    loading.value = true;
+    void fetchMonitoring();
+});
+
+useIntervalFn(fetchMonitoring, 30_000, { immediateCallback: true });
+</script>
+
+<template>
+    <Layout :breadcrumbs="breadcrumbs">
+        <Head :title="`${title} Monitoring`" />
+
+        <div class="flex h-full flex-1 flex-col gap-6 p-4">
+            <Heading :title="title" :description="sensor.location || `${sensor.manufacturer} ${sensor.model} · ${sensor.identifier}`">
+                <Button v-if="can('stage-safety.sensors.edit')" as-child variant="outline">
+                    <Link :href="route('stage-safety.sensors.edit', { organization: organization.slug, stageSafetySensor: sensor.id })">
+                        Edit sensor
+                    </Link>
+                </Button>
+            </Heading>
+
+            <div
+                v-if="error"
+                role="alert"
+                class="rounded-md border border-red-200 bg-red-50 p-3 text-center text-sm text-red-600 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400"
+            >
+                {{ error }}
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Current Wind</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Skeleton v-if="loading && !monitoring" class="h-52 w-full rounded-xl" />
+                    <CurrentWindDisplay v-else-if="currentSensors.length" :sensors="currentSensors" />
+                    <div v-else class="text-muted-foreground flex min-h-52 items-center justify-center">No monitoring data available.</div>
+                </CardContent>
+            </Card>
+
+            <WindHistoryChart v-model:time-range="timeRange" :data="monitoring?.history ?? null" :loading="loading" :error="error" />
+        </div>
+    </Layout>
+</template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -115,6 +115,76 @@ export interface StageSafetySensorCreatedResponse {
     token: string;
 }
 
+export type StageSafetySensorHealthStatus = 'fresh' | 'stale' | 'never_seen' | 'archived';
+export type StageSafetyReadingKind = 'wind_average' | 'wind_gust';
+
+export interface StageSafetySensorSummary {
+    id: number;
+    identifier: string;
+    name: string | null;
+    location: string | null;
+    stale_after_seconds: number;
+}
+
+export interface StageSafetyHistoryReading {
+    kind: StageSafetyReadingKind;
+    value: number;
+    unit: 'm/s';
+    observed_at: string;
+    window_seconds: number | null;
+}
+
+export interface StageSafetyCurrentReading extends StageSafetyHistoryReading {
+    status: 'fresh' | 'stale';
+    received_at: string;
+    receipt_delay_seconds: number;
+}
+
+export interface StageSafetyCurrentSensor {
+    sensor: StageSafetySensorSummary;
+    status: StageSafetySensorHealthStatus;
+    latest_observed_at: string | null;
+    wind_average: StageSafetyCurrentReading | null;
+    wind_gust: StageSafetyCurrentReading | null;
+}
+
+export interface StageSafetyCurrentWindPayload {
+    generated_at: string;
+    sensors: StageSafetyCurrentSensor[];
+}
+
+export interface StageSafetyHealthSensor extends StageSafetySensorSummary {
+    status: 'fresh' | 'stale' | 'never_seen';
+    latest_observed_at: string | null;
+}
+
+export interface StageSafetySensorHealthPayload {
+    generated_at: string;
+    total: number;
+    all_fresh: boolean;
+    fresh: StageSafetyHealthSensor[];
+    stale: StageSafetyHealthSensor[];
+    never_seen: StageSafetyHealthSensor[];
+}
+
+export interface StageSafetyHistorySensor {
+    sensor: StageSafetySensorSummary;
+    readings: StageSafetyHistoryReading[];
+}
+
+export interface StageSafetyWindHistoryPayload {
+    generated_at: string;
+    from: string;
+    to: string;
+    sensors: StageSafetyHistorySensor[];
+}
+
+export interface StageSafetySensorMonitoringPayload {
+    generated_at: string;
+    current: StageSafetyCurrentSensor;
+    history: StageSafetyWindHistoryPayload;
+}
+
 export interface PeoplecountSensor {
     id: number;
     vendor: string;

--- a/resources/js/utils/_tests_/stageSafety.test.ts
+++ b/resources/js/utils/_tests_/stageSafety.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { formatWindSpeed, metersPerSecondToKilometersPerHour } from '../stageSafety';
+
+describe('Stage Safety wind formatting', () => {
+    it('converts canonical meters per second to kilometers per hour', () => {
+        expect(metersPerSecondToKilometersPerHour(5)).toBe(18);
+        expect(formatWindSpeed(8.0556)).toBe('29');
+    });
+});

--- a/resources/js/utils/stageSafety.ts
+++ b/resources/js/utils/stageSafety.ts
@@ -1,0 +1,7 @@
+export function metersPerSecondToKilometersPerHour(value: number): number {
+    return value * 3.6;
+}
+
+export function formatWindSpeed(value: number): string {
+    return Number(metersPerSecondToKilometersPerHour(value).toFixed(1)).toString();
+}

--- a/routes/stage-safety.php
+++ b/routes/stage-safety.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 use App\Http\Controllers\StageSafety\SensorArchiveController;
 use App\Http\Controllers\StageSafety\SensorController;
 use App\Http\Controllers\StageSafety\SensorTokenController;
+use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
+use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
+use App\Http\Controllers\Widgets\StageSafetyWindHistoryWidgetController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(function () {
@@ -22,5 +25,12 @@ Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(
             ->name('sensors.archive.store');
         Route::delete('sensors/{stageSafetySensor}/archive', [SensorArchiveController::class, 'destroy'])
             ->name('sensors.archive.destroy');
+
+        Route::get('current-wind', [StageSafetyCurrentWindWidgetController::class, 'index'])
+            ->name('current-wind.index');
+        Route::get('sensor-health', [StageSafetySensorHealthWidgetController::class, 'index'])
+            ->name('sensor-health.index');
+        Route::get('wind-history', [StageSafetyWindHistoryWidgetController::class, 'index'])
+            ->name('wind-history.index');
     });
 });

--- a/routes/stage-safety.php
+++ b/routes/stage-safety.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\StageSafety\SensorArchiveController;
 use App\Http\Controllers\StageSafety\SensorController;
+use App\Http\Controllers\StageSafety\SensorMonitoringController;
 use App\Http\Controllers\StageSafety\SensorTokenController;
 use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
 use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
@@ -25,6 +26,8 @@ Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(
             ->name('sensors.archive.store');
         Route::delete('sensors/{stageSafetySensor}/archive', [SensorArchiveController::class, 'destroy'])
             ->name('sensors.archive.destroy');
+        Route::get('sensors/{stageSafetySensor}/monitoring', [SensorMonitoringController::class, 'index'])
+            ->name('sensors.monitoring.index');
 
         Route::get('current-wind', [StageSafetyCurrentWindWidgetController::class, 'index'])
             ->name('current-wind.index');

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -91,6 +91,7 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'DELETE', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/revoke-token'],
         ['method' => 'POST', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/archive'],
         ['method' => 'DELETE', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/archive'],
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/monitoring'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/current-wind'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensor-health'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/wind-history'],

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -91,6 +91,9 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'DELETE', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/revoke-token'],
         ['method' => 'POST', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/archive'],
         ['method' => 'DELETE', 'uri' => '{organization}/stage-safety/sensors/{stageSafetySensor}/archive'],
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/current-wind'],
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensor-health'],
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/wind-history'],
 
         // People Count Events Routes
         ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount/events'],

--- a/tests/Feature/Orgmgmt/UsersFeatureTest.php
+++ b/tests/Feature/Orgmgmt/UsersFeatureTest.php
@@ -39,9 +39,12 @@ it('shows the create user form for an organization', function () {
             ->where('availableRoles.0.name', 'PeopleCountViewer')
             ->where('availableRoles.0.display_name', 'People count viewer')
             ->where('availableRoles.0.description', 'Can view people-count dashboards and data.')
-            ->where('availableRoles.1.name', 'OrganizationAdmin')
-            ->where('availableRoles.1.display_name', 'Organization administrator')
-            ->where('availableRoles.1.description', 'Has all organization level permissions over all modules.')
+            ->where('availableRoles.1.name', 'StageSafetyViewer')
+            ->where('availableRoles.1.display_name', 'Stage Safety viewer')
+            ->where('availableRoles.1.description', 'Can view Stage Safety monitoring data.')
+            ->where('availableRoles.2.name', 'OrganizationAdmin')
+            ->where('availableRoles.2.display_name', 'Organization administrator')
+            ->where('availableRoles.2.description', 'Has all organization level permissions over all modules.')
             ->where('selectedRoles', ['PeopleCountViewer'])
         );
 });
@@ -61,7 +64,8 @@ it('shows the edit user form for an organization user', function () {
             ->where('organization.id', $org->id)
             ->where('user.id', $user->id)
             ->where('availableRoles.0.name', 'PeopleCountViewer')
-            ->where('availableRoles.1.name', 'OrganizationAdmin')
+            ->where('availableRoles.1.name', 'StageSafetyViewer')
+            ->where('availableRoles.2.name', 'OrganizationAdmin')
             ->where('selectedRoles', ['OrganizationAdmin'])
         );
 });
@@ -201,6 +205,29 @@ it('assigns multiple roles when creating an organization user', function () {
 
     $this->assertDatabaseMissing('model_has_permissions', [
         'organization_id' => $org->id,
+        'model_id' => $user->id,
+        'model_type' => User::class,
+    ]);
+});
+
+it('assigns the Stage Safety viewer role to an organization user', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $viewerRole = Role::findByName('StageSafetyViewer');
+
+    $this->actingAs($admin)
+        ->post(route('orgmgmt.users.store', ['organization' => $org->slug]), [
+            'name' => 'Stage Safety User',
+            'email' => 'stage-safety@example.com',
+            'roles' => ['StageSafetyViewer'],
+        ])
+        ->assertRedirect(route('orgmgmt.users.index', ['organization' => $org->slug]));
+
+    $user = User::query()->where('email', 'stage-safety@example.com')->firstOrFail();
+
+    $this->assertDatabaseHas('model_has_roles', [
+        'organization_id' => $org->id,
+        'role_id' => $viewerRole->id,
         'model_id' => $user->id,
         'model_type' => User::class,
     ]);

--- a/tests/Feature/StageSafety/SensorControllerTest.php
+++ b/tests/Feature/StageSafety/SensorControllerTest.php
@@ -132,7 +132,7 @@ it('updates and deletes an organization sensor', function () {
     $this->assertSoftDeleted('stage_safety_sensors', ['id' => $sensor->id]);
 });
 
-it('redirects show to edit', function () {
+it('shows the sensor monitoring page', function () {
     $organization = Organization::factory()->create();
     $admin = User::factory()->organizationAdmin($organization)->create();
     $sensor = Sensor::factory()->for($organization)->create();
@@ -142,10 +142,10 @@ it('redirects show to edit', function () {
             'organization' => $organization,
             'stageSafetySensor' => $sensor,
         ]))
-        ->assertRedirect(route('stage-safety.sensors.edit', [
-            'organization' => $organization,
-            'stageSafetySensor' => $sensor,
-        ]));
+        ->assertInertia(fn ($page) => $page
+            ->component('stage-safety/Sensor', false)
+            ->where('organization.id', $organization->id)
+            ->where('sensor.id', $sensor->id));
 });
 
 it('does not bind another organization sensor', function () {

--- a/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
+++ b/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\Organization;
 use App\Models\StageSafety\Reading;
 use App\Models\StageSafety\Sensor;
 use App\Services\StageSafety\MonitoringService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Carbon;
 
 covers(MonitoringService::class);
@@ -180,3 +181,37 @@ it('returns bounded ordered history without archived or foreign sensors', functi
         ->and($payload['sensors'][0]['readings'][1]['value'])->toBe(8.0)
         ->and($emptySensor->exists)->toBeTrue();
 });
+
+it('returns current and bounded history for an archived sensor detail', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create(['archived_at' => now()]);
+
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindAverage,
+        'value' => 5.0,
+        'observed_at' => now()->subMinutes(20),
+        'received_at' => now()->subMinutes(20),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindGust,
+        'value' => 10.0,
+        'observed_at' => now()->subHours(2),
+        'received_at' => now()->subHours(2),
+    ]);
+
+    $payload = $this->service->sensorMonitoring($organization, $sensor, now()->subHour(), now());
+
+    expect($payload['current']['status'])->toBe('archived')
+        ->and($payload['current']['wind_average']['value'])->toBe(5.0)
+        ->and($payload['current']['wind_gust']['value'])->toBe(10.0)
+        ->and($payload['history']['sensors'])->toHaveCount(1)
+        ->and($payload['history']['sensors'][0]['readings'])->toHaveCount(1)
+        ->and($payload['history']['sensors'][0]['readings'][0]['value'])->toBe(5.0);
+});
+
+it('rejects sensor detail from another organization', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->create();
+
+    $this->service->sensorMonitoring($organization, $sensor, now()->subHour(), now());
+})->throws(AuthorizationException::class);

--- a/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
+++ b/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Enums\StageSafety\ReadingKind;
+use App\Enums\StageSafety\SensorHealthStatus;
+use App\Models\Organization;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use App\Services\StageSafety\MonitoringService;
+use Illuminate\Support\Carbon;
+
+covers(MonitoringService::class);
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-07-25 12:00:00 UTC');
+    $this->service = new MonitoringService;
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('returns every fresh sensor with independently resolved latest readings', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create([
+        'name' => 'Main Stage',
+        'stale_after_seconds' => 300,
+    ]);
+
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindAverage,
+        'value' => 3.2,
+        'observed_at' => now()->subMinutes(7),
+        'received_at' => now()->subMinutes(7)->addSeconds(2),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindAverage,
+        'value' => 4.5,
+        'observed_at' => now()->subMinutes(6),
+        'received_at' => now()->subMinutes(6)->addSeconds(3),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindGust,
+        'value' => 7.25,
+        'observed_at' => now()->subMinute(),
+        'received_at' => now()->subMinute()->addSeconds(4),
+        'window_seconds' => 10,
+    ]);
+
+    $staleSensor = Sensor::factory()->for($organization)->create(['stale_after_seconds' => 300]);
+    Reading::factory()->for($staleSensor)->create([
+        'observed_at' => now()->subSeconds(301),
+        'received_at' => now()->subSeconds(300),
+    ]);
+
+    $archivedSensor = Sensor::factory()->for($organization)->create(['archived_at' => now()]);
+    Reading::factory()->for($archivedSensor)->create([
+        'observed_at' => now(),
+        'received_at' => now(),
+    ]);
+
+    $foreignSensor = Sensor::factory()->create();
+    Reading::factory()->for($foreignSensor)->create([
+        'observed_at' => now(),
+        'received_at' => now(),
+    ]);
+
+    $payload = $this->service->currentWind($organization);
+
+    expect($payload['generated_at'])->toBe('2026-07-25T12:00:00+00:00')
+        ->and($payload['sensors'])->toHaveCount(1)
+        ->and($payload['sensors'][0]['sensor']['id'])->toBe($sensor->id)
+        ->and($payload['sensors'][0]['status'])->toBe('fresh')
+        ->and($payload['sensors'][0]['wind_average']['value'])->toBe(4.5)
+        ->and($payload['sensors'][0]['wind_average']['status'])->toBe('stale')
+        ->and($payload['sensors'][0]['wind_average']['receipt_delay_seconds'])->toBe(3)
+        ->and($payload['sensors'][0]['wind_gust']['value'])->toBe(7.25)
+        ->and($payload['sensors'][0]['wind_gust']['window_seconds'])->toBe(10);
+});
+
+it('classifies sensor health at the stale boundary and excludes archived sensors', function () {
+    $organization = Organization::factory()->create();
+    $freshSensor = Sensor::factory()->for($organization)->create(['stale_after_seconds' => 300]);
+    $staleSensor = Sensor::factory()->for($organization)->create(['stale_after_seconds' => 300]);
+    $neverSeenSensor = Sensor::factory()->for($organization)->create();
+    $archivedSensor = Sensor::factory()->for($organization)->create(['archived_at' => now()]);
+
+    Reading::factory()->for($freshSensor)->create([
+        'observed_at' => now()->subSeconds(300),
+        'received_at' => now()->subSeconds(299),
+    ]);
+    Reading::factory()->for($staleSensor)->create([
+        'observed_at' => now()->subSeconds(301),
+        'received_at' => now()->subSeconds(300),
+    ]);
+
+    $payload = $this->service->sensorHealth($organization);
+
+    expect($payload['total'])->toBe(3)
+        ->and($payload['all_fresh'])->toBeFalse()
+        ->and($payload['fresh'])->toHaveCount(1)
+        ->and($payload['fresh'][0]['id'])->toBe($freshSensor->id)
+        ->and($payload['stale'])->toHaveCount(1)
+        ->and($payload['stale'][0]['id'])->toBe($staleSensor->id)
+        ->and($payload['never_seen'])->toHaveCount(1)
+        ->and($payload['never_seen'][0]['id'])->toBe($neverSeenSensor->id)
+        ->and($this->service->status($archivedSensor))->toBe(SensorHealthStatus::Archived);
+});
+
+it('does not treat a future observation as current', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create(['stale_after_seconds' => 300]);
+
+    Reading::factory()->for($sensor)->create([
+        'observed_at' => now()->addHour(),
+        'received_at' => now(),
+    ]);
+
+    expect($this->service->status($sensor))->toBe(SensorHealthStatus::Stale)
+        ->and($this->service->currentWind($organization)['sensors'])->toBe([]);
+});
+
+it('uses the newer average observation as latest sensor activity', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create();
+
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindAverage,
+        'observed_at' => now()->subMinute(),
+        'received_at' => now()->subMinute(),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindGust,
+        'observed_at' => now()->subMinutes(2),
+        'received_at' => now()->subMinutes(2),
+    ]);
+
+    expect($this->service->sensorHealth($organization)['fresh'][0]['latest_observed_at'])
+        ->toBe('2026-07-25T11:59:00+00:00');
+});
+
+it('returns bounded ordered history without archived or foreign sensors', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create();
+    $emptySensor = Sensor::factory()->for($organization)->create();
+    $archivedSensor = Sensor::factory()->for($organization)->create(['archived_at' => now()]);
+    $foreignSensor = Sensor::factory()->create();
+
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindGust,
+        'value' => 8.0,
+        'observed_at' => now()->subMinutes(10),
+        'received_at' => now()->subMinutes(10),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'kind' => ReadingKind::WindAverage,
+        'value' => 4.0,
+        'observed_at' => now()->subMinutes(20),
+        'received_at' => now()->subMinutes(20),
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'value' => 99.0,
+        'observed_at' => now()->subHours(2),
+        'received_at' => now()->subHours(2),
+    ]);
+    Reading::factory()->for($archivedSensor)->create([
+        'observed_at' => now()->subMinutes(5),
+        'received_at' => now()->subMinutes(5),
+    ]);
+    Reading::factory()->for($foreignSensor)->create([
+        'observed_at' => now()->subMinutes(5),
+        'received_at' => now()->subMinutes(5),
+    ]);
+
+    $payload = $this->service->windHistory($organization, now()->subHour(), now());
+
+    expect($payload['sensors'])->toHaveCount(1)
+        ->and($payload['sensors'][0]['sensor']['id'])->toBe($sensor->id)
+        ->and($payload['sensors'][0]['readings'])->toHaveCount(2)
+        ->and($payload['sensors'][0]['readings'][0]['value'])->toBe(4.0)
+        ->and($payload['sensors'][0]['readings'][1]['value'])->toBe(8.0)
+        ->and($emptySensor->exists)->toBeTrue();
+});

--- a/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
+++ b/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Http\Controllers\StageSafety\SensorMonitoringController;
 use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
 use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
 use App\Http\Controllers\Widgets\StageSafetyWindHistoryWidgetController;
+use App\Http\Requests\StageSafety\SensorMonitoringIndexRequest;
 use App\Http\Requests\Widgets\StageSafety\CurrentWindIndexRequest;
 use App\Http\Requests\Widgets\StageSafety\SensorHealthIndexRequest;
 use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
@@ -54,6 +56,15 @@ it('allows a Stage Safety viewer to access all monitoring endpoints', function (
         ->assertJsonPath('from', '2026-07-25T11:00:00+00:00')
         ->assertJsonPath('to', '2026-07-25T12:00:00+00:00')
         ->assertJsonPath('sensors.0.sensor.id', $sensor->id);
+
+    $this->actingAs($viewer)
+        ->getJson(route('stage-safety.sensors.monitoring.index', [
+            'organization' => $organization,
+            'stageSafetySensor' => $sensor,
+        ]))
+        ->assertSuccessful()
+        ->assertJsonPath('current.sensor.id', $sensor->id)
+        ->assertJsonPath('history.sensors.0.sensor.id', $sensor->id);
 });
 
 it('forbids users without monitoring permission', function (string $routeName) {
@@ -86,6 +97,19 @@ it('forbids an organization viewer from accessing another organization', functio
     'wind history' => 'stage-safety.wind-history.index',
 ]);
 
+it('does not bind another organization sensor to monitoring endpoint', function () {
+    $organization = Organization::factory()->create();
+    $admin = User::factory()->globalAdmin()->create();
+    $foreignSensor = Sensor::factory()->create();
+
+    $this->actingAs($admin)
+        ->getJson(route('stage-safety.sensors.monitoring.index', [
+            'organization' => $organization,
+            'stageSafetySensor' => $foreignSensor,
+        ]))
+        ->assertNotFound();
+});
+
 it('rejects invalid history ranges', function (array $query, array $invalidFields) {
     $organization = Organization::factory()->create();
     $admin = User::factory()->organizationAdmin($organization)->create();
@@ -113,6 +137,7 @@ it('uses monitoring form requests and organization middleware', function () {
         'stage-safety.current-wind.index' => [StageSafetyCurrentWindWidgetController::class, CurrentWindIndexRequest::class],
         'stage-safety.sensor-health.index' => [StageSafetySensorHealthWidgetController::class, SensorHealthIndexRequest::class],
         'stage-safety.wind-history.index' => [StageSafetyWindHistoryWidgetController::class, WindHistoryIndexRequest::class],
+        'stage-safety.sensors.monitoring.index' => [SensorMonitoringController::class, SensorMonitoringIndexRequest::class],
     ] as $routeName => [$controller, $request]) {
         test()->assertRouteUsesMiddleware(
             $routeName,

--- a/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
+++ b/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
+use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
+use App\Http\Controllers\Widgets\StageSafetyWindHistoryWidgetController;
+use App\Http\Requests\Widgets\StageSafety\CurrentWindIndexRequest;
+use App\Http\Requests\Widgets\StageSafety\SensorHealthIndexRequest;
+use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
+use App\Models\Organization;
+use App\Models\StageSafety\Reading;
+use App\Models\StageSafety\Sensor;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+beforeEach(function () {
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+    Carbon::setTestNow('2026-07-25 12:00:00 UTC');
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('allows a Stage Safety viewer to access all monitoring endpoints', function () {
+    $organization = Organization::factory()->create();
+    $viewer = User::factory()->create();
+    $viewer->organizations()->attach($organization);
+    setPermissionsOrgId($organization->id);
+    $viewer->assignRole('StageSafetyViewer');
+
+    expect($viewer->can('stage-safety.sensors.edit'))->toBeFalse()
+        ->and($viewer->can('stage-safety.sensors.update'))->toBeFalse()
+        ->and($viewer->can('stage-safety.sensors.destroy'))->toBeFalse();
+
+    $sensor = Sensor::factory()->for($organization)->create();
+    Reading::factory()->for($sensor)->create([
+        'observed_at' => now()->subMinute(),
+        'received_at' => now()->subMinute(),
+    ]);
+
+    $this->actingAs($viewer)
+        ->getJson(route('stage-safety.current-wind.index', ['organization' => $organization]))
+        ->assertSuccessful()
+        ->assertJsonPath('sensors.0.sensor.id', $sensor->id);
+
+    $this->actingAs($viewer)
+        ->getJson(route('stage-safety.sensor-health.index', ['organization' => $organization]))
+        ->assertSuccessful()
+        ->assertJsonPath('fresh.0.id', $sensor->id);
+
+    $this->actingAs($viewer)
+        ->getJson(route('stage-safety.wind-history.index', ['organization' => $organization]))
+        ->assertSuccessful()
+        ->assertJsonPath('from', '2026-07-25T11:00:00+00:00')
+        ->assertJsonPath('to', '2026-07-25T12:00:00+00:00')
+        ->assertJsonPath('sensors.0.sensor.id', $sensor->id);
+});
+
+it('forbids users without monitoring permission', function (string $routeName) {
+    $organization = Organization::factory()->create();
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->getJson(route($routeName, ['organization' => $organization]))
+        ->assertForbidden();
+})->with([
+    'current wind' => 'stage-safety.current-wind.index',
+    'sensor health' => 'stage-safety.sensor-health.index',
+    'wind history' => 'stage-safety.wind-history.index',
+]);
+
+it('forbids an organization viewer from accessing another organization', function (string $routeName) {
+    $organization = Organization::factory()->create();
+    $otherOrganization = Organization::factory()->create();
+    $viewer = User::factory()->create();
+    $viewer->organizations()->attach($organization);
+    setPermissionsOrgId($organization->id);
+    $viewer->assignRole('StageSafetyViewer');
+
+    $this->actingAs($viewer)
+        ->getJson(route($routeName, ['organization' => $otherOrganization]))
+        ->assertForbidden();
+})->with([
+    'current wind' => 'stage-safety.current-wind.index',
+    'sensor health' => 'stage-safety.sensor-health.index',
+    'wind history' => 'stage-safety.wind-history.index',
+]);
+
+it('rejects invalid history ranges', function (array $query, array $invalidFields) {
+    $organization = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($organization)->create();
+
+    $this->actingAs($admin)
+        ->getJson(route('stage-safety.wind-history.index', [
+            'organization' => $organization,
+            ...$query,
+        ]))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors($invalidFields);
+})->with([
+    'longer than 24 hours' => [[
+        'from' => '2026-07-24T11:59:59Z',
+        'to' => '2026-07-25T12:00:00Z',
+    ], ['to']],
+    'reversed' => [[
+        'from' => '2026-07-25T12:00:00Z',
+        'to' => '2026-07-25T11:00:00Z',
+    ], ['from', 'to']],
+]);
+
+it('uses monitoring form requests and organization middleware', function () {
+    foreach ([
+        'stage-safety.current-wind.index' => [StageSafetyCurrentWindWidgetController::class, CurrentWindIndexRequest::class],
+        'stage-safety.sensor-health.index' => [StageSafetySensorHealthWidgetController::class, SensorHealthIndexRequest::class],
+        'stage-safety.wind-history.index' => [StageSafetyWindHistoryWidgetController::class, WindHistoryIndexRequest::class],
+    ] as $routeName => [$controller, $request]) {
+        test()->assertRouteUsesMiddleware(
+            $routeName,
+            ['permissions.organization_slug', 'auth', 'verified'],
+        );
+
+        test()->assertActionUsesFormRequest($controller, 'index', $request);
+        test()->assertRouteUsesFormRequest($routeName, $request);
+    }
+});

--- a/tests/Unit/Requests/StageSafety/SensorMonitoringIndexRequestTest.php
+++ b/tests/Unit/Requests/StageSafety/SensorMonitoringIndexRequestTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Http\Requests\StageSafety\SensorMonitoringIndexRequest;
+use App\Models\User;
+
+covers(SensorMonitoringIndexRequest::class);
+
+it('uses the sensor show permission', function (bool $allowed) {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.sensors.show')->andReturn($allowed);
+    $request = new SensorMonitoringIndexRequest;
+    $request->setUserResolver(fn (): User => $user);
+
+    expect($request->authorize())->toBe($allowed);
+})->with([true, false]);

--- a/tests/Unit/Requests/Widgets/StageSafety/CurrentWindIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/CurrentWindIndexRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Http\Requests\Widgets\StageSafety\CurrentWindIndexRequest;
+use App\Models\User;
+
+covers(CurrentWindIndexRequest::class);
+
+it('has no input rules', function () {
+    expect((new CurrentWindIndexRequest)->rules())->toBe([]);
+});
+
+it('authorizes users with the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnTrue();
+    $request = new CurrentWindIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeTrue();
+});
+
+it('denies users without the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnFalse();
+    $request = new CurrentWindIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Widgets/StageSafety/SensorHealthIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/SensorHealthIndexRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Http\Requests\Widgets\StageSafety\SensorHealthIndexRequest;
+use App\Models\User;
+
+covers(SensorHealthIndexRequest::class);
+
+it('has no input rules', function () {
+    expect((new SensorHealthIndexRequest)->rules())->toBe([]);
+});
+
+it('authorizes users with the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnTrue();
+    $request = new SensorHealthIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeTrue();
+});
+
+it('denies users without the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnFalse();
+    $request = new SensorHealthIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeFalse();
+});

--- a/tests/Unit/Requests/Widgets/StageSafety/WindHistoryIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/WindHistoryIndexRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
+use App\Models\User;
+
+covers(WindHistoryIndexRequest::class);
+
+it('defines paired bounded history inputs', function () {
+    $request = new WindHistoryIndexRequest;
+
+    expect($request->rules())->toBe([
+        'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
+        'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+    ])->and($request->after())->toHaveCount(1)
+        ->and(WindHistoryIndexRequest::MAX_RANGE_HOURS)->toBe(24);
+});
+
+it('authorizes users with the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnTrue();
+    $request = new WindHistoryIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeTrue();
+});
+
+it('denies users without the monitoring permission', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnFalse();
+    $request = new WindHistoryIndexRequest;
+    $request->setUserResolver(fn (?string $guard = null): User => $user);
+
+    expect($request->authorize())->toBeFalse();
+});


### PR DESCRIPTION
Adds organization-scoped wind monitoring so operators can inspect sensor freshness, current conditions, and bounded history from sensor detail pages or dashboard widgets. Stage Safety viewers gain read-only access while management, token, and archive permissions remain unchanged.

## Details

- [MonitoringService.php](https://github.com/musikfestwochen/musikfestapp/blob/feat/stage-safety-monitoring-dashboard/app/Services/StageSafety/MonitoringService.php) - derives current wind, sensor health, and bounded history with organization isolation.
- [Sensor.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/stage-safety-monitoring-dashboard/resources/js/pages/stage-safety/Sensor.vue) - presents current or last-known readings and per-sensor history.
- [Dashboard.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/stage-safety-monitoring-dashboard/resources/js/pages/orgmgmt/Dashboard.vue) - mounts independently polled Stage Safety widgets only for authorized users.

## Notes

Wind remains canonical m/s in backend payloads and converts to km/h in presentation. History defaults to one hour and rejects ranges over 24 hours.

## Reviewer Setup

Frontend sources changed. Build assets before local review:

```sh
npm run build
```

Fixes #188
Fixes #190

---
**«The biggest battle is the war against ignorance.»**
_Mustafa Kemal Atatürk_