### PR TITLE
Improve sensor monitoring dashboard

### DIFF
--- a/app/Services/StageSafety/MonitoringService.php
+++ b/app/Services/StageSafety/MonitoringService.php
@@ -189,10 +189,17 @@ class MonitoringService
      */
     protected function currentSensorPayload(Sensor $sensor, CarbonInterface $now): array
     {
+        $latestReading = $this->latestReading($sensor);
+
         return [
             'sensor' => $this->sensorPayload($sensor),
             'status' => $this->status($sensor, $now)->value,
-            'latest_observed_at' => $this->latestObservedAt($sensor)?->toIso8601String(),
+            'latest_observed_at' => $latestReading?->observed_at->toIso8601String(),
+            'radio_diagnostics' => $latestReading instanceof Reading ? [
+                'battery_low' => $latestReading->battery_low,
+                'rssi_dbm' => $latestReading->rssi_dbm,
+                'cv' => $latestReading->cv,
+            ] : null,
             'wind_average' => $this->currentReadingPayload($sensor, $sensor->latestWindAverage, $now),
             'wind_gust' => $this->currentReadingPayload($sensor, $sensor->latestWindGust, $now),
         ];
@@ -249,20 +256,25 @@ class MonitoringService
 
     protected function latestObservedAt(Sensor $sensor): ?CarbonInterface
     {
-        $averageObservedAt = $sensor->latestWindAverage?->observed_at;
-        $gustObservedAt = $sensor->latestWindGust?->observed_at;
+        return $this->latestReading($sensor)?->observed_at;
+    }
 
-        if ($averageObservedAt === null) {
-            return $gustObservedAt;
+    protected function latestReading(Sensor $sensor): ?Reading
+    {
+        $average = $sensor->latestWindAverage;
+        $gust = $sensor->latestWindGust;
+
+        if ($average === null) {
+            return $gust;
         }
 
-        if ($gustObservedAt === null) {
-            return $averageObservedAt;
+        if ($gust === null) {
+            return $average;
         }
 
-        return $averageObservedAt->getTimestamp() >= $gustObservedAt->getTimestamp()
-            ? $averageObservedAt
-            : $gustObservedAt;
+        return $average->observed_at->getTimestamp() >= $gust->observed_at->getTimestamp()
+            ? $average
+            : $gust;
     }
 
     protected function isFresh(CarbonInterface $observedAt, Sensor $sensor, CarbonInterface $now): bool

--- a/resources/js/components/SensorHealthWidget.vue
+++ b/resources/js/components/SensorHealthWidget.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { Organization, StageSafetySensorHealthPayload } from '@/types';
+import { getRelativeTime } from '@/utils/dateTimeHelpers';
+import { stageSafetySensorName } from '@/utils/stageSafety';
+import { useHttp } from '@inertiajs/vue3';
+import { useIntervalFn } from '@vueuse/core';
+import { computed, ref } from 'vue';
+
+interface PeoplecountHealthSensor {
+    id: number;
+    serial: string;
+    vendor: string;
+    model: string;
+    name: string | null;
+    latest_ts: string | null;
+}
+
+interface PeoplecountSensorHealthPayload {
+    last_updated: string;
+    total: number;
+    all_healthy: boolean;
+    healthy: PeoplecountHealthSensor[];
+    suspicious: PeoplecountHealthSensor[];
+    unhealthy: PeoplecountHealthSensor[];
+}
+
+const props = defineProps<{
+    organization: Organization;
+    showPeoplecount: boolean;
+    showStageSafety: boolean;
+}>();
+
+const peoplecountRequest = useHttp<Record<string, never>, PeoplecountSensorHealthPayload>({});
+const stageSafetyRequest = useHttp<Record<string, never>, StageSafetySensorHealthPayload>({});
+const peoplecount = ref<PeoplecountSensorHealthPayload | null>(null);
+const stageSafety = ref<StageSafetySensorHealthPayload | null>(null);
+const peoplecountLoading = ref(props.showPeoplecount);
+const stageSafetyLoading = ref(props.showStageSafety);
+const peoplecountError = ref<string | null>(null);
+const stageSafetyError = ref<string | null>(null);
+
+const stageSafetyIssues = computed(() => [...(stageSafety.value?.stale ?? []), ...(stageSafety.value?.never_seen ?? [])]);
+
+function peoplecountSensorName(sensor: PeoplecountHealthSensor): string {
+    return sensor.name || `${sensor.vendor} ${sensor.model}`;
+}
+
+async function fetchPeoplecount(): Promise<void> {
+    if (!props.showPeoplecount || peoplecountRequest.processing) return;
+
+    try {
+        peoplecountError.value = null;
+        peoplecount.value = await peoplecountRequest.get(route('peoplecount.sensor-health.index', { organization: props.organization.slug }));
+    } catch {
+        peoplecountError.value = 'Failed to load Peoplecount sensor health.';
+    } finally {
+        peoplecountLoading.value = false;
+    }
+}
+
+async function fetchStageSafety(): Promise<void> {
+    if (!props.showStageSafety || stageSafetyRequest.processing) return;
+
+    try {
+        stageSafetyError.value = null;
+        stageSafety.value = await stageSafetyRequest.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
+    } catch {
+        stageSafetyError.value = 'Failed to load Stage Safety sensor health.';
+    } finally {
+        stageSafetyLoading.value = false;
+    }
+}
+
+async function fetchHealth(): Promise<void> {
+    await Promise.all([fetchPeoplecount(), fetchStageSafety()]);
+}
+
+useIntervalFn(fetchHealth, 10_000, { immediateCallback: true });
+</script>
+
+<template>
+    <Card class="flex h-full flex-col">
+        <CardHeader>
+            <CardTitle>Sensor Health</CardTitle>
+        </CardHeader>
+        <CardContent class="flex flex-1 flex-col divide-y">
+            <section v-if="showPeoplecount" class="pb-4 first:pt-0 last:pb-0">
+                <div class="mb-3 flex items-center justify-between gap-2">
+                    <h3 class="font-medium">Peoplecount</h3>
+                    <Badge v-if="peoplecount?.all_healthy && peoplecount.total" class="bg-green-600 hover:bg-green-600">Healthy</Badge>
+                    <Badge v-else-if="peoplecount?.total" variant="destructive">Attention</Badge>
+                </div>
+                <div
+                    v-if="peoplecountError"
+                    role="alert"
+                    class="mb-3 rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400"
+                >
+                    {{ peoplecountError }}
+                </div>
+                <Skeleton v-if="peoplecountLoading && !peoplecount" class="h-20 w-full" />
+                <p v-else-if="peoplecount && !peoplecount.total" class="text-muted-foreground py-4 text-center text-sm">
+                    No sensors currently assigned.
+                </p>
+                <div v-else-if="peoplecount?.all_healthy" class="py-4 text-center text-sm text-green-700 dark:text-green-400">
+                    All {{ peoplecount.total }} sensors are healthy
+                </div>
+                <ul v-else-if="peoplecount" class="divide-y text-sm">
+                    <li
+                        v-for="sensor in peoplecount.suspicious"
+                        :key="`suspicious-${sensor.id}`"
+                        class="flex items-center justify-between gap-2 py-2"
+                    >
+                        <span class="min-w-0 truncate">{{ peoplecountSensorName(sensor) }} · {{ sensor.serial }}</span>
+                        <Badge variant="secondary">Suspicious</Badge>
+                    </li>
+                    <li v-for="sensor in peoplecount.unhealthy" :key="`unhealthy-${sensor.id}`" class="flex items-center justify-between gap-2 py-2">
+                        <span class="min-w-0 truncate">{{ peoplecountSensorName(sensor) }} · {{ sensor.serial }}</span>
+                        <Badge variant="destructive">Unhealthy</Badge>
+                    </li>
+                </ul>
+                <p v-if="peoplecount" class="text-muted-foreground mt-2 text-right text-xs">
+                    Updated {{ getRelativeTime(new Date(peoplecount.last_updated)) }}
+                </p>
+            </section>
+
+            <section v-if="showStageSafety" class="pt-4 first:pt-0">
+                <div class="mb-3 flex items-center justify-between gap-2">
+                    <h3 class="font-medium">Stage Safety</h3>
+                    <Badge v-if="stageSafety?.all_fresh" class="bg-green-600 hover:bg-green-600">Fresh</Badge>
+                    <Badge v-else-if="stageSafety?.total" variant="destructive">Attention</Badge>
+                </div>
+                <div
+                    v-if="stageSafetyError"
+                    role="alert"
+                    class="mb-3 rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400"
+                >
+                    {{ stageSafetyError }}
+                </div>
+                <Skeleton v-if="stageSafetyLoading && !stageSafety" class="h-20 w-full" />
+                <p v-else-if="stageSafety && !stageSafety.total" class="text-muted-foreground py-4 text-center text-sm">
+                    No active Stage Safety sensors configured.
+                </p>
+                <div v-else-if="stageSafety?.all_fresh" class="py-4 text-center text-sm text-green-700 dark:text-green-400">
+                    All {{ stageSafety.total }} sensors report fresh data
+                </div>
+                <ul v-else-if="stageSafety" class="divide-y text-sm">
+                    <li v-for="sensor in stageSafetyIssues" :key="sensor.id" class="flex items-center justify-between gap-2 py-2">
+                        <div class="min-w-0">
+                            <p class="truncate">{{ stageSafetySensorName(sensor) }}</p>
+                            <p class="text-muted-foreground text-xs">
+                                {{
+                                    sensor.latest_observed_at ? `Observed ${getRelativeTime(new Date(sensor.latest_observed_at))}` : 'Never observed'
+                                }}
+                            </p>
+                        </div>
+                        <Badge :variant="sensor.status === 'stale' ? 'destructive' : 'secondary'">{{ sensor.status.replace('_', ' ') }}</Badge>
+                    </li>
+                </ul>
+            </section>
+        </CardContent>
+    </Card>
+</template>

--- a/resources/js/components/_tests_/SensorHealthWidget.test.ts
+++ b/resources/js/components/_tests_/SensorHealthWidget.test.ts
@@ -1,0 +1,118 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SensorHealthWidget from '../SensorHealthWidget.vue';
+
+const mocks = vi.hoisted(() => ({
+    peoplecountGet: vi.fn(),
+    stageSafetyGet: vi.fn(),
+    peoplecountRequest: { processing: false, get: vi.fn() },
+    stageSafetyRequest: { processing: false, get: vi.fn() },
+    useHttp: vi.fn(),
+    useIntervalFn: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    useHttp: mocks.useHttp,
+}));
+
+vi.mock('@vueuse/core', () => ({
+    useIntervalFn: mocks.useIntervalFn,
+}));
+
+const organization = { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' };
+const peoplecountPayload = {
+    last_updated: '2026-07-25T12:00:00Z',
+    total: 1,
+    all_healthy: false,
+    healthy: [],
+    suspicious: [{ id: 1, serial: 'PC-1', vendor: 'Axis', model: 'P8815-2', name: null, latest_ts: '2026-07-25T12:00:00Z' }],
+    unhealthy: [],
+};
+const stageSafetyPayload = {
+    generated_at: '2026-07-25T12:00:00Z',
+    total: 1,
+    all_fresh: false,
+    fresh: [],
+    stale: [
+        {
+            id: 2,
+            identifier: 'WIND-1',
+            name: 'Main Stage',
+            location: 'Roof',
+            stale_after_seconds: 300,
+            status: 'stale' as const,
+            latest_observed_at: '2026-07-25T11:59:30Z',
+        },
+    ],
+    never_seen: [],
+};
+
+describe('combined sensor health widget', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+        mocks.peoplecountRequest.processing = false;
+        mocks.stageSafetyRequest.processing = false;
+        mocks.peoplecountRequest.get = mocks.peoplecountGet;
+        mocks.stageSafetyRequest.get = mocks.stageSafetyGet;
+        mocks.useHttp.mockReturnValueOnce(mocks.peoplecountRequest).mockReturnValueOnce(mocks.stageSafetyRequest);
+        mocks.useIntervalFn.mockImplementation((callback: () => Promise<void>) => {
+            void callback();
+            return { pause: vi.fn(), resume: vi.fn(), isActive: true };
+        });
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('fetches and renders both authorized health sources independently', async () => {
+        mocks.peoplecountGet.mockResolvedValue(peoplecountPayload);
+        mocks.stageSafetyGet.mockResolvedValue(stageSafetyPayload);
+
+        const wrapper = mount(SensorHealthWidget, {
+            props: { organization, showPeoplecount: true, showStageSafety: true },
+        });
+        await flushPromises();
+
+        expect(mocks.peoplecountGet).toHaveBeenCalledWith('peoplecount.sensor-health.index');
+        expect(mocks.stageSafetyGet).toHaveBeenCalledWith('stage-safety.sensor-health.index');
+        expect(wrapper.text()).toContain('Axis P8815-2 · PC-1');
+        expect(wrapper.text()).toContain('Roof');
+        expect(wrapper.text()).not.toContain('Main Stage');
+        expect(wrapper.text()).toContain('Observed 30 seconds ago');
+    });
+
+    it('only fetches endpoints granted by its permission props', async () => {
+        mocks.peoplecountGet.mockResolvedValue(peoplecountPayload);
+
+        const wrapper = mount(SensorHealthWidget, {
+            props: { organization, showPeoplecount: true, showStageSafety: false },
+        });
+        await flushPromises();
+
+        expect(mocks.peoplecountGet).toHaveBeenCalledOnce();
+        expect(mocks.stageSafetyGet).not.toHaveBeenCalled();
+        expect(wrapper.text()).toContain('Peoplecount');
+        expect(wrapper.text()).not.toContain('Stage Safety');
+    });
+
+    it('keeps one source visible when the other source fails', async () => {
+        mocks.peoplecountGet.mockRejectedValue(new Error('network'));
+        mocks.stageSafetyGet.mockResolvedValue(stageSafetyPayload);
+
+        const wrapper = mount(SensorHealthWidget, {
+            props: { organization, showPeoplecount: true, showStageSafety: true },
+        });
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('Failed to load Peoplecount sensor health');
+        expect(wrapper.text()).not.toContain('No sensors currently assigned');
+        expect(wrapper.text()).toContain('Roof');
+    });
+});

--- a/resources/js/components/peoplecount/ActiveAreaCountsWidget.vue
+++ b/resources/js/components/peoplecount/ActiveAreaCountsWidget.vue
@@ -4,6 +4,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePermissions } from '@/composables/usePermissions';
 import axios from 'axios';
+import { Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface AreaCount {
@@ -142,7 +143,7 @@ const lastUpdatedTime = computed(() => {
 <template>
     <Card :class="{ 'stale-card pulse': isDataStale, 'counts-widget': true }" class="flex h-full flex-col">
         <CardHeader>
-            <CardTitle>Active Area Counts</CardTitle>
+            <CardTitle class="flex items-center gap-2"><Users class="size-4" aria-hidden="true" /> Active Area Counts</CardTitle>
         </CardHeader>
         <CardContent class="counts-widget-content flex flex-1 flex-col">
             <!-- Show error message as a banner if there's an error -->

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -8,7 +8,7 @@ import { CurveType } from '@unovis/ts';
 import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
 import { useStorage } from '@vueuse/core';
 import axios from 'axios';
-import { ChartColumnIncreasing, ChartSpline } from 'lucide-vue-next';
+import { ChartColumnIncreasing, ChartSpline, Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 interface DataPoint {
@@ -174,7 +174,7 @@ onBeforeUnmount(() => {
 <template>
     <Card class="col-span-full flex h-full min-w-0 flex-col">
         <CardHeader class="flex flex-col gap-3 pb-4 sm:flex-row sm:items-center sm:justify-between sm:gap-2 sm:space-y-0">
-            <CardTitle>Area Count History</CardTitle>
+            <CardTitle class="flex items-center gap-2"><Users class="size-4" aria-hidden="true" /> Area Count History</CardTitle>
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
                 <Button
                     variant="ghost"

--- a/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
+++ b/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import axios from 'axios';
+import { Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 interface SensorSums {
@@ -107,7 +108,7 @@ watch(
     <Card class="widget-card flex h-full flex-col">
         <CardHeader>
             <div class="flex items-center justify-between">
-                <CardTitle>Most Active Sensors</CardTitle>
+                <CardTitle class="flex items-center gap-2"><Users class="size-4" aria-hidden="true" /> Most Active Sensors</CardTitle>
                 <div class="inline-flex items-center gap-1">
                     <Button
                         :class="{ 'bg-primary text-primary-foreground': selectedRange === '10m' }"

--- a/resources/js/components/stage-safety/CurrentWindDisplay.vue
+++ b/resources/js/components/stage-safety/CurrentWindDisplay.vue
@@ -2,16 +2,11 @@
 import { Badge } from '@/components/ui/badge';
 import type { StageSafetyCurrentReading, StageSafetyCurrentSensor } from '@/types';
 import { getRelativeTime } from '@/utils/dateTimeHelpers';
-import { formatWindSpeed } from '@/utils/stageSafety';
-import { Wind } from 'lucide-vue-next';
+import { formatWindSpeed, stageSafetySensorName } from '@/utils/stageSafety';
 
 defineProps<{
     sensors: StageSafetyCurrentSensor[];
 }>();
-
-function sensorName(item: StageSafetyCurrentSensor): string {
-    return item.sensor.name || item.sensor.identifier;
-}
 
 function readingLabel(label: string, reading: StageSafetyCurrentReading | null, sensorStatus: StageSafetyCurrentSensor['status']): string {
     return sensorStatus === 'fresh' && reading?.status === 'fresh' ? label : `Last known ${label.toLowerCase()}`;
@@ -26,42 +21,31 @@ function statusVariant(status: StageSafetyCurrentSensor['status']): 'default' | 
 </script>
 
 <template>
-    <div class="grid gap-4" :class="sensors.length > 1 ? 'xl:grid-cols-2' : ''">
-        <article v-for="item in sensors" :key="item.sensor.id" class="bg-muted/25 rounded-xl border p-4 sm:p-6">
-            <div class="flex items-start justify-between gap-4">
-                <div class="min-w-0">
-                    <div class="flex flex-wrap items-center gap-2">
-                        <h3 class="truncate font-semibold">{{ sensorName(item) }}</h3>
-                        <Badge :variant="statusVariant(item.status)">{{ item.status.replace('_', ' ') }}</Badge>
-                    </div>
-                    <p class="text-muted-foreground mt-1 truncate text-sm">
-                        {{ item.sensor.location || item.sensor.identifier }}
-                    </p>
-                </div>
-                <Wind class="text-primary size-6 shrink-0" aria-hidden="true" />
+    <div class="divide-y">
+        <article v-for="item in sensors" :key="item.sensor.id" class="py-4 first:pt-0 last:pb-0">
+            <div class="flex flex-wrap items-center justify-between gap-2">
+                <h3 class="min-w-0 truncate font-semibold">{{ stageSafetySensorName(item.sensor) }}</h3>
+                <Badge v-if="item.status !== 'fresh'" :variant="statusVariant(item.status)">{{ item.status.replace('_', ' ') }}</Badge>
             </div>
 
-            <div class="mt-6 grid grid-cols-2 divide-x">
-                <div class="pr-4 text-center">
-                    <p class="text-primary text-4xl font-semibold tracking-tight sm:text-5xl">
+            <div class="mt-4 grid grid-cols-2 divide-x">
+                <div class="pr-3 text-center">
+                    <p class="text-primary text-3xl font-semibold tracking-tight">
                         {{ item.wind_average ? formatWindSpeed(item.wind_average.value) : '—' }}
-                        <span v-if="item.wind_average" class="text-lg font-medium">km/h</span>
+                        <span v-if="item.wind_average" class="text-sm font-medium">km/h</span>
                     </p>
-                    <p class="text-muted-foreground mt-2 text-sm">{{ readingLabel('Average', item.wind_average, item.status) }}</p>
+                    <p class="text-muted-foreground mt-1 text-xs">{{ readingLabel('Average', item.wind_average, item.status) }}</p>
                 </div>
-                <div class="pl-4 text-center">
-                    <p class="text-3xl font-semibold tracking-tight sm:text-4xl">
+                <div class="pl-3 text-center">
+                    <p class="text-2xl font-semibold tracking-tight">
                         {{ item.wind_gust ? formatWindSpeed(item.wind_gust.value) : '—' }}
-                        <span v-if="item.wind_gust" class="text-base font-medium">km/h</span>
+                        <span v-if="item.wind_gust" class="text-sm font-medium">km/h</span>
                     </p>
-                    <p class="text-muted-foreground mt-2 text-sm">{{ readingLabel('Gust', item.wind_gust, item.status) }}</p>
-                    <p v-if="item.wind_gust?.window_seconds" class="text-muted-foreground mt-1 text-xs">
-                        {{ item.wind_gust.window_seconds }} second period
-                    </p>
+                    <p class="text-muted-foreground mt-1 text-xs">{{ readingLabel('Gust', item.wind_gust, item.status) }}</p>
                 </div>
             </div>
 
-            <p class="text-muted-foreground mt-5 text-right text-xs">
+            <p class="text-muted-foreground mt-3 text-right text-xs">
                 {{ item.latest_observed_at ? `Observed ${getRelativeTime(new Date(item.latest_observed_at))}` : 'Never observed' }}
             </p>
         </article>

--- a/resources/js/components/stage-safety/CurrentWindWidget.vue
+++ b/resources/js/components/stage-safety/CurrentWindWidget.vue
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import type { Organization, StageSafetyCurrentWindPayload } from '@/types';
 import { useHttp } from '@inertiajs/vue3';
 import { useIntervalFn } from '@vueuse/core';
+import { Wind } from 'lucide-vue-next';
 import { ref } from 'vue';
 
 const props = defineProps<{ organization: Organization }>();
@@ -30,9 +31,9 @@ useIntervalFn(fetchCurrentWind, 10_000, { immediateCallback: true });
 </script>
 
 <template>
-    <Card class="flex h-full flex-col lg:col-span-2">
+    <Card class="flex h-full flex-col">
         <CardHeader>
-            <CardTitle>Current Wind</CardTitle>
+            <CardTitle class="flex items-center gap-2"><Wind class="size-4" aria-hidden="true" /> Current Wind</CardTitle>
         </CardHeader>
         <CardContent class="flex flex-1 flex-col">
             <div
@@ -42,9 +43,8 @@ useIntervalFn(fetchCurrentWind, 10_000, { immediateCallback: true });
             >
                 {{ error }}
             </div>
-            <div v-if="loading && !data" class="grid gap-4 sm:grid-cols-2">
-                <Skeleton class="h-48 w-full rounded-xl" />
-                <Skeleton class="hidden h-48 w-full rounded-xl sm:block" />
+            <div v-if="loading && !data">
+                <Skeleton class="h-40 w-full rounded-xl" />
             </div>
             <div v-else-if="!data?.sensors.length" class="text-muted-foreground flex min-h-48 items-center justify-center text-center">
                 No sensors currently report fresh wind data.

--- a/resources/js/components/stage-safety/WindHistoryChart.vue
+++ b/resources/js/components/stage-safety/WindHistoryChart.vue
@@ -4,9 +4,10 @@ import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, comp
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { StageSafetyReadingKind, StageSafetyWindHistoryPayload } from '@/types';
-import { metersPerSecondToKilometersPerHour } from '@/utils/stageSafety';
+import { metersPerSecondToKilometersPerHour, stageSafetySensorName } from '@/utils/stageSafety';
 import { CurveType } from '@unovis/ts';
 import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { Wind } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 interface ChartDataPoint {
@@ -19,12 +20,6 @@ interface ChartSeries {
     label: string;
     color: string;
     dash?: number[];
-    data: SeriesPoint[];
-}
-
-interface SeriesPoint {
-    date: Date;
-    value: number;
 }
 
 const props = defineProps<{
@@ -52,10 +47,6 @@ const selectedRange = computed({
     set: (value: string) => emit('update:timeRange', value),
 });
 
-function sensorName(sensor: StageSafetyWindHistoryPayload['sensors'][number]['sensor']): string {
-    return sensor.name || sensor.identifier;
-}
-
 function seriesKey(sensorId: number, kind: StageSafetyReadingKind): string {
     return `sensor_${sensorId}_${kind}`;
 }
@@ -64,31 +55,21 @@ const chartSeries = computed<ChartSeries[]>(() =>
     (props.data?.sensors ?? []).flatMap((item, index) => {
         const color = SENSOR_COLORS[index % SENSOR_COLORS.length];
         const series: ChartSeries[] = [];
-        const readings = (kind: StageSafetyReadingKind): SeriesPoint[] =>
-            item.readings
-                .filter((reading) => reading.kind === kind)
-                .map((reading) => ({
-                    date: new Date(reading.observed_at),
-                    value: metersPerSecondToKilometersPerHour(reading.value),
-                }));
-        const averageReadings = readings('wind_average');
-        const gustReadings = readings('wind_gust');
+        const hasReadings = (kind: StageSafetyReadingKind): boolean => item.readings.some((reading) => reading.kind === kind);
 
-        if (averageReadings.length) {
+        if (hasReadings('wind_average')) {
             series.push({
                 key: seriesKey(item.sensor.id, 'wind_average'),
-                label: `${sensorName(item.sensor)} average`,
+                label: `${stageSafetySensorName(item.sensor)} average`,
                 color,
-                data: averageReadings,
             });
         }
-        if (gustReadings.length) {
+        if (hasReadings('wind_gust')) {
             series.push({
                 key: seriesKey(item.sensor.id, 'wind_gust'),
-                label: `${sensorName(item.sensor)} gust`,
+                label: `${stageSafetySensorName(item.sensor)} gust`,
                 color,
                 dash: [6, 3],
-                data: gustReadings,
             });
         }
 
@@ -121,13 +102,23 @@ const seriesColors = computed(() => chartSeries.value.map((series) => series.col
 function formatTickDate(value: number): string {
     return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
+
+function formatWindTick(value: number): string {
+    return value.toLocaleString([], { maximumFractionDigits: 1 });
+}
+
+function seriesValue(point: ChartDataPoint, key: string): number | undefined {
+    const value = point[key];
+
+    return typeof value === 'number' ? value : undefined;
+}
 </script>
 
 <template>
     <Card class="col-span-full flex min-w-0 flex-col">
         <CardHeader class="flex flex-col gap-3 pb-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
             <div>
-                <CardTitle>Wind History</CardTitle>
+                <CardTitle class="flex items-center gap-2"><Wind class="size-4" aria-hidden="true" /> Wind History</CardTitle>
                 <p class="text-muted-foreground mt-1 text-sm">Average and gust speed in km/h</p>
             </div>
             <Select v-model="selectedRange">
@@ -172,22 +163,16 @@ function formatTickDate(value: number): string {
                         <VisLine
                             v-for="series in chartSeries"
                             :key="series.key"
-                            :data="series.data"
-                            :x="(point: SeriesPoint) => point.date.getTime()"
-                            :y="(point: SeriesPoint) => point.value"
+                            :x="(point: ChartDataPoint) => point.date.getTime()"
+                            :y="(point: ChartDataPoint) => seriesValue(point, series.key)"
                             :color="series.color"
                             :curve-type="CurveType.MonotoneX"
+                            :interpolate-missing-data="true"
                             :line-width="2"
                             :line-dash-array="series.dash"
                         />
                         <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
-                        <VisAxis
-                            type="y"
-                            :tick-line="false"
-                            :domain-line="false"
-                            :grid-line="true"
-                            :tick-format="(value: number) => Math.round(value).toString()"
-                        />
+                        <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :tick-format="formatWindTick" />
                         <ChartTooltip />
                         <ChartCrosshair
                             :template="

--- a/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
+++ b/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
@@ -1,8 +1,17 @@
 import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import CurrentWindDisplay from '../CurrentWindDisplay.vue';
 
 describe('CurrentWindDisplay', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('renders multiple sensors in km/h and labels stale readings as last known', () => {
         const wrapper = mount(CurrentWindDisplay, {
             props: {
@@ -11,6 +20,7 @@ describe('CurrentWindDisplay', () => {
                         sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: 'Roof', stale_after_seconds: 300 },
                         status: 'archived',
                         latest_observed_at: '2026-07-25T11:59:00Z',
+                        radio_diagnostics: null,
                         wind_average: {
                             kind: 'wind_average',
                             value: 5,
@@ -27,6 +37,7 @@ describe('CurrentWindDisplay', () => {
                         sensor: { id: 2, identifier: 'DEF456', name: 'Town Hall', location: null, stale_after_seconds: 300 },
                         status: 'fresh',
                         latest_observed_at: '2026-07-25T11:59:30Z',
+                        radio_diagnostics: null,
                         wind_average: null,
                         wind_gust: {
                             kind: 'wind_gust',
@@ -43,11 +54,16 @@ describe('CurrentWindDisplay', () => {
             },
         });
 
-        expect(wrapper.text()).toContain('Main Stage');
+        expect(wrapper.text()).toContain('Roof');
+        expect(wrapper.text()).not.toContain('Main Stage');
         expect(wrapper.text()).toContain('Town Hall');
         expect(wrapper.text()).toContain('18');
         expect(wrapper.text()).toContain('29');
         expect(wrapper.text()).toContain('Last known average');
         expect(wrapper.text()).toContain('Last known gust');
+        expect(wrapper.text()).toContain('Observed 30 seconds ago');
+        expect(wrapper.text()).not.toMatch(/\bfresh\b/i);
+        expect(wrapper.text()).not.toContain('second period');
+        expect(wrapper.findAll('article').every((article) => !article.classes().includes('border'))).toBe(true);
     });
 });

--- a/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import WindHistoryChart from '../WindHistoryChart.vue';
 
 vi.mock('@unovis/vue', () => ({
-    VisXYContainer: { template: '<div><slot /></div>' },
-    VisLine: { props: ['data'], template: '<div class="series-line" :data-count="data.length" />' },
+    VisXYContainer: { name: 'VisXYContainer', props: ['data'], template: '<div><slot /></div>' },
+    VisLine: { name: 'VisLine', props: ['y', 'interpolateMissingData'], template: '<div class="series-line" />' },
     VisAxis: { template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: { template: '<div />' },
@@ -32,11 +32,11 @@ const history: StageSafetyWindHistoryPayload = {
     to: '2026-07-25T12:00:00Z',
     sensors: [
         {
-            sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: null, stale_after_seconds: 300 },
+            sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: 'Roof', stale_after_seconds: 300 },
             readings: [
                 { kind: 'wind_average', value: 5, unit: 'm/s', observed_at: '2026-07-25T11:30:00Z', window_seconds: 10 },
                 { kind: 'wind_average', value: 6, unit: 'm/s', observed_at: '2026-07-25T11:40:00Z', window_seconds: 10 },
-                { kind: 'wind_gust', value: 8, unit: 'm/s', observed_at: '2026-07-25T11:30:00Z', window_seconds: 10 },
+                { kind: 'wind_gust', value: 8, unit: 'm/s', observed_at: '2026-07-25T11:35:00Z', window_seconds: 10 },
             ],
         },
         {
@@ -61,10 +61,18 @@ describe('WindHistoryChart', () => {
             global: { stubs: chartStubs },
         });
 
-        expect(wrapper.text()).toContain('Main Stage average');
-        expect(wrapper.text()).toContain('Main Stage gust');
+        expect(wrapper.text()).toContain('Roof average');
+        expect(wrapper.text()).toContain('Roof gust');
         expect(wrapper.text()).toContain('DEF456 average');
-        expect(wrapper.findAll('.series-line').map((line) => line.attributes('data-count'))).toEqual(['2', '1', '1']);
+
+        const rows = wrapper.findComponent({ name: 'VisXYContainer' }).props('data') as Array<Record<string, number | Date | undefined>>;
+        const lines = wrapper.findAllComponents({ name: 'VisLine' });
+
+        expect(lines).toHaveLength(3);
+        expect(lines.every((line) => line.props('interpolateMissingData') === true)).toBe(true);
+        expect(lines[0].props('y')(rows[0])).toBe(18);
+        expect(lines[0].props('y')(rows[1])).toBeUndefined();
+        expect(lines[1].props('y')(rows[1])).toBe(28.8);
     });
 
     it('emits selected time range', async () => {

--- a/resources/js/pages/orgmgmt/Dashboard.vue
+++ b/resources/js/pages/orgmgmt/Dashboard.vue
@@ -2,9 +2,8 @@
 import ActiveAreaCountsWidget from '@/components/peoplecount/ActiveAreaCountsWidget.vue';
 import AreaCountHistoryWidget from '@/components/peoplecount/AreaCountHistoryWidget.vue';
 import MostActiveSensorsWidget from '@/components/peoplecount/MostActiveSensorsWidget.vue';
-import SensorHealthStatusWidget from '@/components/peoplecount/SensorHealthStatusWidget.vue';
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
 import CurrentWindWidget from '@/components/stage-safety/CurrentWindWidget.vue';
-import SensorHealthWidget from '@/components/stage-safety/SensorHealthWidget.vue';
 import WindHistoryWidget from '@/components/stage-safety/WindHistoryWidget.vue';
 import { usePermissions } from '@/composables/usePermissions';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
@@ -17,14 +16,9 @@ const props = defineProps<{
 }>();
 
 const { can } = usePermissions();
-const canViewPeoplecountWidgets = computed(() =>
-    [
-        'peoplecount.widgets.active_area_counts',
-        'peoplecount.widgets.sensor_health',
-        'peoplecount.widgets.most_active_sensors',
-        'peoplecount.widgets.area_count_history',
-    ].some((permission) => can(permission)),
-);
+const canViewPeoplecountHealth = computed(() => can('peoplecount.widgets.sensor_health'));
+const canViewStageSafety = computed(() => can('stage-safety.monitoring.view'));
+const canViewSensorHealth = computed(() => canViewPeoplecountHealth.value || canViewStageSafety.value);
 
 const breadcrumbs = computed((): BreadcrumbItem[] => [
     {
@@ -45,24 +39,19 @@ const breadcrumbs = computed((): BreadcrumbItem[] => [
             <div class="mb-4">
                 <h1 class="text-2xl font-bold">{{ props.organization.name }} Dashboard</h1>
             </div>
-            <section v-if="can('stage-safety.monitoring.view')" class="space-y-4">
-                <h2 class="text-lg font-semibold">Stage Safety</h2>
-                <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                    <CurrentWindWidget :organization="organization" />
-                    <SensorHealthWidget :organization="organization" />
-                    <WindHistoryWidget :organization="organization" />
-                </div>
-            </section>
-
-            <section v-if="canViewPeoplecountWidgets" class="space-y-4">
-                <h2 class="text-lg font-semibold">People Count</h2>
-                <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                    <ActiveAreaCountsWidget v-if="can('peoplecount.widgets.active_area_counts')" :organization="organization" />
-                    <SensorHealthStatusWidget v-if="can('peoplecount.widgets.sensor_health')" :organization="organization" />
-                    <MostActiveSensorsWidget v-if="can('peoplecount.widgets.most_active_sensors')" :organization="organization" />
-                    <AreaCountHistoryWidget v-if="can('peoplecount.widgets.area_count_history')" :organization="organization" />
-                </div>
-            </section>
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <ActiveAreaCountsWidget v-if="can('peoplecount.widgets.active_area_counts')" :organization="organization" />
+                <MostActiveSensorsWidget v-if="can('peoplecount.widgets.most_active_sensors')" :organization="organization" />
+                <CurrentWindWidget v-if="canViewStageSafety" :organization="organization" />
+                <SensorHealthWidget
+                    v-if="canViewSensorHealth"
+                    :organization="organization"
+                    :show-peoplecount="canViewPeoplecountHealth"
+                    :show-stage-safety="canViewStageSafety"
+                />
+                <AreaCountHistoryWidget v-if="can('peoplecount.widgets.area_count_history')" :organization="organization" />
+                <WindHistoryWidget v-if="canViewStageSafety" :organization="organization" />
+            </div>
         </div>
     </Layout>
 </template>

--- a/resources/js/pages/orgmgmt/_tests_/Dashboard.test.ts
+++ b/resources/js/pages/orgmgmt/_tests_/Dashboard.test.ts
@@ -1,3 +1,4 @@
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
 import { shallowMount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Dashboard from '../Dashboard.vue';
@@ -15,28 +16,55 @@ describe('organization dashboard', () => {
         vi.clearAllMocks();
     });
 
-    it('does not mount Stage Safety widgets without monitoring permission', () => {
+    it('does not mount widgets without their permissions', () => {
         mocks.can.mockReturnValue(false);
         const wrapper = shallowMount(Dashboard, {
             props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
             global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
         });
 
-        expect(wrapper.text()).not.toContain('Stage Safety');
         expect(wrapper.find('current-wind-widget-stub').exists()).toBe(false);
+        expect(wrapper.find('sensor-health-widget-stub').exists()).toBe(false);
     });
 
-    it('mounts all Stage Safety widgets with monitoring permission', () => {
+    it('mounts Stage Safety widgets and configures combined health with Stage access only', () => {
         mocks.can.mockImplementation((permission: string) => permission === 'stage-safety.monitoring.view');
         const wrapper = shallowMount(Dashboard, {
             props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
             global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
         });
 
-        expect(wrapper.text()).toContain('Stage Safety');
-        expect(wrapper.text()).not.toContain('People Count');
         expect(wrapper.find('current-wind-widget-stub').exists()).toBe(true);
-        expect(wrapper.find('sensor-health-widget-stub').exists()).toBe(true);
+        expect(wrapper.findComponent(SensorHealthWidget).props()).toMatchObject({ showPeoplecount: false, showStageSafety: true });
         expect(wrapper.find('wind-history-widget-stub').exists()).toBe(true);
+    });
+
+    it('renders all widgets once in the requested order', () => {
+        mocks.can.mockReturnValue(true);
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(Array.from(wrapper.find('.grid').element.children).map((element) => element.tagName.toLowerCase())).toEqual([
+            'active-area-counts-widget-stub',
+            'most-active-sensors-widget-stub',
+            'current-wind-widget-stub',
+            'sensor-health-widget-stub',
+            'area-count-history-widget-stub',
+            'wind-history-widget-stub',
+        ]);
+        expect(wrapper.findComponent(SensorHealthWidget).props()).toMatchObject({ showPeoplecount: true, showStageSafety: true });
+    });
+
+    it('mounts combined health for Peoplecount access only', () => {
+        mocks.can.mockImplementation((permission: string) => permission === 'peoplecount.widgets.sensor_health');
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(wrapper.findComponent(SensorHealthWidget).props()).toMatchObject({ showPeoplecount: true, showStageSafety: false });
+        expect(wrapper.find('current-wind-widget-stub').exists()).toBe(false);
     });
 });

--- a/resources/js/pages/stage-safety/Sensor.vue
+++ b/resources/js/pages/stage-safety/Sensor.vue
@@ -3,11 +3,13 @@ import Heading from '@/components/Heading.vue';
 import CurrentWindDisplay from '@/components/stage-safety/CurrentWindDisplay.vue';
 import WindHistoryChart from '@/components/stage-safety/WindHistoryChart.vue';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePermissions } from '@/composables/usePermissions';
 import Layout from '@/layouts/orgmgmt/Layout.vue';
 import type { BreadcrumbItem, Organization, StageSafetySensor, StageSafetySensorMonitoringPayload } from '@/types';
+import { stageSafetySensorName } from '@/utils/stageSafety';
 import { Head, Link, useHttp } from '@inertiajs/vue3';
 import { useIntervalFn } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
@@ -25,7 +27,7 @@ const error = ref<string | null>(null);
 const timeRange = ref('1h');
 let refreshQueued = false;
 
-const title = props.sensor.name || props.sensor.identifier;
+const title = stageSafetySensorName(props.sensor);
 const currentSensors = computed(() => (monitoring.value ? [monitoring.value.current] : []));
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -91,7 +93,7 @@ useIntervalFn(fetchMonitoring, 30_000, { immediateCallback: true });
         <Head :title="`${title} Monitoring`" />
 
         <div class="flex h-full flex-1 flex-col gap-6 p-4">
-            <Heading :title="title" :description="sensor.location || `${sensor.manufacturer} ${sensor.model} · ${sensor.identifier}`">
+            <Heading :title="title" :description="`${sensor.manufacturer} ${sensor.model} · ${sensor.identifier}`">
                 <Button v-if="can('stage-safety.sensors.edit')" as-child variant="outline">
                     <Link :href="route('stage-safety.sensors.edit', { organization: organization.slug, stageSafetySensor: sensor.id })">
                         Edit sensor
@@ -113,7 +115,34 @@ useIntervalFn(fetchMonitoring, 30_000, { immediateCallback: true });
                 </CardHeader>
                 <CardContent>
                     <Skeleton v-if="loading && !monitoring" class="h-52 w-full rounded-xl" />
-                    <CurrentWindDisplay v-else-if="currentSensors.length" :sensors="currentSensors" />
+                    <template v-else-if="currentSensors.length">
+                        <CurrentWindDisplay :sensors="currentSensors" />
+                        <div v-if="monitoring?.current.radio_diagnostics" class="mt-5 grid grid-cols-3 gap-2 border-t pt-4 text-center text-sm">
+                            <div>
+                                <p class="text-muted-foreground text-xs">RSSI</p>
+                                <p class="mt-1 font-medium">
+                                    {{ monitoring.current.radio_diagnostics.rssi_dbm ?? 'Unavailable'
+                                    }}<span v-if="monitoring.current.radio_diagnostics.rssi_dbm !== null"> dBm</span>
+                                </p>
+                            </div>
+                            <div>
+                                <p class="text-muted-foreground text-xs">CV</p>
+                                <p class="mt-1 font-medium">{{ monitoring.current.radio_diagnostics.cv ?? 'Unavailable' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-muted-foreground text-xs">Battery</p>
+                                <Badge class="mt-1" :variant="monitoring.current.radio_diagnostics.battery_low ? 'destructive' : 'secondary'">
+                                    {{
+                                        monitoring.current.radio_diagnostics.battery_low === null
+                                            ? 'Unknown'
+                                            : monitoring.current.radio_diagnostics.battery_low
+                                              ? 'Low'
+                                              : 'OK'
+                                    }}
+                                </Badge>
+                            </div>
+                        </div>
+                    </template>
                     <div v-else class="text-muted-foreground flex min-h-52 items-center justify-center">No monitoring data available.</div>
                 </CardContent>
             </Card>

--- a/resources/js/pages/stage-safety/_tests_/Sensor.test.ts
+++ b/resources/js/pages/stage-safety/_tests_/Sensor.test.ts
@@ -1,0 +1,91 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Sensor from '../Sensor.vue';
+
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn(), from: '', to: '' },
+    useIntervalFn: vi.fn(),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+    usePermissions: () => ({ can: () => false }),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    Head: { template: '<div />' },
+    Link: { template: '<a><slot /></a>' },
+    useHttp: () => mocks.request,
+}));
+
+vi.mock('@vueuse/core', () => ({
+    useIntervalFn: mocks.useIntervalFn,
+}));
+
+const organization = { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' };
+const sensor = {
+    id: 1,
+    organization_id: 1,
+    manufacturer: 'Broadweigh',
+    model: 'BW-WSS',
+    identifier: 'ABC123',
+    name: 'Main Stage',
+    location: 'Roof',
+    stale_after_seconds: 300,
+    archived_at: null,
+    created_at: '',
+    updated_at: '',
+};
+
+describe('Stage Safety sensor monitoring page', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.request.processing = false;
+        mocks.request.get = mocks.get;
+        mocks.useIntervalFn.mockImplementation((callback: () => Promise<void>) => {
+            void callback();
+            return { pause: vi.fn(), resume: vi.fn(), isActive: true };
+        });
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
+    });
+
+    it('shows newest-frame radio diagnostics and location-first title', async () => {
+        mocks.get.mockResolvedValue({
+            generated_at: '2026-07-25T12:00:00Z',
+            current: {
+                sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: 'Roof', stale_after_seconds: 300 },
+                status: 'fresh',
+                latest_observed_at: '2026-07-25T12:00:00Z',
+                radio_diagnostics: { battery_low: true, rssi_dbm: -70, cv: 103 },
+                wind_average: null,
+                wind_gust: null,
+            },
+            history: {
+                generated_at: '2026-07-25T12:00:00Z',
+                from: '2026-07-25T11:00:00Z',
+                to: '2026-07-25T12:00:00Z',
+                sensors: [],
+            },
+        });
+
+        const wrapper = mount(Sensor, {
+            props: { organization, sensor },
+            global: {
+                stubs: {
+                    Layout: { template: '<main><slot /></main>' },
+                    CurrentWindDisplay: true,
+                    WindHistoryChart: true,
+                },
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('Roof');
+        expect(wrapper.text()).toContain('-70 dBm');
+        expect(wrapper.text()).toContain('103');
+        expect(wrapper.text()).toContain('Low');
+    });
+});

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -144,6 +144,11 @@ export interface StageSafetyCurrentSensor {
     sensor: StageSafetySensorSummary;
     status: StageSafetySensorHealthStatus;
     latest_observed_at: string | null;
+    radio_diagnostics: {
+        battery_low: boolean | null;
+        rssi_dbm: number | null;
+        cv: number | null;
+    } | null;
     wind_average: StageSafetyCurrentReading | null;
     wind_gust: StageSafetyCurrentReading | null;
 }

--- a/resources/js/utils/_tests_/dateTimeHelpers.test.ts
+++ b/resources/js/utils/_tests_/dateTimeHelpers.test.ts
@@ -463,6 +463,14 @@ describe('Date Utility Functions', () => {
             expect(getRelativeTime(new Date('2024-07-25T12:00:28Z'))).toBe('in 28 seconds');
         });
 
+        it('should round relative units equally for past and future dates', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));
+
+            expect(getRelativeTime(new Date('2024-07-25T11:58:01Z'))).toBe('2 minutes ago');
+            expect(getRelativeTime(new Date('2024-07-25T12:01:59Z'))).toBe('in 2 minutes');
+        });
+
         it('should return "in X minutes" for near future', () => {
             vi.useFakeTimers();
             vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));

--- a/resources/js/utils/_tests_/dateTimeHelpers.test.ts
+++ b/resources/js/utils/_tests_/dateTimeHelpers.test.ts
@@ -455,6 +455,14 @@ describe('Date Utility Functions', () => {
             expect(relative).toBe('5 minutes ago');
         });
 
+        it('should return seconds for observations less than one minute old', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));
+
+            expect(getRelativeTime(new Date('2024-07-25T11:59:32Z'))).toBe('28 seconds ago');
+            expect(getRelativeTime(new Date('2024-07-25T12:00:28Z'))).toBe('in 28 seconds');
+        });
+
         it('should return "in X minutes" for near future', () => {
             vi.useFakeTimers();
             vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));

--- a/resources/js/utils/_tests_/stageSafety.test.ts
+++ b/resources/js/utils/_tests_/stageSafety.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { formatWindSpeed, metersPerSecondToKilometersPerHour } from '../stageSafety';
+import { formatWindSpeed, metersPerSecondToKilometersPerHour, stageSafetySensorName } from '../stageSafety';
 
 describe('Stage Safety wind formatting', () => {
     it('converts canonical meters per second to kilometers per hour', () => {
         expect(metersPerSecondToKilometersPerHour(5)).toBe(18);
         expect(formatWindSpeed(8.0556)).toBe('29');
+    });
+
+    it('uses location, name, then identifier as the sensor label', () => {
+        expect(stageSafetySensorName({ location: 'Roof', name: 'Main Stage', identifier: 'ABC123' })).toBe('Roof');
+        expect(stageSafetySensorName({ location: null, name: 'Main Stage', identifier: 'ABC123' })).toBe('Main Stage');
+        expect(stageSafetySensorName({ location: null, name: null, identifier: 'ABC123' })).toBe('ABC123');
     });
 });

--- a/resources/js/utils/dateTimeHelpers.ts
+++ b/resources/js/utils/dateTimeHelpers.ts
@@ -272,10 +272,10 @@ export function getRelativeTime(date: Date): string {
     const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
 
     if (Math.abs(diffSeconds) < 60) return formatter.format(diffSeconds, 'second');
-    if (Math.abs(diffSeconds) < 3600) return formatter.format(Math.trunc(diffSeconds / 60), 'minute');
-    if (Math.abs(diffSeconds) < 86400) return formatter.format(Math.trunc(diffSeconds / 3600), 'hour');
+    if (Math.abs(diffSeconds) < 3600) return formatter.format(Math.round(diffSeconds / 60), 'minute');
+    if (Math.abs(diffSeconds) < 86400) return formatter.format(Math.round(diffSeconds / 3600), 'hour');
 
-    return formatter.format(Math.trunc(diffSeconds / 86400), 'day');
+    return formatter.format(Math.round(diffSeconds / 86400), 'day');
 }
 
 /**

--- a/resources/js/utils/dateTimeHelpers.ts
+++ b/resources/js/utils/dateTimeHelpers.ts
@@ -268,21 +268,14 @@ export function isFuture(date: Date): boolean {
  * Get relative time string (e.g., "2 hours ago", "in 3 days")
  */
 export function getRelativeTime(date: Date): string {
-    const now = new Date();
-    const diffMs = date.getTime() - now.getTime();
-    const diffMinutes = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    const diffSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+    const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
 
-    if (Math.abs(diffMinutes) < 1) {
-        return 'now';
-    } else if (Math.abs(diffMinutes) < 60) {
-        return diffMinutes > 0 ? `in ${diffMinutes} minutes` : `${Math.abs(diffMinutes)} minutes ago`;
-    } else if (Math.abs(diffHours) < 24) {
-        return diffHours > 0 ? `in ${diffHours} hours` : `${Math.abs(diffHours)} hours ago`;
-    } else {
-        return diffDays > 0 ? `in ${diffDays} days` : `${Math.abs(diffDays)} days ago`;
-    }
+    if (Math.abs(diffSeconds) < 60) return formatter.format(diffSeconds, 'second');
+    if (Math.abs(diffSeconds) < 3600) return formatter.format(Math.trunc(diffSeconds / 60), 'minute');
+    if (Math.abs(diffSeconds) < 86400) return formatter.format(Math.trunc(diffSeconds / 3600), 'hour');
+
+    return formatter.format(Math.trunc(diffSeconds / 86400), 'day');
 }
 
 /**

--- a/resources/js/utils/stageSafety.ts
+++ b/resources/js/utils/stageSafety.ts
@@ -5,3 +5,7 @@ export function metersPerSecondToKilometersPerHour(value: number): number {
 export function formatWindSpeed(value: number): string {
     return Number(metersPerSecondToKilometersPerHour(value).toFixed(1)).toString();
 }
+
+export function stageSafetySensorName(sensor: { location: string | null; name: string | null; identifier: string }): string {
+    return sensor.location || sensor.name || sensor.identifier;
+}

--- a/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
+++ b/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
@@ -38,6 +38,9 @@ it('returns every fresh sensor with independently resolved latest readings', fun
         'value' => 4.5,
         'observed_at' => now()->subMinutes(6),
         'received_at' => now()->subMinutes(6)->addSeconds(3),
+        'battery_low' => false,
+        'rssi_dbm' => -90,
+        'cv' => 70,
     ]);
     Reading::factory()->for($sensor)->create([
         'kind' => ReadingKind::WindGust,
@@ -45,6 +48,9 @@ it('returns every fresh sensor with independently resolved latest readings', fun
         'observed_at' => now()->subMinute(),
         'received_at' => now()->subMinute()->addSeconds(4),
         'window_seconds' => 10,
+        'battery_low' => true,
+        'rssi_dbm' => -65,
+        'cv' => 105,
     ]);
 
     $staleSensor = Sensor::factory()->for($organization)->create(['stale_after_seconds' => 300]);
@@ -75,7 +81,12 @@ it('returns every fresh sensor with independently resolved latest readings', fun
         ->and($payload['sensors'][0]['wind_average']['status'])->toBe('stale')
         ->and($payload['sensors'][0]['wind_average']['receipt_delay_seconds'])->toBe(3)
         ->and($payload['sensors'][0]['wind_gust']['value'])->toBe(7.25)
-        ->and($payload['sensors'][0]['wind_gust']['window_seconds'])->toBe(10);
+        ->and($payload['sensors'][0]['wind_gust']['window_seconds'])->toBe(10)
+        ->and($payload['sensors'][0]['radio_diagnostics'])->toBe([
+            'battery_low' => true,
+            'rssi_dbm' => -65,
+            'cv' => 105,
+        ]);
 });
 
 it('classifies sensor health at the stale boundary and excludes archived sensors', function () {


### PR DESCRIPTION
Improves monitoring clarity across Peoplecount and Stage Safety with a compact dashboard flow, permission-aware combined sensor health, and radio diagnostics on sensor detail pages. Fixes wind history rendering when average and gust readings arrive at different timestamps.

## Details

- [SensorHealthWidget.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/sensor-monitoring-dashboard/resources/js/components/SensorHealthWidget.vue) - combines both health sources while fetching only endpoints available to current user.
- [WindHistoryChart.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/sensor-monitoring-dashboard/resources/js/components/stage-safety/WindHistoryChart.vue) - renders sparse asynchronous wind series correctly.
- [Sensor.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/sensor-monitoring-dashboard/resources/js/pages/stage-safety/Sensor.vue) - displays newest-frame battery, RSSI, and CV diagnostics.

## Notes

Formatting, PHPStan, coverage, type coverage, 200 frontend tests, focused PHP tests, and production build pass. E2E web-server timeout is expected in development environment.

## Reviewer Setup

Frontend assets changed. Run:

```sh
npm run build
```

---
**«Nothing worth having comes easy.»**
_Theodore Roosevelt_