### PR TITLE
Improve dashboard widget reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "musikfestapp",
             "dependencies": {
                 "@headlessui/vue": "^1.7.23",
                 "@inertiajs/vue3": "^3.6.1",
@@ -741,9 +740,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -761,9 +757,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -781,9 +774,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -801,9 +791,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -821,9 +808,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -841,9 +825,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -861,9 +842,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -881,9 +859,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -901,9 +876,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -927,9 +899,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -953,9 +922,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -979,9 +945,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1005,9 +968,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1031,9 +991,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1057,9 +1014,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1083,9 +1037,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1567,9 +1518,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1585,9 +1533,6 @@
             "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1605,9 +1550,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1623,9 +1565,6 @@
             "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1643,9 +1582,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1661,9 +1597,6 @@
             "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1752,9 +1685,6 @@
             "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1923,9 +1853,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1943,9 +1870,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1961,9 +1885,6 @@
             "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1982,9 +1903,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7094,9 +7012,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -7176,9 +7091,6 @@
             "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MPL-2.0",
             "optional": true,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
         "test": "vitest run",
+        "test:architecture": "vitest run resources/js/architecture.test.ts",
         "test:watch": "vitest watch",
         "test:coverage": "vitest run --coverage",
         "mailpit:start": "mailpit",

--- a/resources/js/architecture.test.ts
+++ b/resources/js/architecture.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+const browserSources = import.meta.glob('./**/*.{ts,vue}', { eager: true, import: 'default', query: '?raw' }) as Record<string, string>;
+
+describe('frontend architecture', () => {
+    it('uses Inertia HTTP instead of importing Axios directly', () => {
+        const offenders = Object.entries(browserSources)
+            .filter(([, source]) => /(?:from\s*|import\s*)['"]axios['"]/.test(source))
+            .map(([path]) => path);
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/resources/js/architecture.test.ts
+++ b/resources/js/architecture.test.ts
@@ -1,13 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
 const browserSources = import.meta.glob('./**/*.{ts,vue}', { eager: true, import: 'default', query: '?raw' }) as Record<string, string>;
+const axiosImportPatterns = [
+    /^\s*import\s+(?:(?:type\s+)?[^;]*?\s+from\s+)?['"]axios['"]/m,
+    /\bimport\s*\(\s*['"]axios['"]\s*\)/,
+    /\brequire\s*\(\s*['"]axios['"]\s*\)/,
+];
+
+function importsAxios(source: string): boolean {
+    return axiosImportPatterns.some((pattern) => pattern.test(source));
+}
 
 describe('frontend architecture', () => {
     it('uses Inertia HTTP instead of importing Axios directly', () => {
         const offenders = Object.entries(browserSources)
-            .filter(([, source]) => /(?:from\s*|import\s*)['"]axios['"]/.test(source))
+            .filter(([, source]) => importsAxios(source))
             .map(([path]) => path);
 
         expect(offenders).toEqual([]);
+    });
+
+    it('detects supported Axios imports without matching comments', () => {
+        expect(importsAxios(['import axios ', "from 'axios'"].join(''))).toBe(true);
+        expect(importsAxios(['import(', "'axios'", ')'].join(''))).toBe(true);
+        expect(importsAxios(['require(', "'axios'", ')'].join(''))).toBe(true);
+        expect(importsAxios(['// import axios ', "from 'axios'"].join(''))).toBe(false);
     });
 });

--- a/resources/js/components/SensorHealthWidget.vue
+++ b/resources/js/components/SensorHealthWidget.vue
@@ -52,8 +52,9 @@ async function fetchPeoplecount(): Promise<void> {
     if (!props.showPeoplecount || peoplecountRequest.processing) return;
 
     try {
+        const response = await peoplecountRequest.get(route('peoplecount.sensor-health.index', { organization: props.organization.slug }));
         peoplecountError.value = null;
-        peoplecount.value = await peoplecountRequest.get(route('peoplecount.sensor-health.index', { organization: props.organization.slug }));
+        peoplecount.value = response;
     } catch {
         peoplecountError.value = 'Failed to load Peoplecount sensor health.';
     } finally {
@@ -65,8 +66,9 @@ async function fetchStageSafety(): Promise<void> {
     if (!props.showStageSafety || stageSafetyRequest.processing) return;
 
     try {
+        const response = await stageSafetyRequest.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
         stageSafetyError.value = null;
-        stageSafety.value = await stageSafetyRequest.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
+        stageSafety.value = response;
     } catch {
         stageSafetyError.value = 'Failed to load Stage Safety sensor health.';
     } finally {

--- a/resources/js/components/peoplecount/ActiveAreaCountsWidget.vue
+++ b/resources/js/components/peoplecount/ActiveAreaCountsWidget.vue
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePermissions } from '@/composables/usePermissions';
-import axios from 'axios';
+import { useHttp } from '@inertiajs/vue3';
 import { Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
@@ -33,6 +33,7 @@ const props = defineProps<{
 const { can } = usePermissions();
 
 const areaCounts = ref<AreaCount[]>([]);
+const request = useHttp<Record<string, never>, AreaCount[]>({});
 const loading = ref(true);
 const error = ref<string | null>(null);
 let refreshInterval: number | null = null;
@@ -41,12 +42,12 @@ let refreshInterval: number | null = null;
 const canViewDebugCounts = computed(() => can('peoplecount.areas.*'));
 
 const fetchAreaCounts = async () => {
-    try {
-        loading.value = true;
-        error.value = null;
+    if (request.processing) return;
 
-        const response = await axios.get(`/${props.organization.slug}/peoplecount/area-aggregation`);
-        areaCounts.value = response.data;
+    try {
+        const response = await request.get(route('peoplecount.area-aggregation.index', { organization: props.organization.slug }));
+        error.value = null;
+        areaCounts.value = response;
     } catch (err) {
         error.value = 'Failed to load area counts';
         console.error(err);

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -165,11 +165,11 @@ async function fetchHistory(): Promise<void> {
             console.error(err);
         }
     } finally {
-        loading.value = false;
-
         if (refreshQueued) {
             refreshQueued = false;
             void fetchHistory();
+        } else {
+            loading.value = false;
         }
     }
 }

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -6,8 +6,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Skeleton } from '@/components/ui/skeleton';
 import { CurveType } from '@unovis/ts';
 import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { useHttp } from '@inertiajs/vue3';
 import { useStorage } from '@vueuse/core';
-import axios from 'axios';
 import { ChartColumnIncreasing, ChartSpline, Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
@@ -33,6 +33,7 @@ const props = defineProps<{
 }>();
 
 const series = ref<AreaSeries[]>([]);
+const request = useHttp<{ from: string; to: string }, AreaSeries[]>({ from: '', to: '' });
 const loading = ref(true);
 const error = ref<string | null>(null);
 const timeRange = ref('1h');
@@ -141,10 +142,11 @@ function formatTickDate(d: number): string {
 
 async function fetchHistory() {
     try {
-        error.value = null;
         const params = getTimeParams();
-        const response = await axios.get(`/${props.organization.slug}/peoplecount/area-count-history`, { params });
-        series.value = response.data;
+        Object.assign(request, params);
+        const response = await request.get(route('peoplecount.area-count-history.index', { organization: props.organization.slug }));
+        error.value = null;
+        series.value = response;
         lastUpdated.value = new Date();
     } catch (err) {
         error.value = 'Failed to load area count history';
@@ -155,7 +157,6 @@ async function fetchHistory() {
 }
 
 watch(timeRange, () => {
-    loading.value = true;
     fetchHistory();
 });
 

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -41,6 +41,7 @@ const chartStyle = useStorage<'spline' | 'step'>('peoplecount.area-count-history
 const hiddenAreaIds = ref<Set<number>>(new Set());
 const lastUpdated = ref<Date | null>(null);
 let refreshInterval: number | null = null;
+let refreshQueued = false;
 
 function toggleChartStyle(): void {
     chartStyle.value = chartStyle.value === 'spline' ? 'step' : 'spline';
@@ -140,19 +141,36 @@ function formatTickDate(d: number): string {
     return new Date(d).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-async function fetchHistory() {
+async function fetchHistory(): Promise<void> {
+    if (request.processing) {
+        refreshQueued = true;
+        return;
+    }
+
+    const requestedRange = timeRange.value;
+
     try {
         const params = getTimeParams();
         Object.assign(request, params);
         const response = await request.get(route('peoplecount.area-count-history.index', { organization: props.organization.slug }));
-        error.value = null;
-        series.value = response;
-        lastUpdated.value = new Date();
+
+        if (requestedRange === timeRange.value) {
+            error.value = null;
+            series.value = response;
+            lastUpdated.value = new Date();
+        }
     } catch (err) {
-        error.value = 'Failed to load area count history';
-        console.error(err);
+        if (requestedRange === timeRange.value) {
+            error.value = 'Failed to load area count history';
+            console.error(err);
+        }
     } finally {
         loading.value = false;
+
+        if (refreshQueued) {
+            refreshQueued = false;
+            void fetchHistory();
+        }
     }
 }
 

--- a/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
+++ b/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
@@ -3,7 +3,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import axios from 'axios';
+import { useHttp } from '@inertiajs/vue3';
 import { Users } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
@@ -36,6 +36,7 @@ const props = defineProps<{ organization: { id: number; slug: string; name: stri
 const loading = ref(true);
 const error = ref<string | null>(null);
 const data = ref<AreaItem[]>([]);
+const request = useHttp<Record<string, never>, AreaItem[]>({});
 const selectedRange = ref<'10m' | '30m' | '1h' | '2h'>('10m');
 let refreshInterval: number | null = null;
 
@@ -43,11 +44,12 @@ let refreshInterval: number | null = null;
 const openArea = ref<string | undefined>(undefined);
 
 const fetchData = async () => {
+    if (request.processing) return;
+
     try {
-        loading.value = true;
+        const response = await request.get(route('peoplecount.most-active-sensors.index', { organization: props.organization.slug }));
         error.value = null;
-        const response = await axios.get(`/${props.organization.slug}/peoplecount/most-active-sensors`);
-        data.value = response.data;
+        data.value = response;
     } catch (err) {
         error.value = 'Failed to load most active sensors';
         console.error(err);

--- a/resources/js/components/peoplecount/SensorHealthStatusWidget.vue
+++ b/resources/js/components/peoplecount/SensorHealthStatusWidget.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import axios from 'axios';
+import { useHttp } from '@inertiajs/vue3';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface IntervalCountItem {
@@ -33,16 +33,18 @@ interface HealthPayload {
 const props = defineProps<{ organization: { id: number; slug: string; name: string } }>();
 
 const data = ref<HealthPayload | null>(null);
+const request = useHttp<Record<string, never>, HealthPayload>({});
 const loading = ref(true);
 const error = ref<string | null>(null);
 let refreshInterval: number | null = null;
 
 const fetchHealth = async () => {
+    if (request.processing) return;
+
     try {
-        loading.value = true;
+        const response = await request.get(route('peoplecount.sensor-health.index', { organization: props.organization.slug }));
         error.value = null;
-        const response = await axios.get(`/${props.organization.slug}/peoplecount/sensor-health`);
-        data.value = response.data;
+        data.value = response;
     } catch (err) {
         error.value = 'Failed to load sensor health';
         console.error(err);

--- a/resources/js/components/peoplecount/_tests_/ActiveAreaCountsWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/ActiveAreaCountsWidget.test.ts
@@ -1,13 +1,15 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ActiveAreaCountsWidget from '../ActiveAreaCountsWidget.vue';
 
-// Mock axios
-vi.mock('axios');
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn() },
+}));
 
 // Mock Inertia's usePage
 vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
     usePage: () => ({
         props: {
             auth: {
@@ -60,6 +62,12 @@ describe('ActiveAreaCountsWidget', () => {
     beforeEach(() => {
         // Reset mocks before each test
         vi.resetAllMocks();
+        mocks.request.processing = false;
+        mocks.request.get = mocks.get;
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
         vi.useFakeTimers();
 
         // Silence error logs from components during negative-path tests
@@ -83,8 +91,7 @@ describe('ActiveAreaCountsWidget', () => {
     });
 
     it('renders loading state initially', async () => {
-        // Mock axios.get to return a promise that doesn't resolve immediately
-        vi.mocked(axios.get).mockReturnValue(new Promise(() => {}));
+        mocks.get.mockReturnValue(new Promise(() => {}));
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -98,8 +105,7 @@ describe('ActiveAreaCountsWidget', () => {
     });
 
     it('fetches area counts on mount', async () => {
-        // Mock axios.get to return a resolved promise with mock data
-        vi.mocked(axios.get).mockResolvedValue({ data: mockAreaCounts });
+        mocks.get.mockResolvedValue(mockAreaCounts);
 
         mount(ActiveAreaCountsWidget, {
             props: {
@@ -110,13 +116,11 @@ describe('ActiveAreaCountsWidget', () => {
         // Wait for the promise to resolve
         await flushPromises();
 
-        // Check that axios.get was called with the correct URL
-        expect(axios.get).toHaveBeenCalledWith(`/${mockOrganization.slug}/peoplecount/area-aggregation`);
+        expect(mocks.get).toHaveBeenCalledWith('peoplecount.area-aggregation.index');
     });
 
     it('displays area counts correctly', async () => {
-        // Mock axios.get to return a resolved promise with mock data
-        vi.mocked(axios.get).mockResolvedValue({ data: mockAreaCounts });
+        mocks.get.mockResolvedValue(mockAreaCounts);
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -146,8 +150,7 @@ describe('ActiveAreaCountsWidget', () => {
     });
 
     it('displays a message when no active areas are found', async () => {
-        // Mock axios.get to return an empty array
-        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+        mocks.get.mockResolvedValue([]);
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -162,9 +165,21 @@ describe('ActiveAreaCountsWidget', () => {
         expect(wrapper.text()).toContain('No active areas found');
     });
 
+    it('keeps the empty state visible during background refresh', async () => {
+        mocks.get.mockResolvedValueOnce([]);
+        const wrapper = mount(ActiveAreaCountsWidget, { props: { organization: mockOrganization } });
+        await flushPromises();
+
+        mocks.get.mockReturnValueOnce(new Promise(() => {}));
+        const refresh = vi.mocked(window.setInterval).mock.calls[0][0] as () => void;
+        refresh();
+
+        expect(wrapper.text()).toContain('No active areas found');
+        expect(wrapper.find('.animate-pulse').exists()).toBe(false);
+    });
+
     it('displays an error message when API call fails', async () => {
-        // Mock axios.get to return a rejected promise
-        vi.mocked(axios.get).mockRejectedValue(new Error('API error'));
+        mocks.get.mockRejectedValue(new Error('API error'));
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -181,8 +196,7 @@ describe('ActiveAreaCountsWidget', () => {
     });
 
     it('sets up auto-refresh on mount and cleans up on unmount', async () => {
-        // Mock axios.get to return a resolved promise with mock data
-        vi.mocked(axios.get).mockResolvedValue({ data: mockAreaCounts });
+        mocks.get.mockResolvedValue(mockAreaCounts);
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -209,8 +223,7 @@ describe('ActiveAreaCountsWidget', () => {
             },
         ];
 
-        // Mock axios.get to return the stale data
-        vi.mocked(axios.get).mockResolvedValue({ data: staleAreaCounts });
+        mocks.get.mockResolvedValue(staleAreaCounts);
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {
@@ -235,8 +248,7 @@ describe('ActiveAreaCountsWidget', () => {
             },
         ];
 
-        // Mock axios.get to return the fresh data
-        vi.mocked(axios.get).mockResolvedValue({ data: freshAreaCounts });
+        mocks.get.mockResolvedValue(freshAreaCounts);
 
         const wrapper = mount(ActiveAreaCountsWidget, {
             props: {

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -1,12 +1,15 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import AreaCountHistoryWidget from '../AreaCountHistoryWidget.vue';
 
-vi.mock('axios');
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn(), from: '', to: '' },
+}));
 
 vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
     usePage: () => ({
         props: {
             auth: {
@@ -61,6 +64,14 @@ describe('AreaCountHistoryWidget', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mocks.request.processing = false;
+        mocks.request.get = mocks.get;
+        mocks.request.from = '';
+        mocks.request.to = '';
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
         vi.useFakeTimers();
 
         vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -79,7 +90,7 @@ describe('AreaCountHistoryWidget', () => {
     });
 
     it('fetches history on mount with default range', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: mockSeries });
+        mocks.get.mockResolvedValue(mockSeries);
 
         mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -88,16 +99,13 @@ describe('AreaCountHistoryWidget', () => {
 
         await flushPromises();
 
-        expect(axios.get).toHaveBeenCalledWith(`/${mockOrganization.slug}/peoplecount/area-count-history`, {
-            params: {
-                from: '2025-08-04T21:08:00.000Z',
-                to: '2025-08-04T22:08:00.000Z',
-            },
-        });
+        expect(mocks.get).toHaveBeenCalledWith('peoplecount.area-count-history.index');
+        expect(mocks.request.from).toBe('2025-08-04T21:08:00.000Z');
+        expect(mocks.request.to).toBe('2025-08-04T22:08:00.000Z');
     });
 
     it('renders the loading state initially', () => {
-        vi.mocked(axios.get).mockReturnValue(new Promise(() => {}));
+        mocks.get.mockReturnValue(new Promise(() => {}));
 
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -108,7 +116,7 @@ describe('AreaCountHistoryWidget', () => {
     });
 
     it('renders the empty state when no series are returned', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+        mocks.get.mockResolvedValue([]);
 
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -120,8 +128,22 @@ describe('AreaCountHistoryWidget', () => {
         expect(wrapper.text()).toContain('No data available');
     });
 
+    it('keeps the empty state visible while another range loads', async () => {
+        mocks.get.mockResolvedValueOnce([]).mockReturnValueOnce(new Promise(() => {}));
+        const wrapper = mount(AreaCountHistoryWidget, {
+            props: { organization: mockOrganization },
+            global: { stubs: globalStubs },
+        });
+        await flushPromises();
+
+        await wrapper.find('[data-testid="range-select"]').setValue('6h');
+
+        expect(wrapper.text()).toContain('No data available');
+        expect(wrapper.find('.animate-pulse').exists()).toBe(false);
+    });
+
     it('renders an error message when the request fails', async () => {
-        vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
+        mocks.get.mockRejectedValue(new Error('boom'));
 
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -135,7 +157,7 @@ describe('AreaCountHistoryWidget', () => {
     });
 
     it('sets up and cleans up auto-refresh', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: mockSeries });
+        mocks.get.mockResolvedValue(mockSeries);
 
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -150,7 +172,7 @@ describe('AreaCountHistoryWidget', () => {
     });
 
     it('uses selected dropdown range params', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: mockSeries });
+        mocks.get.mockResolvedValue(mockSeries);
 
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
@@ -158,17 +180,14 @@ describe('AreaCountHistoryWidget', () => {
         });
 
         await flushPromises();
-        vi.mocked(axios.get).mockClear();
+        mocks.get.mockClear();
 
         await wrapper.find('[data-testid="range-select"]').setValue('6h');
         await nextTick();
         await flushPromises();
 
-        expect(axios.get).toHaveBeenCalledWith(`/${mockOrganization.slug}/peoplecount/area-count-history`, {
-            params: {
-                from: '2025-08-04T16:08:00.000Z',
-                to: '2025-08-04T22:08:00.000Z',
-            },
-        });
+        expect(mocks.get).toHaveBeenCalledWith('peoplecount.area-count-history.index');
+        expect(mocks.request.from).toBe('2025-08-04T16:08:00.000Z');
+        expect(mocks.request.to).toBe('2025-08-04T22:08:00.000Z');
     });
 });

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -200,7 +200,7 @@ describe('AreaCountHistoryWidget', () => {
                     resolveFirst = resolve;
                 });
             })
-            .mockResolvedValue(mockSeries);
+            .mockReturnValue(new Promise(() => {}));
         const wrapper = mount(AreaCountHistoryWidget, {
             props: { organization: mockOrganization },
             global: { stubs: globalStubs },
@@ -215,5 +215,6 @@ describe('AreaCountHistoryWidget', () => {
 
         expect(mocks.get).toHaveBeenCalledTimes(2);
         expect(mocks.request.from).toBe('2025-08-04T16:08:00.000Z');
+        expect(wrapper.find('.animate-pulse').exists()).toBe(true);
     });
 });

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -190,4 +190,30 @@ describe('AreaCountHistoryWidget', () => {
         expect(mocks.request.from).toBe('2025-08-04T16:08:00.000Z');
         expect(mocks.request.to).toBe('2025-08-04T22:08:00.000Z');
     });
+
+    it('queues a range change while a request is active', async () => {
+        let resolveFirst!: (value: typeof mockSeries) => void;
+        mocks.get
+            .mockImplementationOnce(() => {
+                mocks.request.processing = true;
+                return new Promise((resolve) => {
+                    resolveFirst = resolve;
+                });
+            })
+            .mockResolvedValue(mockSeries);
+        const wrapper = mount(AreaCountHistoryWidget, {
+            props: { organization: mockOrganization },
+            global: { stubs: globalStubs },
+        });
+
+        await wrapper.find('[data-testid="range-select"]').setValue('6h');
+        expect(mocks.get).toHaveBeenCalledOnce();
+
+        mocks.request.processing = false;
+        resolveFirst(mockSeries);
+        await flushPromises();
+
+        expect(mocks.get).toHaveBeenCalledTimes(2);
+        expect(mocks.request.from).toBe('2025-08-04T16:08:00.000Z');
+    });
 });

--- a/resources/js/components/peoplecount/_tests_/MostActiveSensorsWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/MostActiveSensorsWidget.test.ts
@@ -1,11 +1,14 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import MostActiveSensorsWidget from '../MostActiveSensorsWidget.vue';
 
-vi.mock('axios');
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn() },
+}));
 
 vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
     usePage: () => ({
         props: {
             auth: {
@@ -31,6 +34,12 @@ describe('MostActiveSensorsWidget', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mocks.request.processing = false;
+        mocks.request.get = mocks.get;
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
         // Silence error logs from components during negative-path tests
         vi.spyOn(console, 'error').mockImplementation(() => {});
         vi.spyOn(window, 'setInterval').mockImplementation(() => 123 as unknown as number);
@@ -42,23 +51,36 @@ describe('MostActiveSensorsWidget', () => {
     });
 
     it('renders loading state initially', async () => {
-        vi.mocked(axios.get).mockReturnValue(new Promise(() => {}));
+        mocks.get.mockReturnValue(new Promise(() => {}));
         const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         expect(wrapper.findAll('.h-24')).toHaveLength(2);
     });
 
     it('fetches data with correct URL', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: [baseArea()] });
+        mocks.get.mockResolvedValue([baseArea()]);
         mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         await flushPromises();
-        expect(axios.get).toHaveBeenCalledWith(`/${mockOrganization.slug}/peoplecount/most-active-sensors`);
+        expect(mocks.get).toHaveBeenCalledWith('peoplecount.most-active-sensors.index');
     });
 
     it('shows empty state when no data', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+        mocks.get.mockResolvedValue([]);
         const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(wrapper.text()).toContain('No active areas or sensors.');
+    });
+
+    it('keeps the empty state visible during background refresh', async () => {
+        mocks.get.mockResolvedValueOnce([]);
+        const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
+        await flushPromises();
+
+        mocks.get.mockReturnValueOnce(new Promise(() => {}));
+        const refresh = vi.mocked(window.setInterval).mock.calls[0][0] as () => void;
+        refresh();
+
+        expect(wrapper.text()).toContain('No active areas or sensors.');
+        expect(wrapper.find('.animate-pulse').exists()).toBe(false);
     });
 
     it('sorts sensors by selected range total desc and toggles on click', async () => {
@@ -90,7 +112,7 @@ describe('MostActiveSensorsWidget', () => {
                 },
             ],
         });
-        vi.mocked(axios.get).mockResolvedValue({ data: [area] });
+        mocks.get.mockResolvedValue([area]);
         const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         await flushPromises();
 
@@ -118,7 +140,7 @@ describe('MostActiveSensorsWidget', () => {
     });
 
     it('shows error banner when API fails', async () => {
-        vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
+        mocks.get.mockRejectedValue(new Error('boom'));
         const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(wrapper.find('.text-red-500').exists()).toBe(true);
@@ -126,7 +148,7 @@ describe('MostActiveSensorsWidget', () => {
     });
 
     it('sets up and cleans up auto-refresh', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: [baseArea()] });
+        mocks.get.mockResolvedValue([baseArea()]);
         const wrapper = mount(MostActiveSensorsWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(window.setInterval).toHaveBeenCalledWith(expect.any(Function), 10000);

--- a/resources/js/components/peoplecount/_tests_/SensorHealthStatusWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/SensorHealthStatusWidget.test.ts
@@ -1,13 +1,15 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SensorHealthStatusWidget from '../SensorHealthStatusWidget.vue';
 
-// Mock axios
-vi.mock('axios');
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { processing: false, get: vi.fn() },
+}));
 
 // Mock Inertia's usePage (permissions are not directly used in the widget, but keep parity)
 vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
     usePage: () => ({
         props: {
             auth: {
@@ -37,6 +39,12 @@ describe('SensorHealthStatusWidget', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mocks.request.processing = false;
+        mocks.request.get = mocks.get;
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
         vi.useFakeTimers();
         // Silence error logs from components during negative-path tests
         vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -53,7 +61,7 @@ describe('SensorHealthStatusWidget', () => {
     });
 
     it('renders loading state initially', async () => {
-        vi.mocked(axios.get).mockReturnValue(new Promise(() => {}));
+        mocks.get.mockReturnValue(new Promise(() => {}));
 
         const wrapper = mount(SensorHealthStatusWidget, {
             props: { organization: mockOrganization },
@@ -63,29 +71,27 @@ describe('SensorHealthStatusWidget', () => {
     });
 
     it('fetches health data on mount with correct url', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: basePayload });
+        mocks.get.mockResolvedValue(basePayload);
 
         mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
 
-        expect(axios.get).toHaveBeenCalledWith(`/${mockOrganization.slug}/peoplecount/sensor-health`);
+        expect(mocks.get).toHaveBeenCalledWith('peoplecount.sensor-health.index');
     });
 
     it('displays "No active sensors" when total is 0', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: { ...basePayload, total: 0 } });
+        mocks.get.mockResolvedValue({ ...basePayload, total: 0 });
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(wrapper.text()).toContain('No active sensors');
     });
 
     it('displays all healthy state', async () => {
-        vi.mocked(axios.get).mockResolvedValue({
-            data: {
-                ...basePayload,
-                total: 2,
-                all_healthy: true,
-                healthy: [{ id: 1, serial: 'A', vendor: 'V', model: 'M', latest_ts: '2025-08-09T18:01:30Z', interval_counts: [] }],
-            },
+        mocks.get.mockResolvedValue({
+            ...basePayload,
+            total: 2,
+            all_healthy: true,
+            healthy: [{ id: 1, serial: 'A', vendor: 'V', model: 'M', latest_ts: '2025-08-09T18:01:30Z', interval_counts: [] }],
         });
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
@@ -104,7 +110,7 @@ describe('SensorHealthStatusWidget', () => {
             suspicious: [{ id: 1, serial: 'S-1', vendor: 'Axis', model: 'P8815-2', latest_ts: '2025-08-09T18:01:00Z', interval_counts: [] }],
             unhealthy: [{ id: 2, serial: 'U-1', vendor: 'Axis', model: 'P8815-2', latest_ts: '2025-08-09T17:58:00Z', interval_counts: [] }],
         };
-        vi.mocked(axios.get).mockResolvedValue({ data: payload });
+        mocks.get.mockResolvedValue(payload);
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
 
@@ -116,7 +122,7 @@ describe('SensorHealthStatusWidget', () => {
     });
 
     it('shows error when API fails', async () => {
-        vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
+        mocks.get.mockRejectedValue(new Error('boom'));
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(wrapper.find('.text-red-500').exists()).toBe(true);
@@ -124,14 +130,14 @@ describe('SensorHealthStatusWidget', () => {
     });
 
     it('applies stale-card when last_updated older than 2 minutes', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: { ...basePayload, last_updated: '2025-08-09T17:59:59Z', total: 0 } });
+        mocks.get.mockResolvedValue({ ...basePayload, last_updated: '2025-08-09T17:59:59Z', total: 0 });
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(wrapper.find('.stale-card').exists()).toBe(true);
     });
 
     it('sets up and cleans up auto-refresh', async () => {
-        vi.mocked(axios.get).mockResolvedValue({ data: basePayload });
+        mocks.get.mockResolvedValue(basePayload);
         const wrapper = mount(SensorHealthStatusWidget, { props: { organization: mockOrganization } });
         await flushPromises();
         expect(window.setInterval).toHaveBeenCalledWith(expect.any(Function), 10000);

--- a/resources/js/components/stage-safety/CurrentWindWidget.vue
+++ b/resources/js/components/stage-safety/CurrentWindWidget.vue
@@ -18,8 +18,9 @@ async function fetchCurrentWind(): Promise<void> {
     if (request.processing) return;
 
     try {
+        const response = await request.get(route('stage-safety.current-wind.index', { organization: props.organization.slug }));
         error.value = null;
-        data.value = await request.get(route('stage-safety.current-wind.index', { organization: props.organization.slug }));
+        data.value = response;
     } catch {
         error.value = 'Failed to load current wind.';
     } finally {

--- a/resources/js/components/stage-safety/SensorHealthWidget.vue
+++ b/resources/js/components/stage-safety/SensorHealthWidget.vue
@@ -21,8 +21,9 @@ async function fetchHealth(): Promise<void> {
     if (request.processing) return;
 
     try {
+        const response = await request.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
         error.value = null;
-        data.value = await request.get(route('stage-safety.sensor-health.index', { organization: props.organization.slug }));
+        data.value = response;
     } catch {
         error.value = 'Failed to load sensor health.';
     } finally {

--- a/resources/js/components/stage-safety/WindHistoryChart.vue
+++ b/resources/js/components/stage-safety/WindHistoryChart.vue
@@ -8,7 +8,7 @@ import { metersPerSecondToKilometersPerHour, stageSafetySensorName } from '@/uti
 import { CurveType } from '@unovis/ts';
 import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
 import { Wind } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 interface ChartDataPoint {
     date: Date;
@@ -33,7 +33,8 @@ const emit = defineEmits<{
     'update:timeRange': [value: string];
 }>();
 
-const SENSOR_COLORS = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
+const SENSOR_COLORS = ['var(--color-chart-1)', 'var(--color-chart-2)', 'var(--color-chart-3)', 'var(--color-chart-4)', 'var(--color-chart-5)'];
+const hiddenSeriesKeys = ref<Set<string>>(new Set());
 const timeRangeOptions = [
     { value: '1h', label: 'Last hour' },
     { value: '3h', label: 'Last 3 hours' },
@@ -49,6 +50,35 @@ const selectedRange = computed({
 
 function seriesKey(sensorId: number, kind: StageSafetyReadingKind): string {
     return `sensor_${sensorId}_${kind}`;
+}
+
+function isSeriesVisible(key: string): boolean {
+    return !hiddenSeriesKeys.value.has(key);
+}
+
+function toggleSeriesVisibility(key: string): void {
+    const next = new Set(hiddenSeriesKeys.value);
+
+    if (next.has(key)) {
+        next.delete(key);
+    } else {
+        next.add(key);
+    }
+
+    hiddenSeriesKeys.value = next;
+}
+
+function toggleLegendSeries(key: string, event: MouseEvent): void {
+    if (event.shiftKey) {
+        toggleSeriesVisibility(key);
+        return;
+    }
+
+    const visibleKeys = chartSeries.value.filter((series) => isSeriesVisible(series.key)).map((series) => series.key);
+    hiddenSeriesKeys.value =
+        visibleKeys.length === 1 && visibleKeys[0] === key
+            ? new Set()
+            : new Set(chartSeries.value.map((series) => series.key).filter((seriesKey) => seriesKey !== key));
 }
 
 const chartSeries = computed<ChartSeries[]>(() =>
@@ -75,6 +105,20 @@ const chartSeries = computed<ChartSeries[]>(() =>
 
         return series;
     }),
+);
+
+watch(
+    () => chartSeries.value.map((series) => series.key).join(','),
+    () => {
+        const availableKeys = new Set(chartSeries.value.map((series) => series.key));
+        const next = new Set([...hiddenSeriesKeys.value].filter((key) => availableKeys.has(key)));
+
+        if (availableKeys.size > 0 && [...availableKeys].every((key) => next.has(key))) {
+            next.clear();
+        }
+
+        hiddenSeriesKeys.value = next;
+    },
 );
 
 const chartConfig = computed<ChartConfig>(() =>
@@ -160,17 +204,18 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
                     aria-label="Wind history in kilometers per hour"
                 >
                     <VisXYContainer :data="chartData" :margin="{ top: 8, right: 8, bottom: 24, left: 38 }">
-                        <VisLine
-                            v-for="series in chartSeries"
-                            :key="series.key"
-                            :x="(point: ChartDataPoint) => point.date.getTime()"
-                            :y="(point: ChartDataPoint) => seriesValue(point, series.key)"
-                            :color="series.color"
-                            :curve-type="CurveType.MonotoneX"
-                            :interpolate-missing-data="true"
-                            :line-width="2"
-                            :line-dash-array="series.dash"
-                        />
+                        <template v-for="series in chartSeries" :key="series.key">
+                            <VisLine
+                                v-if="isSeriesVisible(series.key)"
+                                :x="(point: ChartDataPoint) => point.date.getTime()"
+                                :y="(point: ChartDataPoint) => seriesValue(point, series.key)"
+                                :color="series.color"
+                                :curve-type="CurveType.MonotoneX"
+                                :interpolate-missing-data="true"
+                                :line-width="2"
+                                :line-dash-array="series.dash"
+                            />
+                        </template>
                         <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
                         <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :tick-format="formatWindTick" />
                         <ChartTooltip />
@@ -193,8 +238,22 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
                 </ChartContainer>
 
                 <div class="mt-4 flex flex-wrap gap-x-5 gap-y-2 border-t pt-3 text-sm">
-                    <div v-for="series in chartSeries" :key="`legend-${series.key}`" class="flex items-center gap-2">
-                        <svg width="24" height="8" :style="{ color: series.color }" aria-hidden="true">
+                    <button
+                        v-for="series in chartSeries"
+                        :key="`legend-${series.key}`"
+                        type="button"
+                        class="hover:bg-accent flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-left"
+                        :aria-label="`Show only ${series.label}. Shift-click to toggle visibility.`"
+                        :data-series="series.key"
+                        @click="toggleLegendSeries(series.key, $event)"
+                    >
+                        <svg
+                            width="24"
+                            height="8"
+                            :style="{ color: series.color }"
+                            :class="{ 'opacity-40': !isSeriesVisible(series.key) }"
+                            aria-hidden="true"
+                        >
                             <line
                                 x1="0"
                                 y1="4"
@@ -205,8 +264,8 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
                                 :stroke-dasharray="series.dash?.join(',') ?? 'none'"
                             />
                         </svg>
-                        <span>{{ series.label }}</span>
-                    </div>
+                        <span :class="{ 'text-muted-foreground line-through': !isSeriesVisible(series.key) }">{{ series.label }}</span>
+                    </button>
                 </div>
             </div>
         </CardContent>

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -39,10 +39,11 @@ async function fetchHistory(): Promise<void> {
             error.value = 'Failed to load wind history.';
         }
     } finally {
-        loading.value = false;
         if (refreshQueued) {
             refreshQueued = false;
             void fetchHistory();
+        } else {
+            loading.value = false;
         }
     }
 }

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -29,9 +29,11 @@ async function fetchHistory(): Promise<void> {
     Object.assign(request, timeParams());
 
     try {
-        error.value = null;
         const response = await request.get(route('stage-safety.wind-history.index', { organization: props.organization.slug }));
-        if (requestedRange === timeRange.value) data.value = response;
+        if (requestedRange === timeRange.value) {
+            error.value = null;
+            data.value = response;
+        }
     } catch {
         error.value = 'Failed to load wind history.';
     } finally {
@@ -44,8 +46,6 @@ async function fetchHistory(): Promise<void> {
 }
 
 watch(timeRange, () => {
-    data.value = null;
-    loading.value = true;
     void fetchHistory();
 });
 

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -35,7 +35,9 @@ async function fetchHistory(): Promise<void> {
             data.value = response;
         }
     } catch {
-        error.value = 'Failed to load wind history.';
+        if (requestedRange === timeRange.value) {
+            error.value = 'Failed to load wind history.';
+        }
     } finally {
         loading.value = false;
         if (refreshQueued) {

--- a/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
+++ b/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
@@ -174,4 +174,35 @@ describe('Stage Safety monitoring widgets', () => {
         expect(mocks.get).toHaveBeenCalledTimes(2);
         expect(mocks.request.from).toBe('2026-07-25T06:00:00.000Z');
     });
+
+    it('ignores an error from a stale history range', async () => {
+        let rejectFirst!: (reason: Error) => void;
+        mocks.get
+            .mockImplementationOnce(() => {
+                mocks.request.processing = true;
+                return new Promise((_, reject) => {
+                    rejectFirst = reject;
+                });
+            })
+            .mockReturnValueOnce(new Promise(() => {}));
+        const wrapper = mount(WindHistoryWidget, {
+            props: { organization },
+            global: {
+                stubs: {
+                    WindHistoryChart: {
+                        name: 'WindHistoryChart',
+                        props: ['error'],
+                        emits: ['update:timeRange'],
+                        template: '<button data-testid="range" @click="$emit(\'update:timeRange\', \'6h\')">range</button>',
+                    },
+                },
+            },
+        });
+        await wrapper.find('[data-testid="range"]').trigger('click');
+        mocks.request.processing = false;
+        rejectFirst(new Error('stale request failed'));
+        await flushPromises();
+
+        expect(wrapper.findComponent({ name: 'WindHistoryChart' }).props('error')).toBeNull();
+    });
 });

--- a/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
+++ b/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
@@ -116,6 +116,35 @@ describe('Stage Safety monitoring widgets', () => {
         expect(mocks.useIntervalFn).toHaveBeenCalledWith(expect.any(Function), 30_000, { immediateCallback: true });
     });
 
+    it('keeps current history visible while another range loads', async () => {
+        const current = {
+            generated_at: '',
+            from: '2026-07-25T11:00:00Z',
+            to: '2026-07-25T12:00:00Z',
+            sensors: [],
+        };
+        mocks.get.mockResolvedValueOnce(current).mockReturnValueOnce(new Promise(() => {}));
+        const wrapper = mount(WindHistoryWidget, {
+            props: { organization },
+            global: {
+                stubs: {
+                    WindHistoryChart: {
+                        name: 'WindHistoryChart',
+                        props: ['data', 'loading', 'timeRange'],
+                        emits: ['update:timeRange'],
+                        template: '<button data-testid="range" @click="$emit(\'update:timeRange\', \'6h\')">range</button>',
+                    },
+                },
+            },
+        });
+        await flushPromises();
+
+        await wrapper.find('[data-testid="range"]').trigger('click');
+
+        expect(wrapper.findComponent({ name: 'WindHistoryChart' }).props('data')).toEqual(current);
+        expect(wrapper.findComponent({ name: 'WindHistoryChart' }).props('loading')).toBe(false);
+    });
+
     it('queues a changed history range while a request is active', async () => {
         let resolveFirst!: (value: { generated_at: string; from: string; to: string; sensors: never[] }) => void;
         mocks.get

--- a/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
+++ b/resources/js/components/stage-safety/_tests_/MonitoringWidgets.test.ts
@@ -154,12 +154,14 @@ describe('Stage Safety monitoring widgets', () => {
                     resolveFirst = resolve;
                 });
             })
-            .mockResolvedValue({ generated_at: '', from: '', to: '', sensors: [] });
+            .mockReturnValue(new Promise(() => {}));
         const wrapper = mount(WindHistoryWidget, {
             props: { organization },
             global: {
                 stubs: {
                     WindHistoryChart: {
+                        name: 'WindHistoryChart',
+                        props: ['loading'],
                         emits: ['update:timeRange'],
                         template: '<button data-testid="range" @click="$emit(\'update:timeRange\', \'6h\')">range</button>',
                     },
@@ -173,6 +175,7 @@ describe('Stage Safety monitoring widgets', () => {
 
         expect(mocks.get).toHaveBeenCalledTimes(2);
         expect(mocks.request.from).toBe('2026-07-25T06:00:00.000Z');
+        expect(wrapper.findComponent({ name: 'WindHistoryChart' }).props('loading')).toBe(true);
     });
 
     it('ignores an error from a stale history range', async () => {

--- a/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryChart.test.ts
@@ -5,7 +5,7 @@ import WindHistoryChart from '../WindHistoryChart.vue';
 
 vi.mock('@unovis/vue', () => ({
     VisXYContainer: { name: 'VisXYContainer', props: ['data'], template: '<div><slot /></div>' },
-    VisLine: { name: 'VisLine', props: ['y', 'interpolateMissingData'], template: '<div class="series-line" />' },
+    VisLine: { name: 'VisLine', props: ['y', 'color', 'interpolateMissingData'], template: '<div class="series-line" />' },
     VisAxis: { template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: { template: '<div />' },
@@ -70,9 +70,48 @@ describe('WindHistoryChart', () => {
 
         expect(lines).toHaveLength(3);
         expect(lines.every((line) => line.props('interpolateMissingData') === true)).toBe(true);
+        expect(lines[0].props('color')).toBe('var(--color-chart-1)');
         expect(lines[0].props('y')(rows[0])).toBe(18);
         expect(lines[0].props('y')(rows[1])).toBeUndefined();
         expect(lines[1].props('y')(rows[1])).toBe(28.8);
+    });
+
+    it('shows only a clicked legend series and restores all when clicked again', async () => {
+        const wrapper = mount(WindHistoryChart, {
+            props: { data: history, loading: false, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+        const legend = wrapper.find('[data-series="sensor_1_wind_average"]');
+
+        await legend.trigger('click');
+        expect(wrapper.findAllComponents({ name: 'VisLine' })).toHaveLength(1);
+        expect(wrapper.find('[data-series="sensor_1_wind_gust"] span').classes()).toContain('line-through');
+
+        await legend.trigger('click');
+        expect(wrapper.findAllComponents({ name: 'VisLine' })).toHaveLength(3);
+    });
+
+    it('restores visibility when the isolated series disappears', async () => {
+        const wrapper = mount(WindHistoryChart, {
+            props: { data: history, loading: false, error: null, timeRange: '1h' },
+            global: { stubs: chartStubs },
+        });
+        await wrapper.find('[data-series="sensor_1_wind_average"]').trigger('click');
+
+        await wrapper.setProps({
+            data: {
+                ...history,
+                sensors: [
+                    {
+                        ...history.sensors[0],
+                        readings: history.sensors[0].readings.filter((reading) => reading.kind === 'wind_gust'),
+                    },
+                ],
+            },
+        });
+
+        expect(wrapper.findAllComponents({ name: 'VisLine' })).toHaveLength(1);
+        expect(wrapper.find('[data-series="sensor_1_wind_gust"] span').classes()).not.toContain('line-through');
     });
 
     it('emits selected time range', async () => {

--- a/resources/js/pages/stage-safety/EditSensor.vue
+++ b/resources/js/pages/stage-safety/EditSensor.vue
@@ -31,6 +31,7 @@ const form = useForm<StageSafetySensorFormData>({
 });
 const tokenRequest = useHttp<Record<string, never>, { token: string }>({});
 const token = ref<string | null>(null);
+const tokenRegenerationPending = ref(false);
 const confirmDialog = useConfirmDialog();
 const { can } = usePermissions();
 
@@ -66,17 +67,21 @@ function updateForm(values: Partial<StageSafetySensorFormData>): void {
 }
 
 async function regenerateToken(): Promise<void> {
-    const confirmed = await confirmDialog.confirm({
-        title: props.sensor.has_active_token ? 'Replace sensor token?' : 'Generate sensor token?',
-        description: props.sensor.has_active_token ? 'The current API token will stop working immediately.' : 'A new API token will be shown once.',
-        confirmText: props.sensor.has_active_token ? 'Replace token' : 'Generate token',
-    });
+    if (tokenRegenerationPending.value) return;
 
-    if (!confirmed) {
-        return;
-    }
+    tokenRegenerationPending.value = true;
 
     try {
+        const confirmed = await confirmDialog.confirm({
+            title: props.sensor.has_active_token ? 'Replace sensor token?' : 'Generate sensor token?',
+            description: props.sensor.has_active_token
+                ? 'The current API token will stop working immediately.'
+                : 'A new API token will be shown once.',
+            confirmText: props.sensor.has_active_token ? 'Replace token' : 'Generate token',
+        });
+
+        if (!confirmed) return;
+
         const response = await tokenRequest.post(
             route('stage-safety.sensors.regenerate-token', {
                 organization: props.organization.slug,
@@ -86,6 +91,8 @@ async function regenerateToken(): Promise<void> {
         token.value = response.token;
     } catch {
         // useHttp retains request errors and processing state.
+    } finally {
+        tokenRegenerationPending.value = false;
     }
 }
 
@@ -129,7 +136,7 @@ function acknowledgeToken(): void {
                     </div>
 
                     <div v-if="can('stage-safety.sensors.update')" class="flex flex-wrap gap-2">
-                        <Button :disabled="tokenRequest.processing" size="sm" type="button" @click="regenerateToken">
+                        <Button :disabled="tokenRegenerationPending" size="sm" type="button" @click="regenerateToken">
                             <RotateCcw v-if="sensor.has_active_token" class="mr-1 size-4" />
                             <KeyRound v-else class="mr-1 size-4" />
                             {{ sensor.has_active_token ? 'Replace Token' : 'Generate Token' }}

--- a/resources/js/pages/stage-safety/Sensor.vue
+++ b/resources/js/pages/stage-safety/Sensor.vue
@@ -60,21 +60,26 @@ async function fetchMonitoring(): Promise<void> {
     Object.assign(request, timeParams());
 
     try {
-        error.value = null;
         const response = await request.get(
             route('stage-safety.sensors.monitoring.index', {
                 organization: props.organization.slug,
                 stageSafetySensor: props.sensor.id,
             }),
         );
-        if (requestedRange === timeRange.value) monitoring.value = response;
+        if (requestedRange === timeRange.value) {
+            error.value = null;
+            monitoring.value = response;
+        }
     } catch {
-        error.value = 'Failed to load sensor monitoring data.';
+        if (requestedRange === timeRange.value) {
+            error.value = 'Failed to load sensor monitoring data.';
+        }
     } finally {
-        loading.value = false;
         if (refreshQueued) {
             refreshQueued = false;
             void fetchMonitoring();
+        } else {
+            loading.value = false;
         }
     }
 }

--- a/resources/js/pages/stage-safety/_tests_/EditSensor.test.ts
+++ b/resources/js/pages/stage-safety/_tests_/EditSensor.test.ts
@@ -1,0 +1,92 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import EditSensor from '../EditSensor.vue';
+
+const mocks = vi.hoisted(() => ({
+    confirm: vi.fn(),
+    post: vi.fn(),
+    request: { processing: false, post: vi.fn() },
+}));
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+    useConfirmDialog: () => ({ confirm: mocks.confirm }),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+    usePermissions: () => ({ can: () => true }),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    Head: { template: '<div />' },
+    Link: { template: '<a><slot /></a>' },
+    router: { reload: vi.fn() },
+    useForm: (data: object) => ({ ...data, errors: {}, processing: false, put: vi.fn() }),
+    useHttp: () => mocks.request,
+}));
+
+const organization = { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' };
+const sensor = {
+    id: 1,
+    organization_id: 1,
+    manufacturer: 'Broadweigh',
+    model: 'BW-WSS',
+    identifier: 'ABC123',
+    name: 'Main Stage',
+    location: 'Roof',
+    stale_after_seconds: 300,
+    archived_at: null,
+    created_at: '',
+    updated_at: '',
+    has_active_token: true,
+};
+
+describe('Stage Safety sensor editing', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.request.processing = false;
+        mocks.request.post = mocks.post;
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
+    });
+
+    it('prevents concurrent token regeneration confirmation flows', async () => {
+        let resolveConfirmation!: (confirmed: boolean) => void;
+        mocks.confirm.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveConfirmation = resolve;
+                }),
+        );
+        mocks.post.mockResolvedValue({ token: 'secret' });
+        const wrapper = mount(EditSensor, {
+            props: { organization, sensor, sensorTypes: [] },
+            global: {
+                mocks: { route: (name: string) => name },
+                stubs: {
+                    Layout: { template: '<main><slot /></main>' },
+                    Heading: true,
+                    SensorForm: true,
+                    SensorTokenDialog: true,
+                    ConfirmActionButton: true,
+                },
+            },
+        });
+        const button = wrapper.findAll('button').find((candidate) => candidate.text().includes('Replace Token'))!;
+
+        button.element.click();
+        button.element.click();
+        await nextTick();
+
+        expect(mocks.confirm).toHaveBeenCalledOnce();
+        expect(button.attributes('disabled')).toBeDefined();
+
+        resolveConfirmation(true);
+        await flushPromises();
+
+        expect(mocks.post).toHaveBeenCalledOnce();
+        expect(button.attributes('disabled')).toBeUndefined();
+    });
+});

--- a/resources/js/pages/stage-safety/_tests_/Sensor.test.ts
+++ b/resources/js/pages/stage-safety/_tests_/Sensor.test.ts
@@ -88,4 +88,37 @@ describe('Stage Safety sensor monitoring page', () => {
         expect(wrapper.text()).toContain('103');
         expect(wrapper.text()).toContain('Low');
     });
+
+    it('keeps loading and ignores stale errors while a changed range is queued', async () => {
+        let rejectFirst!: (reason: Error) => void;
+        mocks.get
+            .mockImplementationOnce(() => {
+                mocks.request.processing = true;
+                return new Promise((_, reject) => {
+                    rejectFirst = reject;
+                });
+            })
+            .mockReturnValueOnce(new Promise(() => {}));
+        const wrapper = mount(Sensor, {
+            props: { organization, sensor },
+            global: {
+                stubs: {
+                    Layout: { template: '<main><slot /></main>' },
+                    CurrentWindDisplay: true,
+                    WindHistoryChart: {
+                        emits: ['update:timeRange'],
+                        template: '<button data-testid="range" @click="$emit(\'update:timeRange\', \'6h\')">range</button>',
+                    },
+                },
+            },
+        });
+
+        await wrapper.find('[data-testid="range"]').trigger('click');
+        mocks.request.processing = false;
+        rejectFirst(new Error('stale request failed'));
+        await flushPromises();
+
+        expect(wrapper.text()).not.toContain('Failed to load sensor monitoring data');
+        expect(wrapper.find('.animate-pulse').exists()).toBe(true);
+    });
 });


### PR DESCRIPTION
Keeps dashboard widgets stable during background refreshes and restores visible, interactive wind history lines. Migrates Peoplecount widgets onto Inertia HTTP so global interceptors apply consistently.

## Details

- [WindHistoryChart.vue](https://github.com/musikfestwochen/musikfestapp/blob/ux/various-improvements/resources/js/components/stage-safety/WindHistoryChart.vue) - fixes line colors, sparse-series rendering, legend toggling, and stale visibility state.
- [architecture.test.ts](https://github.com/musikfestwochen/musikfestapp/blob/ux/various-improvements/resources/js/architecture.test.ts) - prevents direct Axios imports in browser sources.
- [ActiveAreaCountsWidget.vue](https://github.com/musikfestwochen/musikfestapp/blob/ux/various-improvements/resources/js/components/peoplecount/ActiveAreaCountsWidget.vue) - demonstrates initial-only loading and Inertia HTTP migration shared across Peoplecount widgets.

## Notes

Full precommit, including desktop and mobile E2E, passed. Final frontend verification passes 208 Vitest tests and production build.

## Reviewer Setup

Frontend assets changed. Run:

```sh
npm run build
```

Fixes #116

---
**«Well begun is half done.»**
_Aristotle_