### PR TITLE
Add module dashboards and LQI monitoring

### DIFF
--- a/app/Http/Controllers/Widgets/StageSafetyLqiHistoryWidgetController.php
+++ b/app/Http/Controllers/Widgets/StageSafetyLqiHistoryWidgetController.php
@@ -10,12 +10,12 @@ use App\Models\Organization;
 use App\Services\StageSafety\MonitoringService;
 use Illuminate\Http\JsonResponse;
 
-class StageSafetyWindHistoryWidgetController extends Controller
+class StageSafetyLqiHistoryWidgetController extends Controller
 {
     public function index(HistoryIndexRequest $request, Organization $organization, MonitoringService $monitoringService): JsonResponse
     {
         [$from, $to] = $request->range();
 
-        return response()->json($monitoringService->windHistory($organization, $from, $to));
+        return response()->json($monitoringService->lqiHistory($organization, $from, $to));
     }
 }

--- a/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Validation\Validator;
 
-class WindHistoryIndexRequest extends FormRequest
+class HistoryIndexRequest extends FormRequest
 {
     public const int MAX_RANGE_HOURS = 24;
 

--- a/app/Services/StageSafety/MonitoringService.php
+++ b/app/Services/StageSafety/MonitoringService.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Number;
 
 class MonitoringService
 {
@@ -100,6 +101,53 @@ class MonitoringService
                 'sensor' => $this->sensorPayload($sensor),
                 'readings' => array_values($sensor->readings
                     ->map(fn (Reading $reading): array => $this->historyReadingPayload($reading))
+                    ->values()
+                    ->all()),
+            ])
+            ->values()
+            ->all());
+
+        return [
+            'generated_at' => Date::now()->toIso8601String(),
+            'from' => $from->toIso8601String(),
+            'to' => $to->toIso8601String(),
+            'sensors' => $sensors,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     generated_at: string,
+     *     from: string,
+     *     to: string,
+     *     sensors: list<array{sensor: array<string, mixed>, samples: list<array{observed_at: string, lqi_percent: float}>}>
+     * }
+     */
+    public function lqiHistory(Organization $organization, CarbonInterface $from, CarbonInterface $to): array
+    {
+        $sensors = array_values($organization->stageSafetySensors()
+            ->whereNull('archived_at')
+            ->whereHas('readings', fn (Builder $query): Builder => $query
+                ->whereBetween('observed_at', [$from, $to])
+                ->whereNotNull('rssi_dbm')
+                ->whereNotNull('cv'))
+            ->with(['readings' => function (Relation $relation) use ($from, $to): void {
+                $relation->getQuery()
+                    ->whereBetween('observed_at', [$from, $to])
+                    ->whereNotNull('rssi_dbm')
+                    ->whereNotNull('cv')
+                    ->oldest('observed_at')
+                    ->orderBy('kind');
+            }])
+            ->orderBy('id')
+            ->get()
+            ->map(fn (Sensor $sensor): array => [
+                'sensor' => $this->sensorPayload($sensor),
+                'samples' => array_values($sensor->readings
+                    ->map(fn (Reading $reading): array => [
+                        'observed_at' => $reading->observed_at->toIso8601String(),
+                        'lqi_percent' => $this->lqiPercent((int) $reading->rssi_dbm, (int) $reading->cv),
+                    ])
                     ->values()
                     ->all()),
             ])
@@ -246,5 +294,12 @@ class MonitoringService
 
         return $observedTimestamp <= $nowTimestamp
             && $observedTimestamp >= $nowTimestamp - $sensor->stale_after_seconds;
+    }
+
+    protected function lqiPercent(int $rssiDbm, int $cv): float
+    {
+        $rawLqi = ((94 + $rssiDbm + $cv - 55) / 2) * 3.9;
+
+        return Number::clamp(($rawLqi - 50) * 100 / (128 - 50), min: 0, max: 100);
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -51,6 +51,7 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::query()->where('name', 'stage-safety.sensors.show')->delete();
 
         // add widget permissions
+        Permission::findOrCreate('peoplecount.dashboard.view');
         Permission::findOrCreate('peoplecount.widgets.active_area_counts');
         Permission::findOrCreate('peoplecount.widgets.sensor_health');
         Permission::findOrCreate('peoplecount.widgets.most_active_sensors');
@@ -82,6 +83,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.alerts.*',
             'stage-safety.sensors.*',
             'stage-safety.monitoring.view',
+            'peoplecount.dashboard.view',
             'peoplecount.widgets.active_area_counts',
             'peoplecount.widgets.sensor_health',
             'peoplecount.widgets.most_active_sensors',
@@ -99,6 +101,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'peoplecount.alerts.*',
             'stage-safety.sensors.*',
             'stage-safety.monitoring.view',
+            'peoplecount.dashboard.view',
             'peoplecount.widgets.active_area_counts',
             'peoplecount.widgets.sensor_health',
             'peoplecount.widgets.most_active_sensors',
@@ -107,6 +110,7 @@ class RolesAndPermissionsSeeder extends Seeder
 
         $peoplecountViewerRole = $this->role('PeopleCountViewer', 'People count viewer', 'Can view people-count dashboards and data.');
         $peoplecountViewerRole->syncPermissions([
+            'peoplecount.dashboard.view',
             'peoplecount.areas.index',
             'peoplecount.areas.show',
             'peoplecount.events.index',

--- a/peck.json
+++ b/peck.json
@@ -47,7 +47,10 @@
             "stdout",
             "xdebug",
             "broadweigh",
-            "wss"
+            "wss",
+            "lqi",
+            "rssi",
+            "dbm"
         ],
         "paths": []
     }

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -4,7 +4,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
 import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
-import { WIDGET_CHART_COLORS, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import { CurveType } from '@unovis/ts';
@@ -53,7 +53,7 @@ const {
 
 function timeParams(): { from: string; to: string } {
     const to = new Date();
-    const from = new Date(to.getTime() - Number.parseInt(timeRange.value) * 60 * 60 * 1000);
+    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
     return { from: from.toISOString(), to: to.toISOString() };
 }
 

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -226,12 +226,12 @@ describe('AreaCountHistoryWidget', () => {
         await flushPromises();
         mocks.get.mockClear();
 
-        await wrapper.find('[data-testid="range-select"]').setValue('6h');
+        await wrapper.find('[data-testid="range-select"]').setValue('30m');
         await nextTick();
         await flushPromises();
 
         expect(mocks.get).toHaveBeenCalledWith('peoplecount.area-count-history.index');
-        expect(mocks.request.from).toBe('2025-08-04T16:08:00.000Z');
+        expect(mocks.request.from).toBe('2025-08-04T21:38:00.000Z');
         expect(mocks.request.to).toBe('2025-08-04T22:08:00.000Z');
     });
 

--- a/resources/js/components/stage-safety/CurrentWindDisplay.vue
+++ b/resources/js/components/stage-safety/CurrentWindDisplay.vue
@@ -28,7 +28,17 @@ function statusVariant(status: StageSafetyCurrentSensor['status']): 'default' | 
             </div>
 
             <dl class="mt-4 flex flex-col items-center gap-3">
-                <div>
+                <div v-if="item.wind_gust">
+                    <dt :class="readingLabel('Gust', item.wind_gust, item.status) === 'Gust' ? 'sr-only' : 'text-muted-foreground mb-1 text-xs'">
+                        {{ readingLabel('Gust', item.wind_gust, item.status) }}
+                    </dt>
+                    <dd class="text-foreground text-5xl leading-none font-semibold tracking-tight tabular-nums">
+                        {{ formatWindSpeed(item.wind_gust.value) }}
+                        <span class="text-muted-foreground text-sm font-medium">km/h</span>
+                    </dd>
+                </div>
+
+                <div v-else-if="item.wind_average">
                     <dt
                         :class="
                             readingLabel('Average', item.wind_average, item.status) === 'Average' ? 'sr-only' : 'text-muted-foreground mb-1 text-xs'
@@ -36,17 +46,19 @@ function statusVariant(status: StageSafetyCurrentSensor['status']): 'default' | 
                     >
                         {{ readingLabel('Average', item.wind_average, item.status) }}
                     </dt>
-                    <dd v-if="item.wind_average" class="text-foreground text-5xl leading-none font-semibold tracking-tight tabular-nums">
+                    <dd class="text-foreground text-5xl leading-none font-semibold tracking-tight tabular-nums">
                         {{ formatWindSpeed(item.wind_average.value) }}
                         <span class="text-muted-foreground text-sm font-medium">km/h</span>
                     </dd>
-                    <dd v-else class="text-muted-foreground py-2 text-sm">Average unavailable</dd>
                 </div>
 
-                <div v-if="item.wind_gust" class="bg-muted/40 inline-flex items-baseline gap-1.5 rounded-full border px-2.5 py-1">
-                    <dt class="text-muted-foreground text-xs">{{ readingLabel('Gust', item.wind_gust, item.status) }}</dt>
+                <div
+                    v-if="item.wind_gust && item.wind_average"
+                    class="bg-muted/40 inline-flex items-baseline gap-1.5 rounded-full border px-2.5 py-1"
+                >
+                    <dt class="text-muted-foreground text-xs">{{ readingLabel('Average', item.wind_average, item.status) }}</dt>
                     <dd class="text-sm font-semibold tracking-tight tabular-nums">
-                        {{ formatWindSpeed(item.wind_gust.value) }}
+                        {{ formatWindSpeed(item.wind_average.value) }}
                         <span class="text-xs font-medium">km/h</span>
                     </dd>
                 </div>

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
+import { Skeleton } from '@/components/ui/skeleton';
+import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
+import WidgetShell from '@/components/widgets/WidgetShell.vue';
+import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
+import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
+import { useWidgetPolling } from '@/composables/useWidgetPolling';
+import type { Organization, StageSafetyLqiHistoryPayload } from '@/types';
+import { stageSafetySensorName } from '@/utils/stageSafety';
+import { CurveType, type Crosshair } from '@unovis/ts';
+import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { useHttp } from '@inertiajs/vue3';
+import { Radio } from 'lucide-vue-next';
+import { computed, h, nextTick, ref, render, watch } from 'vue';
+
+interface ChartDataPoint {
+    date: Date;
+    [key: string]: Date | number;
+}
+
+const props = defineProps<{ organization: Organization }>();
+const timeRange = ref<WidgetTimeRange>('1h');
+const request = useHttp<{ from: string; to: string }, StageSafetyLqiHistoryPayload>({ from: '', to: '' });
+const { data, loading, error, lastUpdated, refresh } = useWidgetPolling({
+    interval: 30_000,
+    load: () => {
+        Object.assign(request, timeParams());
+        return request.get(route('stage-safety.lqi-history.index', { organization: props.organization.slug }));
+    },
+    errorMessage: 'Failed to load link quality history.',
+});
+
+function timeParams(): { from: string; to: string } {
+    const to = new Date();
+    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
+    return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function seriesKey(sensorId: number): string {
+    return `sensor_${sensorId}_lqi`;
+}
+
+const chartSeries = computed<WidgetChartSeries[]>(() =>
+    (data.value?.sensors ?? []).map((item, index) => ({
+        key: seriesKey(item.sensor.id),
+        label: stageSafetySensorName(item.sensor),
+        color: WIDGET_CHART_COLORS[index % WIDGET_CHART_COLORS.length],
+    })),
+);
+const { hiddenSeriesKeys, isSeriesVisible, selectSeries } = useChartSeriesVisibility(() => chartSeries.value.map((item) => item.key));
+const visibleChartSeries = computed(() => chartSeries.value.filter((item) => isSeriesVisible(item.key)));
+const chartConfig = computed<ChartConfig>(() =>
+    Object.fromEntries(visibleChartSeries.value.map((item) => [item.key, { label: item.label, color: item.color }])),
+);
+const chartDataBySeries = computed<Record<string, ChartDataPoint[]>>(() =>
+    Object.fromEntries(
+        (data.value?.sensors ?? []).map((item) => [
+            seriesKey(item.sensor.id),
+            item.samples.map((sample) => ({
+                date: new Date(sample.observed_at),
+                [seriesKey(item.sensor.id)]: sample.lqi_percent,
+            })),
+        ]),
+    ),
+);
+const chartData = computed(() =>
+    Object.values(chartDataBySeries.value)
+        .flat()
+        .sort((left, right) => left.date.getTime() - right.date.getTime()),
+);
+const hasData = computed(() => chartData.value.length > 0);
+const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
+const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
+const percentageFormatter = new Intl.NumberFormat('de-CH', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+
+function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: number | Date): string {
+    const container = document.createElement('div');
+    const dataPoint = 'data' in datum ? (datum as { data: ChartDataPoint }).data : datum;
+    const payload = Object.fromEntries(
+        Object.entries(dataPoint).map(([key, value]) => [key, typeof value === 'number' ? `${percentageFormatter.format(value)}%` : value]),
+    );
+    const vnode = h(ChartTooltipContent, {
+        payload,
+        config: chartConfig.value,
+        x,
+        indicator: 'line',
+        labelFormatter: (value: number | Date) =>
+            new Date(typeof value === 'number' ? value : value.getTime()).toLocaleString([], {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+            }),
+    });
+
+    render(vnode, container);
+    const html = container.innerHTML;
+    render(null, container);
+
+    return html;
+}
+
+async function syncCrosshair(): Promise<void> {
+    await nextTick();
+    await nextTick();
+    crosshairRef.value?.component.setData(chartData.value);
+}
+
+function seriesValue(point: ChartDataPoint, key: string): number | undefined {
+    const value = point[key];
+    return typeof value === 'number' ? value : undefined;
+}
+
+function formatTickDate(value: number): string {
+    return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatPercentageTick(value: number): string {
+    return `${Math.round(value)}%`;
+}
+
+watch(timeRange, refresh);
+watch(chartData, () => void syncCrosshair());
+</script>
+
+<template>
+    <WidgetShell title="Link Quality History" subtitle="Normalized LQI in %" :error="error" :last-updated="lastUpdated" span="full">
+        <template #icon><Radio /></template>
+        <template #actions><WidgetTimeRangeSelect v-model="timeRange" /></template>
+
+        <div v-if="loading && !hasData" class="flex h-[280px] items-center justify-center sm:h-[350px]">
+            <Skeleton class="h-full w-full" />
+        </div>
+
+        <div v-else-if="data && !hasData" class="text-muted-foreground flex h-[280px] items-center justify-center text-center sm:h-[350px]">
+            No link quality samples for selected time range.
+        </div>
+
+        <div v-else-if="hasData" class="flex flex-1 flex-col">
+            <p class="sr-only" aria-live="polite">
+                Link quality history chart with {{ chartSeries.length }} series across {{ data?.sensors.length ?? 0 }} sensors.
+            </p>
+            <ChartContainer
+                :config="chartConfig"
+                class="h-[280px] w-full min-w-0 sm:h-[350px]"
+                role="img"
+                aria-label="Link quality history in percent"
+            >
+                <VisXYContainer :margin="{ top: 8, right: 8, bottom: 24, left: 38 }" :y-domain="[0, 100]">
+                    <template v-for="item in chartSeries" :key="item.key">
+                        <VisLine
+                            v-if="isSeriesVisible(item.key)"
+                            :data="chartDataBySeries[item.key]"
+                            :x="(point: ChartDataPoint) => point.date.getTime()"
+                            :y="(point: ChartDataPoint) => seriesValue(point, item.key)"
+                            :color="item.color"
+                            :curve-type="CurveType.MonotoneX"
+                            :line-width="2"
+                        />
+                    </template>
+                    <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
+                    <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :tick-format="formatPercentageTick" />
+                    <ChartTooltip />
+                    <ChartCrosshair ref="crosshairRef" :template="crosshairTemplate" :color="seriesColors" />
+                </VisXYContainer>
+            </ChartContainer>
+            <WidgetChartLegend :series="chartSeries" :hidden-series-keys="hiddenSeriesKeys" @select="selectSeries" />
+        </div>
+    </WidgetShell>
+</template>

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -4,7 +4,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
 import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
-import { WIDGET_CHART_COLORS, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import type { Organization, StageSafetyReadingKind, StageSafetyWindHistoryPayload } from '@/types';
@@ -34,7 +34,7 @@ const { data, loading, error, lastUpdated, refresh } = useWidgetPolling({
 
 function timeParams(): { from: string; to: string } {
     const to = new Date();
-    const from = new Date(to.getTime() - Number.parseInt(timeRange.value) * 60 * 60 * 1000);
+    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
     return { from: from.toISOString(), to: to.toISOString() };
 }
 

--- a/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
+++ b/resources/js/components/stage-safety/_tests_/CurrentWindDisplay.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import CurrentWindDisplay from '../CurrentWindDisplay.vue';
 
 describe('CurrentWindDisplay', () => {
-    it('emphasizes averages and only renders gust when available', () => {
+    it('emphasizes gusts, falls back to averages, and pills averages when both are available', () => {
         const wrapper = mount(CurrentWindDisplay, {
             props: {
                 sensors: [
@@ -41,6 +41,32 @@ describe('CurrentWindDisplay', () => {
                             window_seconds: 10,
                         },
                     },
+                    {
+                        sensor: { id: 3, identifier: 'GHI789', name: 'Lake Stage', location: null, stale_after_seconds: 300 },
+                        status: 'fresh',
+                        latest_observed_at: '2026-07-25T11:59:30Z',
+                        radio_diagnostics: null,
+                        wind_average: {
+                            kind: 'wind_average',
+                            value: 5,
+                            unit: 'm/s',
+                            status: 'fresh',
+                            observed_at: '2026-07-25T11:59:30Z',
+                            received_at: '2026-07-25T11:59:31Z',
+                            receipt_delay_seconds: 1,
+                            window_seconds: 10,
+                        },
+                        wind_gust: {
+                            kind: 'wind_gust',
+                            value: 8.0556,
+                            unit: 'm/s',
+                            status: 'fresh',
+                            observed_at: '2026-07-25T11:59:30Z',
+                            received_at: '2026-07-25T11:59:31Z',
+                            receipt_delay_seconds: 1,
+                            window_seconds: 10,
+                        },
+                    },
                 ],
             },
         });
@@ -52,13 +78,17 @@ describe('CurrentWindDisplay', () => {
         expect(wrapper.text()).toContain('29');
         expect(wrapper.text()).toContain('Last known average');
         expect(wrapper.text()).toContain('Last known gust');
-        expect(wrapper.text()).toContain('Average unavailable');
         expect(wrapper.text()).not.toContain('Observed');
         expect(wrapper.text()).not.toContain('—');
         expect(wrapper.text()).not.toMatch(/\bfresh\b/i);
         expect(wrapper.text()).not.toContain('second period');
         expect(wrapper.findAll('article')[0].text()).not.toContain('Gust');
         expect(wrapper.findAll('article')[1].text()).toContain('Last known gust');
+        expect(wrapper.findAll('article')[0].find('.text-5xl').text()).toContain('18');
+        expect(wrapper.findAll('article')[1].find('.text-5xl').text()).toContain('29');
+        expect(wrapper.findAll('article')[2].find('.text-5xl').text()).toContain('29');
+        expect(wrapper.findAll('article')[2].find('.rounded-full').text()).toContain('Average');
+        expect(wrapper.findAll('article')[2].find('.rounded-full').text()).toContain('18');
         expect(wrapper.findAll('article').every((article) => !article.classes().includes('border'))).toBe(true);
     });
 });

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -1,0 +1,142 @@
+import type { StageSafetyLqiHistoryPayload } from '@/types';
+import { CurveType } from '@unovis/ts';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, onMounted, ref } from 'vue';
+import LqiHistoryWidget from '../LqiHistoryWidget.vue';
+
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    request: { get: vi.fn(), from: '', to: '' },
+    useIntervalFn: vi.fn(),
+    crosshair: { setData: vi.fn() },
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    useHttp: () => mocks.request,
+}));
+
+vi.mock('@vueuse/core', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@vueuse/core')>()),
+    useIntervalFn: mocks.useIntervalFn,
+}));
+
+vi.mock('@unovis/vue', () => ({
+    VisXYContainer: { name: 'VisXYContainer', props: ['data', 'yDomain'], template: '<div><slot /></div>' },
+    VisLine: {
+        name: 'VisLine',
+        props: ['data', 'y', 'color', 'curveType'],
+        template: '<div class="series-line" />',
+    },
+    VisAxis: { template: '<div />' },
+    VisTooltip: { template: '<div />' },
+    VisCrosshair: {
+        name: 'VisCrosshair',
+        props: ['color', 'template'],
+        setup: (_props: unknown, { expose }: { expose: (value: unknown) => void }) => {
+            const component = ref<typeof mocks.crosshair>();
+            expose({ component });
+            onMounted(() => void nextTick(() => (component.value = mocks.crosshair)));
+        },
+        template: '<div />',
+    },
+}));
+
+const organization = { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' };
+const history: StageSafetyLqiHistoryPayload = {
+    generated_at: '2026-07-25T12:00:00Z',
+    from: '2026-07-25T11:00:00Z',
+    to: '2026-07-25T12:00:00Z',
+    sensors: [
+        {
+            sensor: { id: 1, identifier: 'ABC123', name: 'Main Stage', location: 'Roof', stale_after_seconds: 300 },
+            samples: [
+                { observed_at: '2026-07-25T11:30:00Z', lqi_percent: 0 },
+                { observed_at: '2026-07-25T11:40:00Z', lqi_percent: 50.8974358974 },
+            ],
+        },
+        {
+            sensor: { id: 2, identifier: 'DEF456', name: null, location: null, stale_after_seconds: 300 },
+            samples: [{ observed_at: '2026-07-25T11:35:00Z', lqi_percent: 100 }],
+        },
+    ],
+};
+
+const stubs = {
+    Select: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template:
+            '<select data-testid="range-select" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+    },
+    SelectTrigger: { template: '<div><slot /></div>' },
+    SelectValue: { template: '<div />' },
+    SelectContent: { template: '<div><slot /></div>' },
+    SelectItem: { props: ['value'], template: '<option :value="value"><slot /></option>' },
+    ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
+    ChartTooltip: { template: '<div />' },
+    ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div />' },
+};
+
+describe('LqiHistoryWidget', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+        mocks.request.get = mocks.get;
+        mocks.request.from = '';
+        mocks.request.to = '';
+        mocks.useIntervalFn.mockImplementation((callback: () => Promise<void>) => {
+            void callback();
+            return { pause: vi.fn(), resume: vi.fn(), isActive: true };
+        });
+        vi.stubGlobal(
+            'route',
+            vi.fn((name: string) => name),
+        );
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders one percentage series per sensor on a fixed domain', async () => {
+        mocks.get.mockResolvedValue(history);
+        const wrapper = mount(LqiHistoryWidget, { props: { organization }, global: { stubs } });
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('Roof');
+        expect(wrapper.text()).toContain('DEF456');
+
+        const lines = wrapper.findAllComponents({ name: 'VisLine' });
+        const firstRows = lines[0].props('data') as Array<Record<string, number | Date>>;
+        const secondRows = lines[1].props('data') as Array<Record<string, number | Date>>;
+
+        expect(lines).toHaveLength(2);
+        expect(wrapper.findComponent({ name: 'VisXYContainer' }).props('yDomain')).toEqual([0, 100]);
+        expect(firstRows).toHaveLength(2);
+        expect(secondRows).toHaveLength(1);
+        expect(lines[0].props('y')(firstRows[1])).toBeCloseTo(50.8974358974);
+        expect(lines[1].props('y')(secondRows[0])).toBe(100);
+        expect(lines.every((line) => line.props('curveType') === CurveType.MonotoneX)).toBe(true);
+
+        const crosshair = wrapper.findComponent({ name: 'VisCrosshair' });
+        const template = crosshair.props('template') as (datum: Record<string, number | Date>, x: Date) => string;
+        expect(template(firstRows[1], firstRows[1].date as Date)).toContain('50.9%');
+    });
+
+    it('uses one hour by default and supports the thirty-minute range', async () => {
+        mocks.get.mockResolvedValue(history);
+        const wrapper = mount(LqiHistoryWidget, { props: { organization }, global: { stubs } });
+        await flushPromises();
+
+        expect(mocks.request.from).toBe('2026-07-25T11:00:00.000Z');
+        expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+
+        await wrapper.get('[data-testid="range-select"]').setValue('30m');
+        await flushPromises();
+
+        expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
+        expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+    });
+});

--- a/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
@@ -66,11 +66,16 @@ const history: StageSafetyWindHistoryPayload = {
 };
 
 const stubs = {
-    Select: { template: '<div><slot /></div>' },
+    Select: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template:
+            '<select data-testid="range-select" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+    },
     SelectTrigger: { template: '<div><slot /></div>' },
     SelectValue: { template: '<div />' },
     SelectContent: { template: '<div><slot /></div>' },
-    SelectItem: { template: '<div><slot /></div>' },
+    SelectItem: { props: ['value'], template: '<option :value="value"><slot /></option>' },
     ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
     ChartTooltip: { template: '<div />' },
     ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div />' },
@@ -132,6 +137,21 @@ describe('WindHistoryWidget', () => {
 
         const crosshairTemplate = crosshair.props('template') as (datum: Record<string, number | Date | undefined>, x: Date) => string;
         expect(crosshairTemplate(averageRows[0], averageRows[0].date as Date)).toContain('18.0');
+    });
+
+    it('uses one hour by default and supports the thirty-minute range', async () => {
+        mocks.get.mockResolvedValue(history);
+        const wrapper = mount(WindHistoryWidget, { props: { organization }, global: { stubs } });
+        await flushPromises();
+
+        expect(mocks.request.from).toBe('2026-07-25T11:00:00.000Z');
+        expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+
+        await wrapper.get('[data-testid="range-select"]').setValue('30m');
+        await flushPromises();
+
+        expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
+        expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
     });
 
     it('isolates a legend series and restores all when selected again', async () => {

--- a/resources/js/components/widgets/WidgetTimeRangeSelect.vue
+++ b/resources/js/components/widgets/WidgetTimeRangeSelect.vue
@@ -17,6 +17,7 @@ const selectedRange = computed({
 });
 
 const options: Array<{ value: WidgetTimeRange; label: string }> = [
+    { value: '30m', label: 'Last 30 minutes' },
     { value: '1h', label: 'Last hour' },
     { value: '3h', label: 'Last 3 hours' },
     { value: '6h', label: 'Last 6 hours' },

--- a/resources/js/components/widgets/_tests_/WidgetTimeRangeSelect.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetTimeRangeSelect.test.ts
@@ -22,6 +22,7 @@ describe('WidgetTimeRangeSelect', () => {
         });
 
         expect(wrapper.findAll('option').map((option) => [option.attributes('value'), option.text()])).toEqual([
+            ['30m', 'Last 30 minutes'],
             ['1h', 'Last hour'],
             ['3h', 'Last 3 hours'],
             ['6h', 'Last 6 hours'],

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -1,4 +1,13 @@
-export type WidgetTimeRange = '1h' | '3h' | '6h' | '12h' | '24h';
+export type WidgetTimeRange = '30m' | '1h' | '3h' | '6h' | '12h' | '24h';
+
+export const WIDGET_TIME_RANGE_MINUTES: Record<WidgetTimeRange, number> = {
+    '30m': 30,
+    '1h': 60,
+    '3h': 180,
+    '6h': 360,
+    '12h': 720,
+    '24h': 1440,
+};
 
 export interface WidgetChartSeries {
     key: string;

--- a/resources/js/nav/_tests_/orgNavItems.test.ts
+++ b/resources/js/nav/_tests_/orgNavItems.test.ts
@@ -6,7 +6,9 @@ describe('organization navigation', () => {
         const items = orgMainNavItems('musikfest');
 
         expect(items.map((item) => item.title)).toEqual(['Dashboard', 'Users', 'Peoplecount', 'Stage Safety']);
-        expect(items[2].children?.map((item) => item.title)).toEqual(['Sensors', 'Events', 'Areas', 'Assignments']);
-        expect(items[3].children?.map((item) => item.title)).toEqual(['Sensors']);
+        expect(items[2].children?.map((item) => item.title)).toEqual(['Dashboard', 'Sensors', 'Events', 'Areas', 'Assignments']);
+        expect(items[2].children?.[0]).toMatchObject({ route: 'peoplecount.dashboard', permission: 'peoplecount.dashboard.view' });
+        expect(items[3].children?.map((item) => item.title)).toEqual(['Dashboard', 'Sensors']);
+        expect(items[3].children?.[0]).toMatchObject({ route: 'stage-safety.dashboard', permission: 'stage-safety.monitoring.view' });
     });
 });

--- a/resources/js/nav/orgNavItems.ts
+++ b/resources/js/nav/orgNavItems.ts
@@ -20,6 +20,12 @@ export const orgMainNavItems = (organization: string | number) => [
         icon: ProjectorIcon,
         children: [
             {
+                title: 'Dashboard',
+                route: 'peoplecount.dashboard',
+                permission: 'peoplecount.dashboard.view',
+                params: { organization },
+            },
+            {
                 title: 'Sensors',
                 route: 'peoplecount.sensors.index',
                 permission: 'peoplecount.sensors.index',
@@ -49,6 +55,12 @@ export const orgMainNavItems = (organization: string | number) => [
         title: 'Stage Safety',
         icon: WindIcon,
         children: [
+            {
+                title: 'Dashboard',
+                route: 'stage-safety.dashboard',
+                permission: 'stage-safety.monitoring.view',
+                params: { organization },
+            },
             {
                 title: 'Sensors',
                 route: 'stage-safety.sensors.index',

--- a/resources/js/pages/peoplecount/Dashboard.vue
+++ b/resources/js/pages/peoplecount/Dashboard.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
+import ActiveAreaCountsWidget from '@/components/peoplecount/ActiveAreaCountsWidget.vue';
+import AreaCountHistoryWidget from '@/components/peoplecount/AreaCountHistoryWidget.vue';
+import MostActiveSensorsWidget from '@/components/peoplecount/MostActiveSensorsWidget.vue';
+import { usePermissions } from '@/composables/usePermissions';
+import Layout from '@/layouts/orgmgmt/Layout.vue';
+import type { BreadcrumbItem, Organization } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+const props = defineProps<{ organization: Organization }>();
+const { can } = usePermissions();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: props.organization.name,
+        href: `/${props.organization.slug}/dashboard`,
+    },
+    {
+        title: 'Peoplecount',
+        href: `/${props.organization.slug}/peoplecount`,
+    },
+];
+</script>
+
+<template>
+    <Head title="Peoplecount Dashboard" />
+    <Layout :breadcrumbs="breadcrumbs">
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+            <h1 class="text-2xl font-bold">Peoplecount Dashboard</h1>
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <ActiveAreaCountsWidget v-if="can('peoplecount.widgets.active_area_counts')" :organization="organization" />
+                <MostActiveSensorsWidget v-if="can('peoplecount.widgets.most_active_sensors')" :organization="organization" />
+                <SensorHealthWidget
+                    v-if="can('peoplecount.widgets.sensor_health')"
+                    :organization="organization"
+                    :show-peoplecount="true"
+                    :show-stage-safety="false"
+                />
+                <AreaCountHistoryWidget v-if="can('peoplecount.widgets.area_count_history')" :organization="organization" />
+            </div>
+        </div>
+    </Layout>
+</template>

--- a/resources/js/pages/peoplecount/_tests_/Dashboard.test.ts
+++ b/resources/js/pages/peoplecount/_tests_/Dashboard.test.ts
@@ -1,0 +1,44 @@
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
+import { shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Dashboard from '../Dashboard.vue';
+
+const mocks = vi.hoisted(() => ({ can: vi.fn() }));
+
+vi.mock('@/composables/usePermissions', () => ({
+    usePermissions: () => ({ can: mocks.can }),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ Head: { template: '<div />' } }));
+
+describe('Peoplecount dashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders permitted Peoplecount widgets', () => {
+        mocks.can.mockReturnValue(true);
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(Array.from(wrapper.find('.grid').element.children).map((element) => element.tagName.toLowerCase())).toEqual([
+            'active-area-counts-widget-stub',
+            'most-active-sensors-widget-stub',
+            'sensor-health-widget-stub',
+            'area-count-history-widget-stub',
+        ]);
+        expect(wrapper.findComponent(SensorHealthWidget).props()).toMatchObject({ showPeoplecount: true, showStageSafety: false });
+    });
+
+    it('does not mount unpermitted widgets', () => {
+        mocks.can.mockReturnValue(false);
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(wrapper.find('.grid').element.children).toHaveLength(0);
+    });
+});

--- a/resources/js/pages/stage-safety/Dashboard.vue
+++ b/resources/js/pages/stage-safety/Dashboard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
+import CurrentWindWidget from '@/components/stage-safety/CurrentWindWidget.vue';
+import LqiHistoryWidget from '@/components/stage-safety/LqiHistoryWidget.vue';
+import WindHistoryWidget from '@/components/stage-safety/WindHistoryWidget.vue';
+import Layout from '@/layouts/orgmgmt/Layout.vue';
+import type { BreadcrumbItem, Organization } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+const props = defineProps<{ organization: Organization }>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: props.organization.name,
+        href: `/${props.organization.slug}/dashboard`,
+    },
+    {
+        title: 'Stage Safety',
+        href: `/${props.organization.slug}/stage-safety`,
+    },
+];
+</script>
+
+<template>
+    <Head title="Stage Safety Dashboard" />
+    <Layout :breadcrumbs="breadcrumbs">
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+            <h1 class="text-2xl font-bold">Stage Safety Dashboard</h1>
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <CurrentWindWidget :organization="organization" />
+                <SensorHealthWidget :organization="organization" :show-peoplecount="false" :show-stage-safety="true" />
+                <WindHistoryWidget :organization="organization" />
+                <LqiHistoryWidget :organization="organization" />
+            </div>
+        </div>
+    </Layout>
+</template>

--- a/resources/js/pages/stage-safety/_tests_/Dashboard.test.ts
+++ b/resources/js/pages/stage-safety/_tests_/Dashboard.test.ts
@@ -1,0 +1,23 @@
+import SensorHealthWidget from '@/components/SensorHealthWidget.vue';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import Dashboard from '../Dashboard.vue';
+
+vi.mock('@inertiajs/vue3', () => ({ Head: { template: '<div />' } }));
+
+describe('Stage Safety dashboard', () => {
+    it('renders Stage Safety widgets', () => {
+        const wrapper = shallowMount(Dashboard, {
+            props: { organization: { id: 1, slug: 'mfw', name: 'MFW', created_at: '', updated_at: '' } },
+            global: { stubs: { Layout: { template: '<main><slot /></main>' } } },
+        });
+
+        expect(Array.from(wrapper.find('.grid').element.children).map((element) => element.tagName.toLowerCase())).toEqual([
+            'current-wind-widget-stub',
+            'sensor-health-widget-stub',
+            'wind-history-widget-stub',
+            'lqi-history-widget-stub',
+        ]);
+        expect(wrapper.findComponent(SensorHealthWidget).props()).toMatchObject({ showPeoplecount: false, showStageSafety: true });
+    });
+});

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -185,6 +185,23 @@ export interface StageSafetyWindHistoryPayload {
     sensors: StageSafetyHistorySensor[];
 }
 
+export interface StageSafetyLqiHistorySample {
+    observed_at: string;
+    lqi_percent: number;
+}
+
+export interface StageSafetyLqiHistorySensor {
+    sensor: StageSafetySensorSummary;
+    samples: StageSafetyLqiHistorySample[];
+}
+
+export interface StageSafetyLqiHistoryPayload {
+    generated_at: string;
+    from: string;
+    to: string;
+    sensors: StageSafetyLqiHistorySensor[];
+}
+
 export interface PeoplecountSensor {
     id: number;
     vendor: string;

--- a/routes/peoplecount.php
+++ b/routes/peoplecount.php
@@ -16,10 +16,16 @@ use App\Http\Controllers\Widgets\PeoplecountActiveAreaCountsWidgetController;
 use App\Http\Controllers\Widgets\PeoplecountAreaCountHistoryWidgetController;
 use App\Http\Controllers\Widgets\PeoplecountMostActiveSensorsWidgetController;
 use App\Http\Controllers\Widgets\PeoplecountSensorHealthStatusWidgetController;
+use App\Models\Organization;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 
 Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(function () {
     Route::prefix('{organization:slug}/peoplecount')->name('peoplecount.')->group(function () {
+        Route::get('/', fn (Organization $organization) => Inertia::render('peoplecount/Dashboard', [
+            'organization' => $organization,
+        ]))->middleware('permission:peoplecount.dashboard.view')->name('dashboard');
+
         Route::resource(
             'sensors',
             SensorController::class

--- a/routes/stage-safety.php
+++ b/routes/stage-safety.php
@@ -6,12 +6,19 @@ use App\Http\Controllers\StageSafety\SensorArchiveController;
 use App\Http\Controllers\StageSafety\SensorController;
 use App\Http\Controllers\StageSafety\SensorTokenController;
 use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
+use App\Http\Controllers\Widgets\StageSafetyLqiHistoryWidgetController;
 use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
 use App\Http\Controllers\Widgets\StageSafetyWindHistoryWidgetController;
+use App\Models\Organization;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 
 Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(function () {
     Route::scopeBindings()->prefix('{organization:slug}/stage-safety')->name('stage-safety.')->group(function () {
+        Route::get('/', fn (Organization $organization) => Inertia::render('stage-safety/Dashboard', [
+            'organization' => $organization,
+        ]))->middleware('permission:stage-safety.monitoring.view')->name('dashboard');
+
         Route::resource('sensors', SensorController::class)
             ->except('show')
             ->parameters(['sensors' => 'stageSafetySensor'])
@@ -32,5 +39,7 @@ Route::middleware(['auth', 'verified', 'permissions.organization_slug'])->group(
             ->name('sensor-health.index');
         Route::get('wind-history', [StageSafetyWindHistoryWidgetController::class, 'index'])
             ->name('wind-history.index');
+        Route::get('lqi-history', [StageSafetyLqiHistoryWidgetController::class, 'index'])
+            ->name('lqi-history.index');
     });
 });

--- a/tests/Architecture/CheckRoutesTest.php
+++ b/tests/Architecture/CheckRoutesTest.php
@@ -65,6 +65,7 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'POST', 'uri' => 'organization/select'],
 
         // People Count Sensor Routes
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount/sensors'],
         ['method' => 'POST', 'uri' => '{organization}/peoplecount/sensors'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount/sensors/create'],
@@ -80,6 +81,7 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'DELETE', 'uri' => '{organization}/peoplecount/sensors/{sensor}/shares/{share}'],
 
         // Stage Safety Sensor Routes
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensors'],
         ['method' => 'POST', 'uri' => '{organization}/stage-safety/sensors'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensors/create'],
@@ -93,6 +95,7 @@ it('tests if no unwanted routes are exposed', function () {
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/current-wind'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/sensor-health'],
         ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/wind-history'],
+        ['method' => 'GET|HEAD', 'uri' => '{organization}/stage-safety/lqi-history'],
 
         // People Count Events Routes
         ['method' => 'GET|HEAD', 'uri' => '{organization}/peoplecount/events'],

--- a/tests/Feature/ModuleDashboardTest.php
+++ b/tests/Feature/ModuleDashboardTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+});
+
+it('renders module dashboards for module viewers', function (string $role, string $routeName, string $component) {
+    $organization = Organization::factory()->create();
+    $viewer = User::factory()->create();
+    $viewer->organizations()->attach($organization);
+    setPermissionsOrgId($organization->id);
+    $viewer->assignRole($role);
+
+    $this->actingAs($viewer)
+        ->get(route($routeName, ['organization' => $organization]))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component($component)
+            ->where('organization.id', $organization->id)
+            ->where('organization.slug', $organization->slug)
+        );
+})->with([
+    'Peoplecount' => ['PeopleCountViewer', 'peoplecount.dashboard', 'peoplecount/Dashboard'],
+    'Stage Safety' => ['StageSafetyViewer', 'stage-safety.dashboard', 'stage-safety/Dashboard'],
+]);
+
+it('forbids module dashboards without module permission', function (string $routeName) {
+    $organization = Organization::factory()->create();
+    $user = User::factory()->create();
+    $user->organizations()->attach($organization);
+
+    $this->actingAs($user)
+        ->get(route($routeName, ['organization' => $organization]))
+        ->assertForbidden();
+})->with([
+    'Peoplecount' => 'peoplecount.dashboard',
+    'Stage Safety' => 'stage-safety.dashboard',
+]);

--- a/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
+++ b/tests/Integration/Services/StageSafety/MonitoringServiceTest.php
@@ -191,3 +191,47 @@ it('returns bounded ordered history without archived or foreign sensors', functi
         ->and($payload['sensors'][0]['readings'][1]['value'])->toBe(8.0)
         ->and($emptySensor->exists)->toBeTrue();
 });
+
+it('returns ordered clamped LQI percentages from complete radio diagnostics', function () {
+    $organization = Organization::factory()->create();
+    $sensor = Sensor::factory()->for($organization)->create();
+    $archivedSensor = Sensor::factory()->for($organization)->create(['archived_at' => now()]);
+    $foreignSensor = Sensor::factory()->create();
+
+    foreach ([
+        ['minutes' => 30, 'rssi_dbm' => -98, 'cv' => 0],
+        ['minutes' => 20, 'rssi_dbm' => -90, 'cv' => 97],
+        ['minutes' => 10, 'rssi_dbm' => -30, 'cv' => 127],
+    ] as $sample) {
+        Reading::factory()->for($sensor)->create([
+            'observed_at' => now()->subMinutes($sample['minutes']),
+            'received_at' => now()->subMinutes($sample['minutes']),
+            'rssi_dbm' => $sample['rssi_dbm'],
+            'cv' => $sample['cv'],
+        ]);
+    }
+
+    Reading::factory()->for($sensor)->create([
+        'observed_at' => now()->subMinutes(5),
+        'received_at' => now()->subMinutes(5),
+        'rssi_dbm' => -70,
+        'cv' => null,
+    ]);
+    Reading::factory()->for($sensor)->create([
+        'observed_at' => now()->subHours(2),
+        'received_at' => now()->subHours(2),
+        'rssi_dbm' => -70,
+        'cv' => 100,
+    ]);
+    Reading::factory()->for($archivedSensor)->create(['rssi_dbm' => -70, 'cv' => 100]);
+    Reading::factory()->for($foreignSensor)->create(['rssi_dbm' => -70, 'cv' => 100]);
+
+    $payload = $this->service->lqiHistory($organization, now()->subHour(), now());
+
+    expect($payload['sensors'])->toHaveCount(1)
+        ->and($payload['sensors'][0]['sensor']['id'])->toBe($sensor->id)
+        ->and($payload['sensors'][0]['samples'])->toHaveCount(3)
+        ->and($payload['sensors'][0]['samples'][0]['lqi_percent'])->toBe(0.0)
+        ->and($payload['sensors'][0]['samples'][1]['lqi_percent'])->toEqualWithDelta(50.8974358974, 0.000001)
+        ->and($payload['sensors'][0]['samples'][2]['lqi_percent'])->toBe(100.0);
+});

--- a/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
+++ b/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use App\Http\Controllers\Widgets\StageSafetyCurrentWindWidgetController;
+use App\Http\Controllers\Widgets\StageSafetyLqiHistoryWidgetController;
 use App\Http\Controllers\Widgets\StageSafetySensorHealthWidgetController;
 use App\Http\Controllers\Widgets\StageSafetyWindHistoryWidgetController;
 use App\Http\Requests\Widgets\StageSafety\CurrentWindIndexRequest;
+use App\Http\Requests\Widgets\StageSafety\HistoryIndexRequest;
 use App\Http\Requests\Widgets\StageSafety\SensorHealthIndexRequest;
-use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
 use App\Models\Organization;
 use App\Models\StageSafety\Reading;
 use App\Models\StageSafety\Sensor;
@@ -36,6 +37,8 @@ it('allows a Stage Safety viewer to access all monitoring endpoints', function (
     Reading::factory()->for($sensor)->create([
         'observed_at' => now()->subMinute(),
         'received_at' => now()->subMinute(),
+        'rssi_dbm' => -90,
+        'cv' => 97,
     ]);
 
     $this->actingAs($viewer)
@@ -55,6 +58,14 @@ it('allows a Stage Safety viewer to access all monitoring endpoints', function (
         ->assertJsonPath('to', '2026-07-25T12:00:00+00:00')
         ->assertJsonPath('sensors.0.sensor.id', $sensor->id);
 
+    $this->actingAs($viewer)
+        ->getJson(route('stage-safety.lqi-history.index', ['organization' => $organization]))
+        ->assertSuccessful()
+        ->assertJsonPath('from', '2026-07-25T11:00:00+00:00')
+        ->assertJsonPath('to', '2026-07-25T12:00:00+00:00')
+        ->assertJsonPath('sensors.0.sensor.id', $sensor->id)
+        ->assertJsonPath('sensors.0.samples.0.lqi_percent', fn (float $value): bool => abs($value - 50.8974358974) < 0.0001);
+
 });
 
 it('forbids users without monitoring permission', function (string $routeName) {
@@ -68,6 +79,7 @@ it('forbids users without monitoring permission', function (string $routeName) {
     'current wind' => 'stage-safety.current-wind.index',
     'sensor health' => 'stage-safety.sensor-health.index',
     'wind history' => 'stage-safety.wind-history.index',
+    'LQI history' => 'stage-safety.lqi-history.index',
 ]);
 
 it('forbids an organization viewer from accessing another organization', function (string $routeName) {
@@ -85,6 +97,7 @@ it('forbids an organization viewer from accessing another organization', functio
     'current wind' => 'stage-safety.current-wind.index',
     'sensor health' => 'stage-safety.sensor-health.index',
     'wind history' => 'stage-safety.wind-history.index',
+    'LQI history' => 'stage-safety.lqi-history.index',
 ]);
 
 it('rejects invalid history ranges', function (array $query, array $invalidFields) {
@@ -113,7 +126,8 @@ it('uses monitoring form requests and organization middleware', function () {
     foreach ([
         'stage-safety.current-wind.index' => [StageSafetyCurrentWindWidgetController::class, CurrentWindIndexRequest::class],
         'stage-safety.sensor-health.index' => [StageSafetySensorHealthWidgetController::class, SensorHealthIndexRequest::class],
-        'stage-safety.wind-history.index' => [StageSafetyWindHistoryWidgetController::class, WindHistoryIndexRequest::class],
+        'stage-safety.wind-history.index' => [StageSafetyWindHistoryWidgetController::class, HistoryIndexRequest::class],
+        'stage-safety.lqi-history.index' => [StageSafetyLqiHistoryWidgetController::class, HistoryIndexRequest::class],
     ] as $routeName => [$controller, $request]) {
         test()->assertRouteUsesMiddleware(
             $routeName,

--- a/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
@@ -1,24 +1,24 @@
 <?php
 
-use App\Http\Requests\Widgets\StageSafety\WindHistoryIndexRequest;
+use App\Http\Requests\Widgets\StageSafety\HistoryIndexRequest;
 use App\Models\User;
 
-covers(WindHistoryIndexRequest::class);
+covers(HistoryIndexRequest::class);
 
 it('defines paired bounded history inputs', function () {
-    $request = new WindHistoryIndexRequest;
+    $request = new HistoryIndexRequest;
 
     expect($request->rules())->toBe([
         'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
         'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
     ])->and($request->after())->toHaveCount(1)
-        ->and(WindHistoryIndexRequest::MAX_RANGE_HOURS)->toBe(24);
+        ->and(HistoryIndexRequest::MAX_RANGE_HOURS)->toBe(24);
 });
 
 it('authorizes users with the monitoring permission', function () {
     $user = Mockery::mock(User::class);
     $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnTrue();
-    $request = new WindHistoryIndexRequest;
+    $request = new HistoryIndexRequest;
     $request->setUserResolver(fn (?string $guard = null): User => $user);
 
     expect($request->authorize())->toBeTrue();
@@ -27,7 +27,7 @@ it('authorizes users with the monitoring permission', function () {
 it('denies users without the monitoring permission', function () {
     $user = Mockery::mock(User::class);
     $user->shouldReceive('can')->with('stage-safety.monitoring.view')->andReturnFalse();
-    $request = new WindHistoryIndexRequest;
+    $request = new HistoryIndexRequest;
     $request->setUserResolver(fn (?string $guard = null): User => $user);
 
     expect($request->authorize())->toBeFalse();


### PR DESCRIPTION
Adds dedicated Peoplecount and Stage Safety dashboards so module monitoring is easier to find and understand. Stage Safety now includes normalized 0–100% LQI history, while history widgets gain a 30-minute range and current wind prioritizes gust readings.

## Details

- Adds permission-aware module dashboard routes and navigation.
- Derives LQI percentages from stored RSSI/CV diagnostics and displays per-sensor history.
- Keeps one hour as default history range while adding a shared 30-minute option.
- Shows gust prominently when available, with average below when both exist.

## Notes

Full `composer precommit:ai` gate passes, including coverage, static analysis, frontend tests, and e2e tests.

## Reviewer Setup

New frontend sources and the Peoplecount dashboard permission require:

```sh
php artisan db:seed --class=RolesAndPermissionsSeeder
npm run build
```

---
**«Do what you can, with what you have, where you are.»**
_Theodore Roosevelt_