### PR TITLE
Fix timezone, request validation, and service bindings

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -28,3 +28,18 @@ Use **kebab-case** for the short description.
 | `ui`         | UX/UI improvements without adding features  | `ux/improve-dashboard-spacing`             |
 | `i18n`       | Internationalization/localization changes   | `i18n/add-french-translations`             |
 | `migration`  | Major database schema changes               | `migration/refactor-user-tables`           |
+
+## Datetime Input Contract
+
+All datetime inputs to backend endpoints (form posts and query parameters) must be
+**ISO 8601 UTC with milliseconds**, i.e. the exact output of `Date.prototype.toISOString()`:
+
+```
+2026-08-01T09:00:00.000Z
+```
+
+- FormRequests enforce this via `date_format:Y-m-d\TH:i:s.v\Z`. Use that rule for new
+  datetime fields; do not use the permissive `date` rule.
+- In PHP tests, produce the format with `$carbon->toIso8601ZuluString('millisecond')`.
+- Exception: the hardware-facing sensor API (`observed_at`) accepts ISO 8601 with `Z` or
+  numeric offset at seconds precision, enforced by regex in `ReadingStoreRequest`.

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -38,7 +38,7 @@ class NewPasswordController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
+        $validated = $request->validate([
             'token' => ['required'],
             'email' => ['required', 'email'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
@@ -48,7 +48,7 @@ class NewPasswordController extends Controller
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = Password::reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
+            $validated,
             function (User $user) use ($request): void {
                 $user->forceFill([
                     'password' => Hash::make($request->password),

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -31,12 +31,12 @@ class PasswordResetLinkController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
+        $validated = $request->validate([
             'email' => ['required', 'email'],
         ]);
 
         Password::sendResetLink(
-            $request->only('email')
+            $validated
         );
 
         return back()->with('status', __('A reset link will be sent if the account exists.'));

--- a/app/Http/Controllers/Peoplecount/IntervalCountController.php
+++ b/app/Http/Controllers/Peoplecount/IntervalCountController.php
@@ -16,7 +16,12 @@ class IntervalCountController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * TODO: Consider adding request validation class for improved type safety
+     * Intentionally uses a plain Request: the Axis vendor payload allows
+     * additional properties (see the OpenAPI spec in docs/api), which
+     * conflicts with global fail-on-unknown-fields. IntervalCountService
+     * performs structural validation instead and rejects invalid payloads
+     * with an exception.
+     *
      * TODO: Consider adding rate limiting for API endpoints
      * TODO: Consider adding request logging for debugging sensor issues
      */

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -32,6 +32,7 @@ class LoginRequest extends FormRequest
         return [
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string'],
+            'remember' => ['boolean'],
         ];
     }
 
@@ -44,7 +45,7 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        if (! Auth::attempt($this->safe()->only('email', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/app/Http/Requests/Peoplecount/AreaSingleResetStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AreaSingleResetStoreRequest.php
@@ -26,7 +26,7 @@ class AreaSingleResetStoreRequest extends FormRequest
     {
         return [
             'reset_value' => ['required', 'integer', 'min:0'],
-            'effective_at' => ['required', 'date'],
+            'effective_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
             'notes' => ['nullable', 'string', 'max:1000'],
         ];
     }

--- a/app/Http/Requests/Peoplecount/AssignmentStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentStoreRequest.php
@@ -30,8 +30,8 @@ class AssignmentStoreRequest extends FormRequest
             'sensor_id' => ['required', 'integer', 'exists:peoplecount_sensors,id'],
             'label' => ['nullable', 'string', 'max:255'],
             'direction_flipped' => ['required', 'boolean'],
-            'active_from' => ['required', 'date', 'before:active_to'],
-            'active_to' => ['required', 'date', 'after:active_from'],
+            'active_from' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:active_to'],
+            'active_to' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:active_from'],
         ];
     }
 

--- a/app/Http/Requests/Peoplecount/AssignmentUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/AssignmentUpdateRequest.php
@@ -30,8 +30,8 @@ class AssignmentUpdateRequest extends FormRequest
             'sensor_id' => ['required', 'integer', 'exists:peoplecount_sensors,id'],
             'label' => ['nullable', 'string', 'max:255'],
             'direction_flipped' => ['required', 'boolean'],
-            'active_from' => ['required', 'date', 'before:active_to'],
-            'active_to' => ['required', 'date', 'after:active_from'],
+            'active_from' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:active_to'],
+            'active_to' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:active_from'],
         ];
     }
 

--- a/app/Http/Requests/Peoplecount/EventStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/EventStoreRequest.php
@@ -26,8 +26,8 @@ class EventStoreRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'starts_at' => ['required', 'date'],
-            'ends_at' => ['required', 'date', 'after:starts_at'],
+            'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
+            'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
         ];
     }
 }

--- a/app/Http/Requests/Peoplecount/EventUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/EventUpdateRequest.php
@@ -26,8 +26,8 @@ class EventUpdateRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'starts_at' => ['required', 'date'],
-            'ends_at' => ['required', 'date', 'after:starts_at'],
+            'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
+            'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
         ];
     }
 }

--- a/app/Http/Requests/Peoplecount/SensorShareStoreRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShareStoreRequest.php
@@ -26,8 +26,8 @@ class SensorShareStoreRequest extends FormRequest
     {
         return [
             'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
-            'starts_at' => ['required', 'date', 'before:ends_at'],
-            'ends_at' => ['required', 'date', 'after:starts_at'],
+            'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:ends_at'],
+            'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
         ];
     }
 

--- a/app/Http/Requests/Peoplecount/SensorShareUpdateRequest.php
+++ b/app/Http/Requests/Peoplecount/SensorShareUpdateRequest.php
@@ -26,8 +26,8 @@ class SensorShareUpdateRequest extends FormRequest
     {
         return [
             'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
-            'starts_at' => ['required', 'date', 'before:ends_at'],
-            'ends_at' => ['required', 'date', 'after:starts_at'],
+            'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:ends_at'],
+            'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
         ];
     }
 

--- a/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
@@ -23,8 +23,8 @@ class AreaCountHistoryIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
-            'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+            'from' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:to', 'before_or_equal:to'],
+            'to' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:from', 'after_or_equal:from'],
         ];
     }
 

--- a/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
@@ -30,8 +30,8 @@ class HistoryIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
-            'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+            'from' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:to', 'before_or_equal:to'],
+            'to' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:from', 'after_or_equal:from'],
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,7 @@ use App\Services\Peoplecount\IntervalCountService;
 use App\Services\Peoplecount\SensorService;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
@@ -57,6 +58,9 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Model::automaticallyEagerLoadRelationships();
+
+        // Reject unknown fields in all FormRequests globally (#115)
+        FormRequest::failOnUnknownFields();
 
         URL::forceHttps(app()->isProduction());
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,14 +11,6 @@ use App\Listeners\Permissions\RoleDetachedListener;
 use App\Models\StageSafety\Sensor as StageSafetySensor;
 use App\Models\User;
 use App\Services\GlobalPermissionService;
-use App\Services\Peoplecount\AlertService;
-use App\Services\Peoplecount\AreaAggregationService;
-use App\Services\Peoplecount\AreaResetService;
-use App\Services\Peoplecount\AreaService;
-use App\Services\Peoplecount\AssignmentService;
-use App\Services\Peoplecount\EventService;
-use App\Services\Peoplecount\IntervalCountService;
-use App\Services\Peoplecount\SensorService;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
@@ -35,23 +27,6 @@ use Spatie\Permission\Events\RoleDetachedEvent;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
-    public function register(): void
-    {
-        $this->app->singleton(GlobalPermissionService::class);
-        $this->app->singleton(SensorService::class);
-        $this->app->singleton(IntervalCountService::class);
-        $this->app->singleton(EventService::class);
-        $this->app->singleton(AreaService::class);
-        $this->app->singleton(AreaResetService::class);
-        $this->app->singleton(AssignmentService::class);
-        $this->app->singleton(AreaAggregationService::class);
-        $this->app->singleton(AlertService::class);
-
-    }
-
     /**
      * Bootstrap any application services.
      */

--- a/composer.json
+++ b/composer.json
@@ -101,13 +101,13 @@
             "npm run typecheck"
         ],
         "test:coverage": [
-            "pest --coverage --parallel --min=100"
+            "pest --coverage --parallel --min=100 --no-tia"
         ],
         "test:coverage:ci": [
             "pest --ci --coverage --parallel --min=100"
         ],
         "test:coverage:ai": [
-            "pest --coverage --parallel --min=100 --compact --no-progress --coverage-text=storage/logs/precommit-ai-coverage.txt --only-summary-for-coverage-text"
+            "pest --coverage --parallel --min=100 --no-tia --compact --no-progress --coverage-text=storage/logs/precommit-ai-coverage.txt --only-summary-for-coverage-text"
         ],
         "test:types": [
             "pest --type-coverage --parallel --min=100"

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRect
 use Rector\ValueObject\PhpVersion;
 use RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
 use RectorLaravel\Rector\ArrayDimFetch\ServerVariableToRequestFacadeRector;
+use RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector;
 use RectorLaravel\Set\LaravelLevelSetList;
 use RectorLaravel\Set\LaravelSetList;
 
@@ -37,6 +38,10 @@ return static function (RectorConfig $rectorConfig): void {
         // TODO: Remove once https://github.com/driftingly/rector-laravel/issues/419 is fixed.
         ServerVariableToRequestFacadeRector::class => [
             __DIR__.'/tests/Feature/PeoplecountConfigTest.php',
+        ],
+        // Unit tests must stay facade-free (UnitTestPurityTest)
+        CarbonToDateFacadeRector::class => [
+            __DIR__.'/tests/Unit',
         ],
         __DIR__.'/vendor/*',
         __DIR__.'/node_modules/*',

--- a/resources/js/components/peoplecount/resets/SingleResetForm.vue
+++ b/resources/js/components/peoplecount/resets/SingleResetForm.vue
@@ -16,7 +16,6 @@ const props = defineProps<{
 }>();
 
 const form = useForm({
-    area_id: props.area.id,
     reset_value: props.reset?.reset_value || 0,
     effective_at: props.reset ? utcStringToDatetimeLocal(props.reset.effective_at) : utcStringToDatetimeLocal(new Date().toISOString()),
     notes: props.reset?.notes || '',

--- a/resources/js/components/users/UserForm.vue
+++ b/resources/js/components/users/UserForm.vue
@@ -55,17 +55,26 @@ const withoutRoles = (data: UserFormData) => {
     return dataWithoutRoles;
 };
 
+// orgmgmt endpoints derive the organization from the route, and admin user
+// creation assigns no organizations — neither accepts organization_ids
+const withoutOrganizationIds = <T extends { organization_ids: number[] }>(data: T) => {
+    const { organization_ids, ...dataWithoutOrganizationIds } = data;
+    void organization_ids;
+
+    return dataWithoutOrganizationIds;
+};
+
 const submit = () => {
     if (props.user && props.organization) {
-        form.transform((data) => (showRoleField.value ? data : withoutRoles(data))).put(
+        form.transform((data) => withoutOrganizationIds(showRoleField.value ? data : withoutRoles(data))).put(
             route('orgmgmt.users.update', { user: props.user.id, organization: props.organization.slug }),
         );
     } else if (props.user) {
         form.transform(withoutRoles).put(route('admin.users.update', { id: props.user.id }));
     } else if (props.organization) {
-        form.post(route('orgmgmt.users.store', { organization: props.organization.slug }));
+        form.transform(withoutOrganizationIds).post(route('orgmgmt.users.store', { organization: props.organization.slug }));
     } else if (!props.user && !props.organization) {
-        form.transform(withoutRoles).post(route('admin.users.store'));
+        form.transform((data) => withoutOrganizationIds(withoutRoles(data))).post(route('admin.users.store'));
     }
 };
 </script>

--- a/resources/js/utils/_tests_/dateTimeHelpers.test.ts
+++ b/resources/js/utils/_tests_/dateTimeHelpers.test.ts
@@ -324,6 +324,99 @@ describe('Time Format Functions', () => {
             expect(occurrences).toHaveLength(1);
             expect(occurrences[0]).toBeInstanceOf(Date);
         });
+
+        describe('timezone-aware behavior', () => {
+            afterEach(() => {
+                vi.useRealTimers();
+            });
+
+            const wallTimeIn = (date: Date, timezone: string): string =>
+                date.toLocaleString(APP_LOCALE, {
+                    timeZone: timezone,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hourCycle: 'h23',
+                });
+
+            it('should apply the reset time in the target timezone, not the viewer timezone', () => {
+                // 2024-07-25 12:00 UTC — independent of the host/viewer timezone,
+                // every occurrence must read 09:00 in Europe/Zurich
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));
+
+                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
+
+                expect(occurrences).toHaveLength(3);
+                for (const occurrence of occurrences) {
+                    expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('09:00');
+                }
+            });
+
+            it('should shift UTC instants across DST transitions while keeping local wall time', () => {
+                // Europe/Zurich springs forward CET -> CEST on 2024-03-31
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-03-30T12:00:00Z'));
+
+                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
+
+                expect(occurrences.map((date) => date.toISOString())).toEqual([
+                    '2024-03-31T07:00:00.000Z', // CET (UTC+1)
+                    '2024-04-01T07:00:00.000Z', // CEST (UTC+2)
+                    '2024-04-02T07:00:00.000Z', // CEST (UTC+2)
+                ]);
+            });
+
+            it('should keep UTC instants aligned across DST fall-back', () => {
+                // Europe/Zurich falls back CEST -> CET on 2024-10-27
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-10-25T12:00:00Z'));
+
+                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
+
+                expect(occurrences.map((date) => date.toISOString())).toEqual([
+                    '2024-10-26T07:00:00.000Z', // CEST (UTC+2)
+                    '2024-10-27T08:00:00.000Z', // CET (UTC+1)
+                    '2024-10-28T08:00:00.000Z', // CET (UTC+1)
+                ]);
+            });
+
+            it('should skip today when the reset time already passed in the target timezone', () => {
+                // 2024-07-25 10:00 UTC = 12:00 in Europe/Zurich — 09:00 already passed there
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-07-25T10:00:00Z'));
+
+                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 2);
+
+                expect(occurrences.map((date) => date.toISOString())).toEqual(['2024-07-26T07:00:00.000Z', '2024-07-27T07:00:00.000Z']);
+            });
+
+            it('should include today when the reset time is still ahead near midnight', () => {
+                // 2024-07-25 21:30 UTC = 23:30 in Europe/Zurich — 00:00 tomorrow is 30 min away
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-07-25T21:30:00Z'));
+
+                const occurrences = getNextDailyOccurrence('00:00', 'Europe/Zurich', 2);
+
+                expect(occurrences.map((date) => date.toISOString())).toEqual(['2024-07-25T22:00:00.000Z', '2024-07-26T22:00:00.000Z']);
+            });
+
+            it('should return occurrences in the future and in ascending order', () => {
+                vi.useFakeTimers();
+                const now = new Date('2024-07-25T12:00:00Z');
+                vi.setSystemTime(now);
+
+                const occurrences = getNextDailyOccurrence('14:30', 'America/New_York', 5);
+
+                expect(occurrences).toHaveLength(5);
+                for (const occurrence of occurrences) {
+                    expect(occurrence.getTime()).toBeGreaterThan(now.getTime());
+                    expect(wallTimeIn(occurrence, 'America/New_York')).toBe('14:30');
+                }
+                for (let i = 1; i < occurrences.length; i++) {
+                    expect(occurrences[i].getTime()).toBeGreaterThan(occurrences[i - 1].getTime());
+                }
+            });
+        });
     });
 });
 

--- a/resources/js/utils/_tests_/dateTimeHelpers.test.ts
+++ b/resources/js/utils/_tests_/dateTimeHelpers.test.ts
@@ -13,7 +13,6 @@ import {
     formatTimeForInput,
     formatTimestamp,
     getLocalDateFromUTC,
-    getNextDailyOccurrence,
     getRelativeTime,
     getUserTimezone,
     getUTCStringFromLocal,
@@ -139,14 +138,6 @@ describe('DateTimeHelper Class', () => {
             it('should convert time and timezone to readable text', () => {
                 const text = DateTimeHelper.dailyResetToText('08:00', 'Europe/Zurich');
                 expect(text).toBe('Daily at 08:00 (Europe/Zurich)');
-            });
-        });
-
-        describe('getNextDailyOccurrence', () => {
-            it('should return next daily occurrences', () => {
-                const occurrences = DateTimeHelper.getNextDailyOccurrence('09:00', 'UTC', 3);
-                expect(occurrences).toHaveLength(3);
-                expect(occurrences[0]).toBeInstanceOf(Date);
             });
         });
     });
@@ -291,161 +282,6 @@ describe('Time Format Functions', () => {
         it('should handle UTC timezone', () => {
             const text = dailyResetToText('12:00', 'UTC');
             expect(text).toBe('Daily at 12:00 (UTC)');
-        });
-    });
-
-    describe('getNextDailyOccurrence', () => {
-        it('should return next daily occurrences', () => {
-            const occurrences = getNextDailyOccurrence('09:00', 'UTC', 3);
-            expect(occurrences).toHaveLength(3);
-            expect(occurrences[0]).toBeInstanceOf(Date);
-            expect(occurrences[1]).toBeInstanceOf(Date);
-            expect(occurrences[2]).toBeInstanceOf(Date);
-        });
-
-        it('should handle different timezones', () => {
-            const occurrences = getNextDailyOccurrence('14:30', 'Europe/Zurich', 2);
-            expect(occurrences).toHaveLength(2);
-            expect(occurrences[0]).toBeInstanceOf(Date);
-        });
-
-        it('should handle invalid time format', () => {
-            const occurrences = getNextDailyOccurrence('invalid', 'UTC', 3);
-            expect(occurrences).toHaveLength(0);
-        });
-
-        it('should limit occurrences to requested count', () => {
-            const occurrences = getNextDailyOccurrence('08:00', 'UTC', 2);
-            expect(occurrences).toHaveLength(2);
-        });
-
-        it('should reject non-positive, fractional, and infinite counts', () => {
-            expect(getNextDailyOccurrence('08:00', 'UTC', 0)).toEqual([]);
-            expect(getNextDailyOccurrence('08:00', 'UTC', -1)).toEqual([]);
-            expect(getNextDailyOccurrence('08:00', 'UTC', 1.5)).toEqual([]);
-            expect(getNextDailyOccurrence('08:00', 'UTC', Infinity)).toEqual([]);
-            expect(getNextDailyOccurrence('08:00', 'UTC', NaN)).toEqual([]);
-        });
-
-        it('should handle edge case times', () => {
-            const occurrences = getNextDailyOccurrence('00:00', 'UTC', 1);
-            expect(occurrences).toHaveLength(1);
-            expect(occurrences[0]).toBeInstanceOf(Date);
-        });
-
-        describe('timezone-aware behavior', () => {
-            afterEach(() => {
-                vi.useRealTimers();
-            });
-
-            const wallTimeIn = (date: Date, timezone: string): string =>
-                date.toLocaleString(APP_LOCALE, {
-                    timeZone: timezone,
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hourCycle: 'h23',
-                });
-
-            it('should apply the reset time in the target timezone, not the viewer timezone', () => {
-                // 2024-07-25 12:00 UTC — independent of the host/viewer timezone,
-                // every occurrence must read 09:00 in Europe/Zurich
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-07-25T12:00:00Z'));
-
-                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
-
-                expect(occurrences).toHaveLength(3);
-                for (const occurrence of occurrences) {
-                    expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('09:00');
-                }
-            });
-
-            it('should shift UTC instants across DST transitions while keeping local wall time', () => {
-                // Europe/Zurich springs forward CET -> CEST on 2024-03-31
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-03-30T12:00:00Z'));
-
-                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
-
-                expect(occurrences.map((date) => date.toISOString())).toEqual([
-                    '2024-03-31T07:00:00.000Z', // CET (UTC+1)
-                    '2024-04-01T07:00:00.000Z', // CEST (UTC+2)
-                    '2024-04-02T07:00:00.000Z', // CEST (UTC+2)
-                ]);
-            });
-
-            it('should move nonexistent spring-forward times to the first valid local minute', () => {
-                // 02:30 does not exist in Europe/Zurich on 2024-03-31.
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-03-30T12:00:00Z'));
-
-                const [occurrence] = getNextDailyOccurrence('02:30', 'Europe/Zurich', 1);
-
-                expect(occurrence.toISOString()).toBe('2024-03-31T01:00:00.000Z');
-                expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('03:00');
-            });
-
-            it('should keep UTC instants aligned across DST fall-back', () => {
-                // Europe/Zurich falls back CEST -> CET on 2024-10-27
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-10-25T12:00:00Z'));
-
-                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 3);
-
-                expect(occurrences.map((date) => date.toISOString())).toEqual([
-                    '2024-10-26T07:00:00.000Z', // CEST (UTC+2)
-                    '2024-10-27T08:00:00.000Z', // CET (UTC+1)
-                    '2024-10-28T08:00:00.000Z', // CET (UTC+1)
-                ]);
-            });
-
-            it('should deterministically use the second occurrence of an ambiguous fall-back time', () => {
-                // 02:30 occurs twice in Europe/Zurich on 2024-10-27.
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-10-26T12:00:00Z'));
-
-                const [occurrence] = getNextDailyOccurrence('02:30', 'Europe/Zurich', 1);
-
-                expect(occurrence.toISOString()).toBe('2024-10-27T01:30:00.000Z');
-                expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('02:30');
-            });
-
-            it('should skip today when the reset time already passed in the target timezone', () => {
-                // 2024-07-25 10:00 UTC = 12:00 in Europe/Zurich — 09:00 already passed there
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-07-25T10:00:00Z'));
-
-                const occurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 2);
-
-                expect(occurrences.map((date) => date.toISOString())).toEqual(['2024-07-26T07:00:00.000Z', '2024-07-27T07:00:00.000Z']);
-            });
-
-            it('should include today when the reset time is still ahead near midnight', () => {
-                // 2024-07-25 21:30 UTC = 23:30 in Europe/Zurich — 00:00 tomorrow is 30 min away
-                vi.useFakeTimers();
-                vi.setSystemTime(new Date('2024-07-25T21:30:00Z'));
-
-                const occurrences = getNextDailyOccurrence('00:00', 'Europe/Zurich', 2);
-
-                expect(occurrences.map((date) => date.toISOString())).toEqual(['2024-07-25T22:00:00.000Z', '2024-07-26T22:00:00.000Z']);
-            });
-
-            it('should return occurrences in the future and in ascending order', () => {
-                vi.useFakeTimers();
-                const now = new Date('2024-07-25T12:00:00Z');
-                vi.setSystemTime(now);
-
-                const occurrences = getNextDailyOccurrence('14:30', 'America/New_York', 5);
-
-                expect(occurrences).toHaveLength(5);
-                for (const occurrence of occurrences) {
-                    expect(occurrence.getTime()).toBeGreaterThan(now.getTime());
-                    expect(wallTimeIn(occurrence, 'America/New_York')).toBe('14:30');
-                }
-                for (let i = 1; i < occurrences.length; i++) {
-                    expect(occurrences[i].getTime()).toBeGreaterThan(occurrences[i - 1].getTime());
-                }
-            });
         });
     });
 });

--- a/resources/js/utils/_tests_/dateTimeHelpers.test.ts
+++ b/resources/js/utils/_tests_/dateTimeHelpers.test.ts
@@ -319,6 +319,14 @@ describe('Time Format Functions', () => {
             expect(occurrences).toHaveLength(2);
         });
 
+        it('should reject non-positive, fractional, and infinite counts', () => {
+            expect(getNextDailyOccurrence('08:00', 'UTC', 0)).toEqual([]);
+            expect(getNextDailyOccurrence('08:00', 'UTC', -1)).toEqual([]);
+            expect(getNextDailyOccurrence('08:00', 'UTC', 1.5)).toEqual([]);
+            expect(getNextDailyOccurrence('08:00', 'UTC', Infinity)).toEqual([]);
+            expect(getNextDailyOccurrence('08:00', 'UTC', NaN)).toEqual([]);
+        });
+
         it('should handle edge case times', () => {
             const occurrences = getNextDailyOccurrence('00:00', 'UTC', 1);
             expect(occurrences).toHaveLength(1);
@@ -366,6 +374,17 @@ describe('Time Format Functions', () => {
                 ]);
             });
 
+            it('should move nonexistent spring-forward times to the first valid local minute', () => {
+                // 02:30 does not exist in Europe/Zurich on 2024-03-31.
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-03-30T12:00:00Z'));
+
+                const [occurrence] = getNextDailyOccurrence('02:30', 'Europe/Zurich', 1);
+
+                expect(occurrence.toISOString()).toBe('2024-03-31T01:00:00.000Z');
+                expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('03:00');
+            });
+
             it('should keep UTC instants aligned across DST fall-back', () => {
                 // Europe/Zurich falls back CEST -> CET on 2024-10-27
                 vi.useFakeTimers();
@@ -378,6 +397,17 @@ describe('Time Format Functions', () => {
                     '2024-10-27T08:00:00.000Z', // CET (UTC+1)
                     '2024-10-28T08:00:00.000Z', // CET (UTC+1)
                 ]);
+            });
+
+            it('should deterministically use the second occurrence of an ambiguous fall-back time', () => {
+                // 02:30 occurs twice in Europe/Zurich on 2024-10-27.
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-10-26T12:00:00Z'));
+
+                const [occurrence] = getNextDailyOccurrence('02:30', 'Europe/Zurich', 1);
+
+                expect(occurrence.toISOString()).toBe('2024-10-27T01:30:00.000Z');
+                expect(wallTimeIn(occurrence, 'Europe/Zurich')).toBe('02:30');
             });
 
             it('should skip today when the reset time already passed in the target timezone', () => {

--- a/resources/js/utils/dateTimeHelpers.ts
+++ b/resources/js/utils/dateTimeHelpers.ts
@@ -161,11 +161,69 @@ export function formatDateInTimezone(date: Date, timezone: string, options?: Int
 }
 
 /**
+ * Wall-clock parts of a date as seen in a specific IANA timezone
+ */
+interface TimezoneWallClockParts {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+}
+
+/**
+ * Get the wall-clock parts of a date in a specific timezone
+ */
+function getWallClockPartsInTimezone(date: Date, timezone: string): TimezoneWallClockParts {
+    const parts = new Intl.DateTimeFormat(APP_LOCALE, {
+        timeZone: timezone,
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        hourCycle: 'h23',
+    }).formatToParts(date);
+
+    const partValue = (type: Intl.DateTimeFormatPartTypes): number => Number(parts.find((part) => part.type === type)?.value);
+
+    return {
+        year: partValue('year'),
+        month: partValue('month'),
+        day: partValue('day'),
+        hour: partValue('hour'),
+        minute: partValue('minute'),
+    };
+}
+
+/**
+ * Convert a wall-clock time in a specific timezone to a UTC instant.
+ * Iteratively corrects the timezone offset by reading back the candidate
+ * instant in the target timezone. For nonexistent wall times (DST
+ * spring-forward gap) the iteration does not converge and the last
+ * approximation is returned (pre-gap instant).
+ */
+function wallTimeInTimezoneToUtc(year: number, month: number, day: number, hour: number, minute: number, timezone: string): Date {
+    const target = Date.UTC(year, month - 1, day, hour, minute);
+    let utc = target;
+
+    for (let i = 0; i < 3; i++) {
+        const parts = getWallClockPartsInTimezone(new Date(utc), timezone);
+        const readBack = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
+        if (readBack === target) {
+            break;
+        }
+        utc -= readBack - target;
+    }
+
+    return new Date(utc);
+}
+
+/**
  * Calculate next daily occurrences at resetTime in specified timezone
  * Handles DST by applying reset at defined time in current day
  */
 export function getNextDailyOccurrence(resetTime: string, timezone: string, count: number = 5): Date[] {
-    const occurrences: Date[] = [];
     const [hours, minutes] = resetTime.split(':').map(Number);
 
     // Validate time format
@@ -174,19 +232,17 @@ export function getNextDailyOccurrence(resetTime: string, timezone: string, coun
     }
 
     const now = new Date();
+    const today = getWallClockPartsInTimezone(now, timezone);
+    const occurrences: Date[] = [];
 
-    for (let i = 0; i < count; i++) {
-        // Create a date for today + i days
-        const targetDate = new Date(now);
-        targetDate.setDate(now.getDate() + i);
-        targetDate.setHours(hours, minutes, 0, 0);
+    // Each day after the first always yields an occurrence, so this terminates
+    for (let i = 0; occurrences.length < count; i++) {
+        const day = new Date(Date.UTC(today.year, today.month - 1, today.day + i));
+        const candidate = wallTimeInTimezoneToUtc(day.getUTCFullYear(), day.getUTCMonth() + 1, day.getUTCDate(), hours, minutes, timezone);
 
-        // If it's today and the time has already passed, skip to tomorrow
-        if (i === 0 && targetDate <= now) {
-            targetDate.setDate(now.getDate() + 1);
+        if (candidate > now) {
+            occurrences.push(candidate);
         }
-
-        occurrences.push(targetDate);
     }
 
     return occurrences;

--- a/resources/js/utils/dateTimeHelpers.ts
+++ b/resources/js/utils/dateTimeHelpers.ts
@@ -199,9 +199,8 @@ function getWallClockPartsInTimezone(date: Date, timezone: string): TimezoneWall
 /**
  * Convert a wall-clock time in a specific timezone to a UTC instant.
  * Iteratively corrects the timezone offset by reading back the candidate
- * instant in the target timezone. For nonexistent wall times (DST
- * spring-forward gap) the iteration does not converge and the last
- * approximation is returned (pre-gap instant).
+ * instant in the target timezone. Nonexistent wall times during DST
+ * spring-forward move to the first valid minute after the gap.
  */
 function wallTimeInTimezoneToUtc(year: number, month: number, day: number, hour: number, minute: number, timezone: string): Date {
     const target = Date.UTC(year, month - 1, day, hour, minute);
@@ -211,9 +210,29 @@ function wallTimeInTimezoneToUtc(year: number, month: number, day: number, hour:
         const parts = getWallClockPartsInTimezone(new Date(utc), timezone);
         const readBack = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
         if (readBack === target) {
-            break;
+            return new Date(utc);
         }
         utc -= readBack - target;
+    }
+
+    // Resolve a spring-forward gap to its first valid local minute.
+    for (let i = 0; i < 24 * 60; i++) {
+        const parts = getWallClockPartsInTimezone(new Date(utc), timezone);
+        const readBack = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
+
+        if (readBack >= target) {
+            while (utc > 0) {
+                const previousUtc = utc - 60000;
+                const previous = getWallClockPartsInTimezone(new Date(previousUtc), timezone);
+                const previousReadBack = Date.UTC(previous.year, previous.month - 1, previous.day, previous.hour, previous.minute);
+                if (previousReadBack < target) {
+                    return new Date(utc);
+                }
+                utc = previousUtc;
+            }
+        }
+
+        utc += 60000;
     }
 
     return new Date(utc);
@@ -227,7 +246,17 @@ export function getNextDailyOccurrence(resetTime: string, timezone: string, coun
     const [hours, minutes] = resetTime.split(':').map(Number);
 
     // Validate time format
-    if (isNaN(hours) || isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    if (
+        isNaN(hours) ||
+        isNaN(minutes) ||
+        hours < 0 ||
+        hours > 23 ||
+        minutes < 0 ||
+        minutes > 59 ||
+        !Number.isFinite(count) ||
+        !Number.isInteger(count) ||
+        count <= 0
+    ) {
         return [];
     }
 

--- a/resources/js/utils/dateTimeHelpers.ts
+++ b/resources/js/utils/dateTimeHelpers.ts
@@ -1,26 +1,4 @@
-/**
- * Date and Time Helper Functions
- * Provides utility functions for date and time formatting and conversion
- * Includes daily reset scheduling and advanced timezone handling
- *
- * IMPORTANT: Daily Reset Timezone Handling
- * ========================================
- * This implementation handles daily resets at specific times in specified timezones:
- *
- * 1. Reset times are stored in HH:MM format (24-hour)
- * 2. Timezone handling ensures resets occur at the correct local time
- * 3. DST transitions are handled by applying the reset at the defined time in the current day
- * 4. Next occurrence calculation accounts for whether today's reset time has already passed
- *
- * Example of daily reset usage:
- * ```typescript
- * const nextOccurrences = getNextDailyOccurrence('09:00', 'Europe/Zurich', 5);
- * const isValid = validateResetTime('09:00');
- * const description = dailyResetToText('09:00', 'Europe/Zurich');
- * ```
- *
- * This approach ensures consistent daily reset behavior across different timezones and DST transitions.
- */
+/** Date and time formatting and conversion helpers. */
 
 export const APP_LOCALE = 'en-US';
 
@@ -158,123 +136,6 @@ export function formatDateInTimezone(date: Date, timezone: string, options?: Int
     };
 
     return date.toLocaleString(APP_LOCALE, { ...defaultOptions, ...options });
-}
-
-/**
- * Wall-clock parts of a date as seen in a specific IANA timezone
- */
-interface TimezoneWallClockParts {
-    year: number;
-    month: number;
-    day: number;
-    hour: number;
-    minute: number;
-}
-
-/**
- * Get the wall-clock parts of a date in a specific timezone
- */
-function getWallClockPartsInTimezone(date: Date, timezone: string): TimezoneWallClockParts {
-    const parts = new Intl.DateTimeFormat(APP_LOCALE, {
-        timeZone: timezone,
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        hourCycle: 'h23',
-    }).formatToParts(date);
-
-    const partValue = (type: Intl.DateTimeFormatPartTypes): number => Number(parts.find((part) => part.type === type)?.value);
-
-    return {
-        year: partValue('year'),
-        month: partValue('month'),
-        day: partValue('day'),
-        hour: partValue('hour'),
-        minute: partValue('minute'),
-    };
-}
-
-/**
- * Convert a wall-clock time in a specific timezone to a UTC instant.
- * Iteratively corrects the timezone offset by reading back the candidate
- * instant in the target timezone. Nonexistent wall times during DST
- * spring-forward move to the first valid minute after the gap.
- */
-function wallTimeInTimezoneToUtc(year: number, month: number, day: number, hour: number, minute: number, timezone: string): Date {
-    const target = Date.UTC(year, month - 1, day, hour, minute);
-    let utc = target;
-
-    for (let i = 0; i < 3; i++) {
-        const parts = getWallClockPartsInTimezone(new Date(utc), timezone);
-        const readBack = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
-        if (readBack === target) {
-            return new Date(utc);
-        }
-        utc -= readBack - target;
-    }
-
-    // Resolve a spring-forward gap to its first valid local minute.
-    for (let i = 0; i < 24 * 60; i++) {
-        const parts = getWallClockPartsInTimezone(new Date(utc), timezone);
-        const readBack = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
-
-        if (readBack >= target) {
-            while (utc > 0) {
-                const previousUtc = utc - 60000;
-                const previous = getWallClockPartsInTimezone(new Date(previousUtc), timezone);
-                const previousReadBack = Date.UTC(previous.year, previous.month - 1, previous.day, previous.hour, previous.minute);
-                if (previousReadBack < target) {
-                    return new Date(utc);
-                }
-                utc = previousUtc;
-            }
-        }
-
-        utc += 60000;
-    }
-
-    return new Date(utc);
-}
-
-/**
- * Calculate next daily occurrences at resetTime in specified timezone
- * Handles DST by applying reset at defined time in current day
- */
-export function getNextDailyOccurrence(resetTime: string, timezone: string, count: number = 5): Date[] {
-    const [hours, minutes] = resetTime.split(':').map(Number);
-
-    // Validate time format
-    if (
-        isNaN(hours) ||
-        isNaN(minutes) ||
-        hours < 0 ||
-        hours > 23 ||
-        minutes < 0 ||
-        minutes > 59 ||
-        !Number.isFinite(count) ||
-        !Number.isInteger(count) ||
-        count <= 0
-    ) {
-        return [];
-    }
-
-    const now = new Date();
-    const today = getWallClockPartsInTimezone(now, timezone);
-    const occurrences: Date[] = [];
-
-    // Each day after the first always yields an occurrence, so this terminates
-    for (let i = 0; occurrences.length < count; i++) {
-        const day = new Date(Date.UTC(today.year, today.month - 1, today.day + i));
-        const candidate = wallTimeInTimezoneToUtc(day.getUTCFullYear(), day.getUTCMonth() + 1, day.getUTCDate(), hours, minutes, timezone);
-
-        if (candidate > now) {
-            occurrences.push(candidate);
-        }
-    }
-
-    return occurrences;
 }
 
 /**
@@ -438,13 +299,6 @@ export class DateTimeHelper {
      */
     static formatDateInTimezone(date: Date, timezone: string, options?: Intl.DateTimeFormatOptions): string {
         return formatDateInTimezone(date, timezone, options);
-    }
-
-    /**
-     * Calculate next daily occurrences at resetTime in specified timezone
-     */
-    static getNextDailyOccurrence(resetTime: string, timezone: string, count: number = 5): Date[] {
-        return getNextDailyOccurrence(resetTime, timezone, count);
     }
 
     /**

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -1,15 +1,6 @@
 <?php
 
 use App\Models\User;
-use App\Services\GlobalPermissionService;
-use App\Services\Peoplecount\AlertService;
-use App\Services\Peoplecount\AreaAggregationService;
-use App\Services\Peoplecount\AreaResetService;
-use App\Services\Peoplecount\AreaService;
-use App\Services\Peoplecount\AssignmentService;
-use App\Services\Peoplecount\EventService;
-use App\Services\Peoplecount\IntervalCountService;
-use App\Services\Peoplecount\SensorService;
 
 beforeEach(function () {
     $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
@@ -35,23 +26,4 @@ it('defines a gate for laravel pulse', function () {
     $result = Gate::forUser($user)->allows('viewPulse');
 
     expect($result)->toBeTrue();
-});
-
-it('auto-resolves concrete services without explicit bindings', function () {
-    $services = [
-        GlobalPermissionService::class,
-        SensorService::class,
-        IntervalCountService::class,
-        EventService::class,
-        AreaService::class,
-        AreaResetService::class,
-        AssignmentService::class,
-        AreaAggregationService::class,
-        AlertService::class,
-    ];
-
-    foreach ($services as $service) {
-        expect(app()->bound($service))->toBeFalse()
-            ->and(resolve($service))->toBeInstanceOf($service);
-    }
 });

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -1,6 +1,15 @@
 <?php
 
 use App\Models\User;
+use App\Services\GlobalPermissionService;
+use App\Services\Peoplecount\AlertService;
+use App\Services\Peoplecount\AreaAggregationService;
+use App\Services\Peoplecount\AreaResetService;
+use App\Services\Peoplecount\AreaService;
+use App\Services\Peoplecount\AssignmentService;
+use App\Services\Peoplecount\EventService;
+use App\Services\Peoplecount\IntervalCountService;
+use App\Services\Peoplecount\SensorService;
 
 beforeEach(function () {
     $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
@@ -26,4 +35,23 @@ it('defines a gate for laravel pulse', function () {
     $result = Gate::forUser($user)->allows('viewPulse');
 
     expect($result)->toBeTrue();
+});
+
+it('auto-resolves concrete services without explicit bindings', function () {
+    $services = [
+        GlobalPermissionService::class,
+        SensorService::class,
+        IntervalCountService::class,
+        EventService::class,
+        AreaService::class,
+        AreaResetService::class,
+        AssignmentService::class,
+        AreaAggregationService::class,
+        AlertService::class,
+    ];
+
+    foreach ($services as $service) {
+        expect(app()->bound($service))->toBeFalse()
+            ->and(resolve($service))->toBeInstanceOf($service);
+    }
 });

--- a/tests/Feature/Peoplecount/SensorShareControllerTest.php
+++ b/tests/Feature/Peoplecount/SensorShareControllerTest.php
@@ -24,8 +24,8 @@ it('stores a sensor share', function () {
             'sensor' => $sensor->id,
         ]), [
             'borrower_organization_id' => (string) $borrower->id,
-            'starts_at' => '2026-08-01 09:00:00',
-            'ends_at' => '2026-08-01 18:00:00',
+            'starts_at' => '2026-08-01T09:00:00.000Z',
+            'ends_at' => '2026-08-01T18:00:00.000Z',
         ])
         ->assertRedirect(route('peoplecount.sensors.edit', [
             'organization' => $owner->slug,
@@ -51,8 +51,8 @@ it('returns validation errors when storing invalid share', function () {
             'sensor' => $sensor->id,
         ]), [
             'borrower_organization_id' => $owner->id,
-            'starts_at' => '2026-08-01 09:00:00',
-            'ends_at' => '2026-08-01 18:00:00',
+            'starts_at' => '2026-08-01T09:00:00.000Z',
+            'ends_at' => '2026-08-01T18:00:00.000Z',
         ])
         ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
         ->assertSessionHasErrors('borrower_organization_id');
@@ -73,8 +73,8 @@ it('updates a sensor share', function () {
             'share' => $share->id,
         ]), [
             'borrower_organization_id' => (string) $newBorrower->id,
-            'starts_at' => '2026-08-01 08:00:00',
-            'ends_at' => '2026-08-01 19:00:00',
+            'starts_at' => '2026-08-01T08:00:00.000Z',
+            'ends_at' => '2026-08-01T19:00:00.000Z',
         ])
         ->assertRedirect(route('peoplecount.sensors.edit', [
             'organization' => $owner->slug,
@@ -99,8 +99,8 @@ it('rejects updating a share for another sensor', function () {
             'share' => $share->id,
         ]), [
             'borrower_organization_id' => $borrower->id,
-            'starts_at' => '2026-08-01 08:00:00',
-            'ends_at' => '2026-08-01 19:00:00',
+            'starts_at' => '2026-08-01T08:00:00.000Z',
+            'ends_at' => '2026-08-01T19:00:00.000Z',
         ])
         ->assertNotFound();
 });
@@ -120,8 +120,8 @@ it('returns validation errors when updating invalid share', function () {
             'share' => $share->id,
         ]), [
             'borrower_organization_id' => $owner->id,
-            'starts_at' => '2026-08-01 08:00:00',
-            'ends_at' => '2026-08-01 19:00:00',
+            'starts_at' => '2026-08-01T08:00:00.000Z',
+            'ends_at' => '2026-08-01T19:00:00.000Z',
         ])
         ->assertRedirect(route('peoplecount.sensors.edit', ['organization' => $owner->slug, 'sensor' => $sensor->id]))
         ->assertSessionHasErrors('borrower_organization_id');

--- a/tests/Feature/StageSafety/ReadingControllerTest.php
+++ b/tests/Feature/StageSafety/ReadingControllerTest.php
@@ -69,7 +69,7 @@ it('persists a token-bound m/s reading with client and server timestamps', funct
         ->and($reading->cv)->toBe(103);
 });
 
-it('ignores extra identity and payload fields', function () {
+it('rejects extra identity and payload fields', function () {
     $authenticatedSensor = Sensor::factory()->create();
     $otherSensor = Sensor::factory()->for(Organization::factory())->create();
     $payload = stageSafetyReadingPayload([
@@ -87,10 +87,10 @@ it('ignores extra identity and payload fields', function () {
         route('stage-safety.readings.store'),
         $payload,
         stageSafetyReadingHeaders(stageSafetyReadingToken($authenticatedSensor)),
-    )->assertOk();
+    )->assertUnprocessable()
+        ->assertJsonValidationErrors(['sensor_id', 'organization_id', 'ignored']);
 
-    expect(Reading::query()->sole()->sensor_id)->toBe($authenticatedSensor->id)
-        ->and(Reading::query()->whereBelongsTo($otherSensor)->exists())->toBeFalse();
+    expect(Reading::query()->count())->toBe(0);
 });
 
 it('stores average and gust frames independently', function () {

--- a/tests/Feature/StageSafety/SensorControllerTest.php
+++ b/tests/Feature/StageSafety/SensorControllerTest.php
@@ -83,12 +83,11 @@ it('shows create and edit pages with supported sensor types', function () {
 
 it('creates a sensor for the route organization', function () {
     $organization = Organization::factory()->create();
-    $otherOrganization = Organization::factory()->create();
     $admin = User::factory()->organizationAdmin($organization)->create();
 
     $response = $this->actingAs($admin)->postJson(
         route('stage-safety.sensors.store', ['organization' => $organization]),
-        stageSafetySensorPayload(['organization_id' => $otherOrganization->id]),
+        stageSafetySensorPayload(),
     );
 
     $response->assertCreated()
@@ -102,6 +101,20 @@ it('creates a sensor for the route organization', function () {
         'organization_id' => $organization->id,
         'identifier' => 'FF1234',
     ]);
+});
+
+it('rejects a spoofed organization_id when creating a sensor', function () {
+    $organization = Organization::factory()->create();
+    $otherOrganization = Organization::factory()->create();
+    $admin = User::factory()->organizationAdmin($organization)->create();
+
+    $this->actingAs($admin)->postJson(
+        route('stage-safety.sensors.store', ['organization' => $organization]),
+        stageSafetySensorPayload(['organization_id' => $otherOrganization->id]),
+    )->assertUnprocessable()
+        ->assertJsonValidationErrors(['organization_id']);
+
+    $this->assertDatabaseMissing('stage_safety_sensors', ['identifier' => 'FF1234']);
 });
 
 it('updates and deletes an organization sensor', function () {

--- a/tests/Integration/Peoplecount/AreaSingleResetControllerTest.php
+++ b/tests/Integration/Peoplecount/AreaSingleResetControllerTest.php
@@ -52,7 +52,7 @@ it('can create an area single reset', function () {
     ]);
     $resetData = [
         'reset_value' => '50',
-        'effective_at' => '2025-07-27T15:00:00',
+        'effective_at' => '2025-07-27T15:00:00.000Z',
         'notes' => 'Manual reset for testing',
     ];
 

--- a/tests/Integration/Peoplecount/AssignmentControllerTest.php
+++ b/tests/Integration/Peoplecount/AssignmentControllerTest.php
@@ -70,8 +70,8 @@ it('can create an assignment for an organization', function () {
         'area_id' => (string) $area->id,
         'sensor_id' => (string) $sensor->id,
         'direction_flipped' => '0',
-        'active_from' => now()->subDays(2)->toDateTimeString(),
-        'active_to' => now()->addDays(2)->toDateTimeString(),
+        'active_from' => now()->subDays(2)->toIso8601ZuluString('millisecond'),
+        'active_to' => now()->addDays(2)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)
@@ -178,8 +178,8 @@ it('can update an assignment for an organization', function () {
             'area_id' => (string) $area->id,
             'sensor_id' => (string) $sensor->id,
             'direction_flipped' => '1',
-            'active_from' => now()->subDays(1)->toDateTimeString(),
-            'active_to' => now()->addDays(1)->toDateTimeString(),
+            'active_from' => now()->subDays(1)->toIso8601ZuluString('millisecond'),
+            'active_to' => now()->addDays(1)->toIso8601ZuluString('millisecond'),
         ]);
     $response->assertRedirect(route('peoplecount.assignments.index', ['organization' => $org->slug]));
     $this->assertDatabaseHas('peoplecount_assignments', [
@@ -217,8 +217,8 @@ it('does not update another organization assignment', function () {
             'area_id' => $area->id,
             'sensor_id' => $sensor->id,
             'direction_flipped' => true,
-            'active_from' => now()->subDay()->toDateTimeString(),
-            'active_to' => now()->addDay()->toDateTimeString(),
+            'active_from' => now()->subDay()->toIso8601ZuluString('millisecond'),
+            'active_to' => now()->addDay()->toIso8601ZuluString('millisecond'),
         ])
         ->assertNotFound();
 
@@ -300,6 +300,29 @@ it('does not show another organization assignment', function () {
         ->assertNotFound();
 });
 
+it('rejects non-ISO 8601 UTC datetimes when creating an assignment', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+    $event = Event::factory()->for($org, 'organization')->create([
+        'starts_at' => now()->subDays(5),
+        'ends_at' => now()->addDays(5),
+    ]);
+    $area = Area::factory()->for($event)->create();
+    $sensor = Sensor::factory()->for($org)->create();
+
+    $response = $this->actingAs($admin)
+        ->post(route('peoplecount.assignments.store', ['organization' => $org->slug]), [
+            'event_id' => (string) $event->id,
+            'area_id' => (string) $area->id,
+            'sensor_id' => (string) $sensor->id,
+            'direction_flipped' => '0',
+            'active_from' => now()->subDays(2)->toDateTimeString(),
+            'active_to' => now()->addDays(2)->toDateTimeString(),
+        ]);
+
+    $response->assertSessionHasErrors(['active_from', 'active_to']);
+});
+
 it('validates overlapping assignments on create', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
@@ -327,8 +350,8 @@ it('validates overlapping assignments on create', function () {
         'area_id' => $area->id,
         'sensor_id' => $sensor->id,
         'direction_flipped' => false,
-        'active_from' => now()->subDays(2)->toDateTimeString(),
-        'active_to' => now()->addDays(2)->toDateTimeString(),
+        'active_from' => now()->subDays(2)->toIso8601ZuluString('millisecond'),
+        'active_to' => now()->addDays(2)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)
@@ -353,8 +376,8 @@ it('validates assignment time within event time on create', function () {
         'area_id' => $area->id,
         'sensor_id' => $sensor->id,
         'direction_flipped' => false,
-        'active_from' => now()->subDays(2)->toDateTimeString(), // Before event starts
-        'active_to' => now()->addDays(2)->toDateTimeString(),
+        'active_from' => now()->subDays(2)->toIso8601ZuluString('millisecond'), // Before event starts
+        'active_to' => now()->addDays(2)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)
@@ -401,8 +424,8 @@ it('validates overlapping assignments on update', function () {
         'area_id' => $area->id,
         'sensor_id' => $sensor->id,
         'direction_flipped' => false,
-        'active_from' => now()->subDays(2)->toDateTimeString(), // Overlaps with first assignment
-        'active_to' => now()->addDays(2)->toDateTimeString(),
+        'active_from' => now()->subDays(2)->toIso8601ZuluString('millisecond'), // Overlaps with first assignment
+        'active_to' => now()->addDays(2)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)
@@ -436,8 +459,8 @@ it('validates assignment time within event time on update', function () {
         'area_id' => $area->id,
         'sensor_id' => $sensor->id,
         'direction_flipped' => false,
-        'active_from' => now()->subDays(2)->toDateTimeString(), // Before event starts
-        'active_to' => now()->addDays(2)->toDateTimeString(),
+        'active_from' => now()->subDays(2)->toIso8601ZuluString('millisecond'), // Before event starts
+        'active_to' => now()->addDays(2)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)

--- a/tests/Integration/Peoplecount/EventControllerTest.php
+++ b/tests/Integration/Peoplecount/EventControllerTest.php
@@ -81,6 +81,21 @@ it('rejects non-ISO 8601 UTC datetimes when creating an event', function () {
     $response->assertSessionHasErrors(['starts_at', 'ends_at']);
 });
 
+it('rejects unknown fields when creating an event', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+
+    $response = $this->actingAs($admin)
+        ->post(route('peoplecount.events.store', ['organization' => $org->slug]), [
+            'name' => 'Test Event',
+            'starts_at' => now()->toIso8601ZuluString('millisecond'),
+            'ends_at' => now()->addDays(3)->toIso8601ZuluString('millisecond'),
+            'unexpected_field' => 'nope',
+        ]);
+
+    $response->assertSessionHasErrors(['unexpected_field']);
+});
+
 it('shows the edit event form for an organization event', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();

--- a/tests/Integration/Peoplecount/EventControllerTest.php
+++ b/tests/Integration/Peoplecount/EventControllerTest.php
@@ -53,8 +53,8 @@ it('can create an event for an organization', function () {
     $org = Organization::factory()->create();
     $eventData = [
         'name' => 'Test Event',
-        'starts_at' => now()->format('Y-m-d H:i:s'),
-        'ends_at' => now()->addDays(3)->format('Y-m-d H:i:s'),
+        'starts_at' => now()->toIso8601ZuluString('millisecond'),
+        'ends_at' => now()->addDays(3)->toIso8601ZuluString('millisecond'),
     ];
 
     $response = $this->actingAs($admin)
@@ -65,6 +65,20 @@ it('can create an event for an organization', function () {
         'organization_id' => $org->id,
         'deleted_at' => null,
     ]);
+});
+
+it('rejects non-ISO 8601 UTC datetimes when creating an event', function () {
+    $admin = User::factory()->globalAdmin()->create();
+    $org = Organization::factory()->create();
+
+    $response = $this->actingAs($admin)
+        ->post(route('peoplecount.events.store', ['organization' => $org->slug]), [
+            'name' => 'Test Event',
+            'starts_at' => now()->format('Y-m-d H:i:s'),
+            'ends_at' => now()->addDays(3)->format('Y-m-d H:i:s'),
+        ]);
+
+    $response->assertSessionHasErrors(['starts_at', 'ends_at']);
 });
 
 it('shows the edit event form for an organization event', function () {
@@ -106,8 +120,8 @@ it('can update an event for an organization', function () {
     $response = $this->actingAs($admin)
         ->put(route('peoplecount.events.update', ['organization' => $org->slug, 'event' => $event->id]), [
             'name' => $newName,
-            'starts_at' => $event->starts_at,
-            'ends_at' => $event->ends_at,
+            'starts_at' => $event->starts_at->toIso8601ZuluString('millisecond'),
+            'ends_at' => $event->ends_at->toIso8601ZuluString('millisecond'),
         ]);
     $response->assertRedirect(route('peoplecount.events.index', ['organization' => $org->slug]));
     $this->assertDatabaseHas('peoplecount_events', [

--- a/tests/Integration/Peoplecount/PeoplecountAreaCountHistoryWidgetControllerTest.php
+++ b/tests/Integration/Peoplecount/PeoplecountAreaCountHistoryWidgetControllerTest.php
@@ -99,8 +99,8 @@ it('does not return data outside the requested range', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->subHour()->toIso8601String(),
-            'to' => Date::now()->toIso8601String(),
+            'from' => Date::now()->subHour()->toIso8601ZuluString('millisecond'),
+            'to' => Date::now()->toIso8601ZuluString('millisecond'),
         ]));
 
     $response->assertStatus(200)
@@ -218,6 +218,17 @@ it('rejects invalid date parameters', function () {
 
     $response->assertStatus(422)
         ->assertJsonValidationErrors(['from']);
+
+    // Naive datetime strings without UTC marker are rejected too
+    $response = $this->actingAs($admin)
+        ->getJson(route('peoplecount.area-count-history.index', [
+            'organization' => $org->slug,
+            'from' => '2025-08-04 21:08:00',
+            'to' => '2025-08-04 22:08:00',
+        ]));
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['from', 'to']);
 });
 
 it('rejects history ranges above maximum allowed duration', function () {
@@ -229,8 +240,8 @@ it('rejects history ranges above maximum allowed duration', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->subHours(25)->toIso8601String(),
-            'to' => Date::now()->toIso8601String(),
+            'from' => Date::now()->subHours(25)->toIso8601ZuluString('millisecond'),
+            'to' => Date::now()->toIso8601ZuluString('millisecond'),
         ]));
 
     $response->assertStatus(422)
@@ -248,8 +259,8 @@ it('rejects an inverted history range', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->toIso8601String(),
-            'to' => Date::now()->subHour()->toIso8601String(),
+            'from' => Date::now()->toIso8601ZuluString('millisecond'),
+            'to' => Date::now()->subHour()->toIso8601ZuluString('millisecond'),
         ]));
 
     $response->assertStatus(422)
@@ -294,8 +305,8 @@ it('allows history ranges at maximum allowed duration', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->subHours(24)->toIso8601String(),
-            'to' => Date::now()->toIso8601String(),
+            'from' => Date::now()->subHours(24)->toIso8601ZuluString('millisecond'),
+            'to' => Date::now()->toIso8601ZuluString('millisecond'),
         ]));
 
     $response->assertStatus(200);

--- a/tests/Integration/Peoplecount/SensorControllerTest.php
+++ b/tests/Integration/Peoplecount/SensorControllerTest.php
@@ -128,7 +128,7 @@ it('can update a sensor for an organization', function () {
     ]);
 });
 
-it('ignores unvalidated sensor update fields', function () {
+it('rejects unvalidated sensor update fields', function () {
     $admin = User::factory()->globalAdmin()->create();
     $org = Organization::factory()->create();
     $foreignOrg = Organization::factory()->create();
@@ -146,14 +146,11 @@ it('ignores unvalidated sensor update fields', function () {
             'api_token' => 'changed-token',
             'archived_at' => now()->toDateTimeString(),
         ])
-        ->assertRedirect(route('peoplecount.sensors.index', ['organization' => $org->slug]));
+        ->assertSessionHasErrors(['organization_id', 'api_token', 'archived_at']);
 
     $sensor->refresh();
 
-    expect($sensor->vendor)->toBe('UpdatedVendor')
-        ->and($sensor->model)->toBe('UpdatedModel')
-        ->and($sensor->serial)->toBe('UpdatedSerial')
-        ->and($sensor->organization_id)->toBe($org->id)
+    expect($sensor->organization_id)->toBe($org->id)
         ->and($sensor->api_token)->toBe('original-token')
         ->and($sensor->archived_at)->toBeNull();
 });

--- a/tests/Integration/Requests/Auth/LoginRequestTest.php
+++ b/tests/Integration/Requests/Auth/LoginRequestTest.php
@@ -13,11 +13,13 @@ covers(LoginRequest::class);
 function createLoginRequest(string $email, string $password, bool $remember = false, string $ip = '127.0.0.1'): LoginRequest
 {
     $request = new LoginRequest;
-    $request->merge([
+    $data = [
         'email' => $email,
         'password' => $password,
         'remember' => $remember,
-    ]);
+    ];
+    $request->merge($data);
+    $request->setValidator(validator($data, $request->rules()));
     $request->server->set('REMOTE_ADDR', $ip);
 
     return $request;
@@ -47,6 +49,7 @@ describe('basic functionality', function () {
         expect($request->rules())->toBe([
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string'],
+            'remember' => ['boolean'],
         ]);
     });
 

--- a/tests/Integration/Services/GlobalPermissionServiceTest.php
+++ b/tests/Integration/Services/GlobalPermissionServiceTest.php
@@ -188,7 +188,7 @@ describe('canGlobally', function () {
             ->andReturn(true);
 
         $result = GlobalPermissionService::canGlobally($user, 'any-ability');
-        expect($result)->not->not->toBeNull()->toBeTrue()->toBeFalse();
+        expect($result)->toBeTrue();
     });
 
     it('returns true when user has the specific global permission', function () {

--- a/tests/Integration/Services/Peoplecount/AreaServiceTest.php
+++ b/tests/Integration/Services/Peoplecount/AreaServiceTest.php
@@ -571,7 +571,8 @@ describe('checksum functionality', function () {
                 ->and($result)->toHaveKeys(['area', 'event', 'assignments', 'areaSingleResets', 'areaRecurringResets']);
             // Check area data
             // Check event data
-            expect($result)->toMatchArray(['area' => $event->id, 'event' => $event->id]);
+            expect($result['area'])->toMatchArray(['id' => $area->id, 'event_id' => $event->id])
+                ->and($result['event'])->toMatchArray(['id' => $event->id]);
 
             // Check collection data (should be empty arrays for new area)
             expect($result['assignments'])->toBeArray()

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -115,7 +115,7 @@ describe('getUsers', function () {
     })->with(
         [
             [GLOBAL_ORG_ID, 2],
-            [Str(GLOBAL_ORG_ID), 0], // String "0" should not match integer 0
+            [(string) GLOBAL_ORG_ID, 0], // String "0" should not match integer 0
         ]
     );
 

--- a/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
+++ b/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
@@ -113,13 +113,17 @@ it('rejects invalid history ranges', function (array $query, array $invalidField
         ->assertJsonValidationErrors($invalidFields);
 })->with([
     'longer than 24 hours' => [[
-        'from' => '2026-07-24T11:59:59Z',
-        'to' => '2026-07-25T12:00:00Z',
+        'from' => '2026-07-24T11:59:59.000Z',
+        'to' => '2026-07-25T12:00:00.000Z',
     ], ['to']],
     'reversed' => [[
-        'from' => '2026-07-25T12:00:00Z',
-        'to' => '2026-07-25T11:00:00Z',
+        'from' => '2026-07-25T12:00:00.000Z',
+        'to' => '2026-07-25T11:00:00.000Z',
     ], ['from', 'to']],
+    'not iso 8601 utc' => [[
+        'from' => '2026-07-24 11:59:59',
+        'to' => '2026-07-25T12:00:00.000Z',
+    ], ['from']],
 ]);
 
 it('uses monitoring form requests and organization middleware', function () {

--- a/tests/Unit/Models/Peoplecount/AreaRecurringResetTest.php
+++ b/tests/Unit/Models/Peoplecount/AreaRecurringResetTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 
 covers(AreaRecurringReset::class);
 
@@ -55,7 +56,7 @@ it('belongs to an area', function () {
 
 it('gets next daily occurrence', function () {
     // Freeze time at 06:00 UTC (07:00 in Europe/Zurich during standard time)
-    Carbon::setTestNow('2024-01-15 06:00:00');
+    Date::setTestNow('2024-01-15 06:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -67,12 +68,12 @@ it('gets next daily occurrence', function () {
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since 08:00 hasn't passed yet
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets next daily occurrence for tomorrow if time has passed today', function () {
     // Freeze time at 10:30 UTC - well after midnight, so next occurrence should be tomorrow
-    Carbon::setTestNow('2024-01-15 10:30:00');
+    Date::setTestNow('2024-01-15 10:30:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '00:00'; // Midnight - already passed today
@@ -84,12 +85,12 @@ it('gets next daily occurrence for tomorrow if time has passed today', function 
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow since midnight has passed
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets previous daily occurrence', function () {
     // Freeze time at 10:00 UTC (11:00 in Europe/Zurich during standard time) - after 08:00 reset time
-    Carbon::setTestNow('2024-01-15 10:00:00');
+    Date::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -100,15 +101,15 @@ it('gets previous daily occurrence', function () {
     expect($previousOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($previousOccurrence->format('H:i'))->toBe('07:00') // Time in UTC (08:00 in Europe/Zurich)
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-15') // Should be today since 08:00 has already passed
-        ->and($previousOccurrence->isBefore(Carbon::parse('2024-01-15 10:00:00', 'Europe/Zurich')))->toBeTrue();
+        ->and($previousOccurrence->isBefore(Date::parse('2024-01-15 10:00:00', 'Europe/Zurich')))->toBeTrue();
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets previous daily occurrence for yesterday if time has not yet occurred today', function () {
     // Freeze time at 10:30 UTC - well before 23:59, so previous occurrence should be yesterday
-    Carbon::setTestNow('2024-01-15 10:30:00');
+    Date::setTestNow('2024-01-15 10:30:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '23:59'; // Late time, has not yet occurred today
@@ -119,15 +120,15 @@ it('gets previous daily occurrence for yesterday if time has not yet occurred to
     expect($previousOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($previousOccurrence->format('H:i'))->toBe('23:59')
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-14') // Should be yesterday since 23:59 hasn't occurred today
-        ->and($previousOccurrence->isBefore(Carbon::parse('2024-01-15 10:30:00', 'UTC')))->toBeTrue();
+        ->and($previousOccurrence->isBefore(Date::parse('2024-01-15 10:30:00', 'UTC')))->toBeTrue();
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('handles different timezones for next daily occurrence', function () {
     // Freeze time at 10:00 UTC (06:00 in America/New_York during standard time) - before 14:30 reset time
-    Carbon::setTestNow('2024-01-15 10:00:00');
+    Date::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '14:30';
@@ -140,12 +141,12 @@ it('handles different timezones for next daily occurrence', function () {
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since 14:30 hasn't passed yet in NY timezone
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets next daily occurrence when current time equals reset time', function () {
     // Freeze time at exactly 08:00 UTC - same as reset time
-    Carbon::setTestNow('2024-01-15 08:00:00');
+    Date::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -157,12 +158,12 @@ it('gets next daily occurrence when current time equals reset time', function ()
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow since current time >= reset time
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets previous daily occurrence when current time equals reset time', function () {
     // Freeze time at exactly 08:00 UTC - same as reset time
-    Carbon::setTestNow('2024-01-15 08:00:00');
+    Date::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -174,27 +175,27 @@ it('gets previous daily occurrence when current time equals reset time', functio
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since current time is not < reset time
 
     // Reset time mocking
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets next daily occurrence with while loop when reset time is before provided datetime', function () {
     // This test covers line 70 - the while loop in getNextDailyOccurrence
     // Create a scenario where the reset time needs to be advanced multiple times
-    Carbon::setTestNow('2024-01-15 10:00:00');
+    Date::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
     $model->timezone = 'UTC';
 
     // Pass a datetime that's after today's reset time but before tomorrow's
-    $fromTime = Carbon::parse('2024-01-15 09:00:00', 'UTC');
+    $fromTime = Date::parse('2024-01-15 09:00:00', 'UTC');
 
     $nextOccurrence = $model->getNextDailyOccurrence($fromTime);
     expect($nextOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($nextOccurrence->format('H:i'))->toBe('08:00')
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow
 
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('gets occurrences between two dates', function () {
@@ -202,15 +203,15 @@ it('gets occurrences between two dates', function () {
     $model->reset_time = '12:00:00';
     $model->timezone = 'UTC';
 
-    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Carbon::parse('2024-01-17 14:00:00', 'UTC');
+    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Date::parse('2024-01-17 14:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
     $expectedOccurrences = [
-        Carbon::parse('2024-01-15 12:00:00', 'UTC'),
-        Carbon::parse('2024-01-16 12:00:00', 'UTC'),
-        Carbon::parse('2024-01-17 12:00:00', 'UTC'),
+        Date::parse('2024-01-15 12:00:00', 'UTC'),
+        Date::parse('2024-01-16 12:00:00', 'UTC'),
+        Date::parse('2024-01-17 12:00:00', 'UTC'),
     ];
 
     expect($occurrences)->toBeArray()
@@ -223,16 +224,16 @@ it('gets occurrences between two dates in different timezones', function () {
     $model->reset_time = '15:30:00';
     $model->timezone = 'Europe/Zurich';
 
-    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Carbon::parse('2024-01-17 19:00:00', 'UTC');
+    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Date::parse('2024-01-17 19:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
     // Convert expected occurrences to UTC for comparison
     $expectedOccurrences = [
-        Carbon::parse('2024-01-15 14:30:00', 'UTC'),
-        Carbon::parse('2024-01-16 14:30:00', 'UTC'),
-        Carbon::parse('2024-01-17 14:30:00', 'UTC'),
+        Date::parse('2024-01-15 14:30:00', 'UTC'),
+        Date::parse('2024-01-16 14:30:00', 'UTC'),
+        Date::parse('2024-01-17 14:30:00', 'UTC'),
     ];
 
     expect($occurrences)->toBeArray()
@@ -246,8 +247,8 @@ it('gets occurrences between dates with single occurrence', function () {
     $model->reset_time = '15:30';
     $model->timezone = 'UTC';
 
-    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Carbon::parse('2024-01-15 20:00:00', 'UTC');
+    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Date::parse('2024-01-15 20:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -260,14 +261,14 @@ it('gets occurrences between dates with single occurrence', function () {
 
 it('gets previous daily occurrence with explicit Carbon parameter', function () {
     // This test covers the $from instanceof Carbon branch in getPreviousDailyOccurrence
-    Carbon::setTestNow('2024-01-15 10:00:00');
+    Date::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
     $model->timezone = 'UTC';
 
     // Create an explicit Carbon instance to pass as parameter
-    $explicitTime = Carbon::parse('2024-01-15 07:00:00', 'UTC');
+    $explicitTime = Date::parse('2024-01-15 07:00:00', 'UTC');
 
     $previousOccurrence = $model->getPreviousDailyOccurrence($explicitTime);
 
@@ -276,7 +277,7 @@ it('gets previous daily occurrence with explicit Carbon parameter', function () 
         ->and($previousOccurrence->format('H:i'))->toBe('08:00')
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-14');
 
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('verifies date part is correctly set in previous daily occurrence', function () {
@@ -284,7 +285,7 @@ it('verifies date part is correctly set in previous daily occurrence', function 
     // We'll use a specific date that's different from the default to ensure the setDate method is working
 
     // Create a mock Carbon instance for testing
-    $mockNow = Carbon::parse('2023-12-25 10:00:00', 'UTC'); // Christmas day
+    $mockNow = Date::parse('2023-12-25 10:00:00', 'UTC'); // Christmas day
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -302,7 +303,7 @@ it('verifies date part is correctly set in previous daily occurrence', function 
         ->and($previousOccurrence->day)->toBe($mockNow->day);
 
     // Now test with a time before the reset time
-    $mockNow = Carbon::parse('2023-12-25 07:00:00', 'UTC'); // Christmas day, before reset
+    $mockNow = Date::parse('2023-12-25 07:00:00', 'UTC'); // Christmas day, before reset
 
     // Call the method with our mock date
     $previousOccurrence = $model->getPreviousDailyOccurrence($mockNow);
@@ -318,15 +319,15 @@ it('verifies date part is correctly set in previous daily occurrence', function 
 
 it('verifies occurrences are only added if within range', function () {
     // This test verifies that occurrences are only added if they are within the range
-    Carbon::setTestNow('2024-01-15 08:00:00');
+    Date::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '12:00';
     $model->timezone = 'UTC';
 
     // Test with a next occurrence that's outside the range
-    $start = Carbon::parse('2024-01-16 13:00:00', 'UTC'); // After the reset time on Jan 16
-    $end = Carbon::parse('2024-01-17 11:00:00', 'UTC');   // Before the reset time on Jan 17
+    $start = Date::parse('2024-01-16 13:00:00', 'UTC'); // After the reset time on Jan 16
+    $end = Date::parse('2024-01-17 11:00:00', 'UTC');   // Before the reset time on Jan 17
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -336,8 +337,8 @@ it('verifies occurrences are only added if within range', function () {
         ->and($occurrences)->toBeEmpty();
 
     // Now test with a range that includes exactly one occurrence
-    $start = Carbon::parse('2024-01-16 10:00:00', 'UTC'); // Before the reset time on Jan 16
-    $end = Carbon::parse('2024-01-16 14:00:00', 'UTC');   // After the reset time on Jan 16
+    $start = Date::parse('2024-01-16 10:00:00', 'UTC'); // Before the reset time on Jan 16
+    $end = Date::parse('2024-01-16 14:00:00', 'UTC');   // After the reset time on Jan 16
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -345,7 +346,7 @@ it('verifies occurrences are only added if within range', function () {
         ->and($occurrences)->toHaveCount(1)
         ->and($occurrences[0]->format('Y-m-d H:i'))->toBe('2024-01-16 12:00');
 
-    Carbon::setTestNow();
+    Date::setTestNow();
 });
 
 it('has factory', function () {
@@ -361,7 +362,7 @@ it('throws on invalid timezone when getting next daily occurrence', function () 
 });
 
 it('does not modify the provided $from Carbon instance and returns UTC timezone', function () {
-    $from = Carbon::parse('2024-01-15 23:30:00', 'UTC');
+    $from = Date::parse('2024-01-15 23:30:00', 'UTC');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -381,8 +382,8 @@ it('includes occurrences equal to start and end boundaries', function () {
     $model->reset_time = '12:00';
     $model->timezone = 'UTC';
 
-    $start = Carbon::parse('2024-01-15 12:00:00', 'UTC');
-    $end = Carbon::parse('2024-01-16 12:00:00', 'UTC');
+    $start = Date::parse('2024-01-15 12:00:00', 'UTC');
+    $end = Date::parse('2024-01-16 12:00:00', 'UTC');
 
     $occ = $model->getOccurrencesBetween($start, $end);
 
@@ -400,8 +401,8 @@ it('returns strictly increasing daily occurrences without duplicates across DST 
     $model->timezone = 'Europe/Zurich';
 
     // Window that spans the EU spring DST transition in 2024 (2024-03-31)
-    $start = Carbon::parse('2024-03-29 00:00:00', 'UTC');
-    $end = Carbon::parse('2024-04-03 23:59:59', 'UTC');
+    $start = Date::parse('2024-03-29 00:00:00', 'UTC');
+    $end = Date::parse('2024-04-03 23:59:59', 'UTC');
 
     $occ = $model->getOccurrencesBetween($start, $end);
 

--- a/tests/Unit/Models/Peoplecount/AreaRecurringResetTest.php
+++ b/tests/Unit/Models/Peoplecount/AreaRecurringResetTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
 
 covers(AreaRecurringReset::class);
 
@@ -56,7 +55,7 @@ it('belongs to an area', function () {
 
 it('gets next daily occurrence', function () {
     // Freeze time at 06:00 UTC (07:00 in Europe/Zurich during standard time)
-    Date::setTestNow('2024-01-15 06:00:00');
+    Carbon::setTestNow('2024-01-15 06:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -68,12 +67,12 @@ it('gets next daily occurrence', function () {
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since 08:00 hasn't passed yet
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets next daily occurrence for tomorrow if time has passed today', function () {
     // Freeze time at 10:30 UTC - well after midnight, so next occurrence should be tomorrow
-    Date::setTestNow('2024-01-15 10:30:00');
+    Carbon::setTestNow('2024-01-15 10:30:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '00:00'; // Midnight - already passed today
@@ -85,12 +84,12 @@ it('gets next daily occurrence for tomorrow if time has passed today', function 
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow since midnight has passed
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets previous daily occurrence', function () {
     // Freeze time at 10:00 UTC (11:00 in Europe/Zurich during standard time) - after 08:00 reset time
-    Date::setTestNow('2024-01-15 10:00:00');
+    Carbon::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -101,15 +100,15 @@ it('gets previous daily occurrence', function () {
     expect($previousOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($previousOccurrence->format('H:i'))->toBe('07:00') // Time in UTC (08:00 in Europe/Zurich)
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-15') // Should be today since 08:00 has already passed
-        ->and($previousOccurrence->isBefore(Date::parse('2024-01-15 10:00:00', 'Europe/Zurich')))->toBeTrue();
+        ->and($previousOccurrence->isBefore(Carbon::parse('2024-01-15 10:00:00', 'Europe/Zurich')))->toBeTrue();
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets previous daily occurrence for yesterday if time has not yet occurred today', function () {
     // Freeze time at 10:30 UTC - well before 23:59, so previous occurrence should be yesterday
-    Date::setTestNow('2024-01-15 10:30:00');
+    Carbon::setTestNow('2024-01-15 10:30:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '23:59'; // Late time, has not yet occurred today
@@ -120,15 +119,15 @@ it('gets previous daily occurrence for yesterday if time has not yet occurred to
     expect($previousOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($previousOccurrence->format('H:i'))->toBe('23:59')
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-14') // Should be yesterday since 23:59 hasn't occurred today
-        ->and($previousOccurrence->isBefore(Date::parse('2024-01-15 10:30:00', 'UTC')))->toBeTrue();
+        ->and($previousOccurrence->isBefore(Carbon::parse('2024-01-15 10:30:00', 'UTC')))->toBeTrue();
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('handles different timezones for next daily occurrence', function () {
     // Freeze time at 10:00 UTC (06:00 in America/New_York during standard time) - before 14:30 reset time
-    Date::setTestNow('2024-01-15 10:00:00');
+    Carbon::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '14:30';
@@ -141,12 +140,12 @@ it('handles different timezones for next daily occurrence', function () {
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since 14:30 hasn't passed yet in NY timezone
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets next daily occurrence when current time equals reset time', function () {
     // Freeze time at exactly 08:00 UTC - same as reset time
-    Date::setTestNow('2024-01-15 08:00:00');
+    Carbon::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -158,12 +157,12 @@ it('gets next daily occurrence when current time equals reset time', function ()
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow since current time >= reset time
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets previous daily occurrence when current time equals reset time', function () {
     // Freeze time at exactly 08:00 UTC - same as reset time
-    Date::setTestNow('2024-01-15 08:00:00');
+    Carbon::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -175,27 +174,27 @@ it('gets previous daily occurrence when current time equals reset time', functio
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-15'); // Should be today since current time is not < reset time
 
     // Reset time mocking
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets next daily occurrence with while loop when reset time is before provided datetime', function () {
     // This test covers line 70 - the while loop in getNextDailyOccurrence
     // Create a scenario where the reset time needs to be advanced multiple times
-    Date::setTestNow('2024-01-15 10:00:00');
+    Carbon::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
     $model->timezone = 'UTC';
 
     // Pass a datetime that's after today's reset time but before tomorrow's
-    $fromTime = Date::parse('2024-01-15 09:00:00', 'UTC');
+    $fromTime = Carbon::parse('2024-01-15 09:00:00', 'UTC');
 
     $nextOccurrence = $model->getNextDailyOccurrence($fromTime);
     expect($nextOccurrence)->toBeInstanceOf(Carbon::class)
         ->and($nextOccurrence->format('H:i'))->toBe('08:00')
         ->and($nextOccurrence->format('Y-m-d'))->toBe('2024-01-16'); // Should be tomorrow
 
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('gets occurrences between two dates', function () {
@@ -203,15 +202,15 @@ it('gets occurrences between two dates', function () {
     $model->reset_time = '12:00:00';
     $model->timezone = 'UTC';
 
-    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Date::parse('2024-01-17 14:00:00', 'UTC');
+    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Carbon::parse('2024-01-17 14:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
     $expectedOccurrences = [
-        Date::parse('2024-01-15 12:00:00', 'UTC'),
-        Date::parse('2024-01-16 12:00:00', 'UTC'),
-        Date::parse('2024-01-17 12:00:00', 'UTC'),
+        Carbon::parse('2024-01-15 12:00:00', 'UTC'),
+        Carbon::parse('2024-01-16 12:00:00', 'UTC'),
+        Carbon::parse('2024-01-17 12:00:00', 'UTC'),
     ];
 
     expect($occurrences)->toBeArray()
@@ -224,16 +223,16 @@ it('gets occurrences between two dates in different timezones', function () {
     $model->reset_time = '15:30:00';
     $model->timezone = 'Europe/Zurich';
 
-    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Date::parse('2024-01-17 19:00:00', 'UTC');
+    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Carbon::parse('2024-01-17 19:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
     // Convert expected occurrences to UTC for comparison
     $expectedOccurrences = [
-        Date::parse('2024-01-15 14:30:00', 'UTC'),
-        Date::parse('2024-01-16 14:30:00', 'UTC'),
-        Date::parse('2024-01-17 14:30:00', 'UTC'),
+        Carbon::parse('2024-01-15 14:30:00', 'UTC'),
+        Carbon::parse('2024-01-16 14:30:00', 'UTC'),
+        Carbon::parse('2024-01-17 14:30:00', 'UTC'),
     ];
 
     expect($occurrences)->toBeArray()
@@ -247,8 +246,8 @@ it('gets occurrences between dates with single occurrence', function () {
     $model->reset_time = '15:30';
     $model->timezone = 'UTC';
 
-    $start = Date::parse('2024-01-15 10:00:00', 'UTC');
-    $end = Date::parse('2024-01-15 20:00:00', 'UTC');
+    $start = Carbon::parse('2024-01-15 10:00:00', 'UTC');
+    $end = Carbon::parse('2024-01-15 20:00:00', 'UTC');
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -261,14 +260,14 @@ it('gets occurrences between dates with single occurrence', function () {
 
 it('gets previous daily occurrence with explicit Carbon parameter', function () {
     // This test covers the $from instanceof Carbon branch in getPreviousDailyOccurrence
-    Date::setTestNow('2024-01-15 10:00:00');
+    Carbon::setTestNow('2024-01-15 10:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
     $model->timezone = 'UTC';
 
     // Create an explicit Carbon instance to pass as parameter
-    $explicitTime = Date::parse('2024-01-15 07:00:00', 'UTC');
+    $explicitTime = Carbon::parse('2024-01-15 07:00:00', 'UTC');
 
     $previousOccurrence = $model->getPreviousDailyOccurrence($explicitTime);
 
@@ -277,7 +276,7 @@ it('gets previous daily occurrence with explicit Carbon parameter', function () 
         ->and($previousOccurrence->format('H:i'))->toBe('08:00')
         ->and($previousOccurrence->format('Y-m-d'))->toBe('2024-01-14');
 
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('verifies date part is correctly set in previous daily occurrence', function () {
@@ -285,7 +284,7 @@ it('verifies date part is correctly set in previous daily occurrence', function 
     // We'll use a specific date that's different from the default to ensure the setDate method is working
 
     // Create a mock Carbon instance for testing
-    $mockNow = Date::parse('2023-12-25 10:00:00', 'UTC'); // Christmas day
+    $mockNow = Carbon::parse('2023-12-25 10:00:00', 'UTC'); // Christmas day
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -303,7 +302,7 @@ it('verifies date part is correctly set in previous daily occurrence', function 
         ->and($previousOccurrence->day)->toBe($mockNow->day);
 
     // Now test with a time before the reset time
-    $mockNow = Date::parse('2023-12-25 07:00:00', 'UTC'); // Christmas day, before reset
+    $mockNow = Carbon::parse('2023-12-25 07:00:00', 'UTC'); // Christmas day, before reset
 
     // Call the method with our mock date
     $previousOccurrence = $model->getPreviousDailyOccurrence($mockNow);
@@ -319,15 +318,15 @@ it('verifies date part is correctly set in previous daily occurrence', function 
 
 it('verifies occurrences are only added if within range', function () {
     // This test verifies that occurrences are only added if they are within the range
-    Date::setTestNow('2024-01-15 08:00:00');
+    Carbon::setTestNow('2024-01-15 08:00:00');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '12:00';
     $model->timezone = 'UTC';
 
     // Test with a next occurrence that's outside the range
-    $start = Date::parse('2024-01-16 13:00:00', 'UTC'); // After the reset time on Jan 16
-    $end = Date::parse('2024-01-17 11:00:00', 'UTC');   // Before the reset time on Jan 17
+    $start = Carbon::parse('2024-01-16 13:00:00', 'UTC'); // After the reset time on Jan 16
+    $end = Carbon::parse('2024-01-17 11:00:00', 'UTC');   // Before the reset time on Jan 17
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -337,8 +336,8 @@ it('verifies occurrences are only added if within range', function () {
         ->and($occurrences)->toBeEmpty();
 
     // Now test with a range that includes exactly one occurrence
-    $start = Date::parse('2024-01-16 10:00:00', 'UTC'); // Before the reset time on Jan 16
-    $end = Date::parse('2024-01-16 14:00:00', 'UTC');   // After the reset time on Jan 16
+    $start = Carbon::parse('2024-01-16 10:00:00', 'UTC'); // Before the reset time on Jan 16
+    $end = Carbon::parse('2024-01-16 14:00:00', 'UTC');   // After the reset time on Jan 16
 
     $occurrences = $model->getOccurrencesBetween($start, $end);
 
@@ -346,7 +345,7 @@ it('verifies occurrences are only added if within range', function () {
         ->and($occurrences)->toHaveCount(1)
         ->and($occurrences[0]->format('Y-m-d H:i'))->toBe('2024-01-16 12:00');
 
-    Date::setTestNow();
+    Carbon::setTestNow();
 });
 
 it('has factory', function () {
@@ -362,7 +361,7 @@ it('throws on invalid timezone when getting next daily occurrence', function () 
 });
 
 it('does not modify the provided $from Carbon instance and returns UTC timezone', function () {
-    $from = Date::parse('2024-01-15 23:30:00', 'UTC');
+    $from = Carbon::parse('2024-01-15 23:30:00', 'UTC');
 
     $model = new AreaRecurringReset;
     $model->reset_time = '08:00';
@@ -382,8 +381,8 @@ it('includes occurrences equal to start and end boundaries', function () {
     $model->reset_time = '12:00';
     $model->timezone = 'UTC';
 
-    $start = Date::parse('2024-01-15 12:00:00', 'UTC');
-    $end = Date::parse('2024-01-16 12:00:00', 'UTC');
+    $start = Carbon::parse('2024-01-15 12:00:00', 'UTC');
+    $end = Carbon::parse('2024-01-16 12:00:00', 'UTC');
 
     $occ = $model->getOccurrencesBetween($start, $end);
 
@@ -401,8 +400,8 @@ it('returns strictly increasing daily occurrences without duplicates across DST 
     $model->timezone = 'Europe/Zurich';
 
     // Window that spans the EU spring DST transition in 2024 (2024-03-31)
-    $start = Date::parse('2024-03-29 00:00:00', 'UTC');
-    $end = Date::parse('2024-04-03 23:59:59', 'UTC');
+    $start = Carbon::parse('2024-03-29 00:00:00', 'UTC');
+    $end = Carbon::parse('2024-04-03 23:59:59', 'UTC');
 
     $occ = $model->getOccurrencesBetween($start, $end);
 

--- a/tests/Unit/Requests/Peoplecount/AreaCountHistoryIndexRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/AreaCountHistoryIndexRequestTest.php
@@ -11,8 +11,8 @@ beforeEach(function () {
 
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
-        'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
-        'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+        'from' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:to', 'before_or_equal:to'],
+        'to' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:from', 'after_or_equal:from'],
     ]);
 });
 

--- a/tests/Unit/Requests/Peoplecount/AreaSingleResetStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/AreaSingleResetStoreRequestTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
         'reset_value' => ['required', 'integer', 'min:0'],
-        'effective_at' => ['required', 'date'],
+        'effective_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
         'notes' => ['nullable', 'string', 'max:1000'],
     ]);
 });

--- a/tests/Unit/Requests/Peoplecount/AssignmentStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/AssignmentStoreRequestTest.php
@@ -24,8 +24,8 @@ it('has correct rules', function () {
         ->and($rules['sensor_id'])->toBe(['required', 'integer', 'exists:peoplecount_sensors,id'])
         ->and($rules['label'])->toBe(['nullable', 'string', 'max:255'])
         ->and($rules['direction_flipped'])->toBe(['required', 'boolean'])
-        ->and($rules['active_from'])->toBe(['required', 'date', 'before:active_to'])
-        ->and($rules['active_to'])->toBe(['required', 'date', 'after:active_from']);
+        ->and($rules['active_from'])->toBe(['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:active_to'])
+        ->and($rules['active_to'])->toBe(['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:active_from']);
 
 });
 

--- a/tests/Unit/Requests/Peoplecount/AssignmentUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/AssignmentUpdateRequestTest.php
@@ -24,8 +24,8 @@ it('has correct rules', function () {
         ->and($rules['sensor_id'])->toBe(['required', 'integer', 'exists:peoplecount_sensors,id'])
         ->and($rules['label'])->toBe(['nullable', 'string', 'max:255'])
         ->and($rules['direction_flipped'])->toBe(['required', 'boolean'])
-        ->and($rules['active_from'])->toBe(['required', 'date', 'before:active_to'])
-        ->and($rules['active_to'])->toBe(['required', 'date', 'after:active_from']);
+        ->and($rules['active_from'])->toBe(['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:active_to'])
+        ->and($rules['active_to'])->toBe(['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:active_from']);
 
     // The direction_flipped field uses a boolean validation rule to ensure the value is true or false
 

--- a/tests/Unit/Requests/Peoplecount/EventStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/EventStoreRequestTest.php
@@ -12,8 +12,8 @@ beforeEach(function () {
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
         'name' => ['required', 'string', 'max:255'],
-        'starts_at' => ['required', 'date'],
-        'ends_at' => ['required', 'date', 'after:starts_at'],
+        'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
+        'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
     ]);
 });
 

--- a/tests/Unit/Requests/Peoplecount/EventUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/EventUpdateRequestTest.php
@@ -12,8 +12,8 @@ beforeEach(function () {
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
         'name' => ['required', 'string', 'max:255'],
-        'starts_at' => ['required', 'date'],
-        'ends_at' => ['required', 'date', 'after:starts_at'],
+        'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z'],
+        'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
     ]);
 });
 

--- a/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareStoreRequestTest.php
@@ -12,8 +12,8 @@ beforeEach(function () {
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
         'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
-        'starts_at' => ['required', 'date', 'before:ends_at'],
-        'ends_at' => ['required', 'date', 'after:starts_at'],
+        'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:ends_at'],
+        'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
     ]);
 });
 

--- a/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
+++ b/tests/Unit/Requests/Peoplecount/SensorShareUpdateRequestTest.php
@@ -12,8 +12,8 @@ beforeEach(function () {
 it('has correct rules', function () {
     expect($this->request->rules())->toBe([
         'borrower_organization_id' => ['required', 'integer', 'exists:organizations,id'],
-        'starts_at' => ['required', 'date', 'before:ends_at'],
-        'ends_at' => ['required', 'date', 'after:starts_at'],
+        'starts_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'before:ends_at'],
+        'ends_at' => ['required', 'date_format:Y-m-d\TH:i:s.v\Z', 'after:starts_at'],
     ]);
 });
 

--- a/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
@@ -9,8 +9,8 @@ it('defines paired bounded history inputs', function () {
     $request = new HistoryIndexRequest;
 
     expect($request->rules())->toBe([
-        'from' => ['nullable', 'date', 'required_with:to', 'before_or_equal:to'],
-        'to' => ['nullable', 'date', 'required_with:from', 'after_or_equal:from'],
+        'from' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:to', 'before_or_equal:to'],
+        'to' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:from', 'after_or_equal:from'],
     ])->and($request->after())->toHaveCount(1)
         ->and(HistoryIndexRequest::MAX_RANGE_HOURS)->toBe(24);
 });


### PR DESCRIPTION
Makes recurring-reset previews timezone-correct, locks datetime payloads to the frontend UTC format, rejects unknown FormRequest fields, and removes redundant concrete service singletons. Also repairs four pre-existing failing tests and makes coverage runs deterministic by disabling TIA replay for coverage.

## Notes

- Datetime API inputs now require `Date.prototype.toISOString()` output (`YYYY-MM-DDTHH:mm:ss.sssZ`).
- Interval-count vendor payloads remain an intentional plain-Request exception because that contract allows additional properties.

## Reviewer Setup

Frontend form payloads changed for strict validation. Build assets after pulling:

```sh
npm run build
```

- Fixes #113
- Fixes #114
- Fixes #115
- Fixes #131

---
**«Act only according to that maxim whereby you can, at the same time, will that it should become a universal law.»**
_Immanuel Kant_