### PR TITLE
Feat/chart statistics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,6 +118,13 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
+
 === tests rules ===
 
 # Test Enforcement

--- a/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/Peoplecount/AreaCountHistoryIndexRequest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Date;
 
 class AreaCountHistoryIndexRequest extends FormRequest
 {
-    public const int MAX_RANGE_HOURS = 24;
+    public const int MAX_RANGE_HOURS = 25;
 
     public function authorize(): bool
     {

--- a/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
+++ b/app/Http/Requests/Widgets/StageSafety/HistoryIndexRequest.php
@@ -12,7 +12,7 @@ use Illuminate\Validation\Validator;
 
 class HistoryIndexRequest extends FormRequest
 {
-    public const int MAX_RANGE_HOURS = 24;
+    public const int MAX_RANGE_HOURS = 25;
 
     /**
      * Determine if the user is authorized to make this request.

--- a/composer.lock
+++ b/composer.lock
@@ -2100,16 +2100,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
                 "shasum": ""
             },
             "require": {
@@ -2146,7 +2146,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -2203,7 +2203,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-03T13:42:31+00:00"
         },
         {
             "name": "league/config",

--- a/peck.json
+++ b/peck.json
@@ -50,7 +50,8 @@
             "wss",
             "lqi",
             "rssi",
-            "dbm"
+            "dbm",
+            "devtools"
         ],
         "paths": []
     }

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -2,14 +2,22 @@
 import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, componentToString, type ChartConfig } from '@/components/ui/chart';
 import { Skeleton } from '@/components/ui/skeleton';
 import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
+import WidgetHistoryControls from '@/components/widgets/WidgetHistoryControls.vue';
 import WidgetShell from '@/components/widgets/WidgetShell.vue';
-import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
-import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import {
+    calculateWidgetChartStatistics,
+    WIDGET_CHART_COLORS,
+    WIDGET_TIME_RANGE_MINUTES,
+    type WidgetChartSeries,
+    type WidgetChartStatistics,
+    type WidgetChartValue,
+    type WidgetTimeRange,
+} from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import { APP_LOCALE } from '@/utils/dateTimeHelpers';
-import { CurveType } from '@unovis/ts';
-import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position } from '@unovis/ts';
+import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Users } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
@@ -31,11 +39,17 @@ interface ChartDataPoint {
     [key: `area_${number}`]: number | null | undefined;
 }
 
+interface StatisticMarker extends WidgetChartValue {
+    label: string;
+    position: Position;
+}
+
 const props = defineProps<{
     organization: { id: number; slug: string; name: string };
 }>();
 
 const timeRange = ref<WidgetTimeRange>('1h');
+const statisticsEnabled = ref(false);
 const request = useHttp<{ from: string; to: string }, AreaSeries[]>({ from: '', to: '' });
 const {
     data: series,
@@ -87,9 +101,36 @@ const chartData = computed<ChartDataPoint[]>(() => {
 
     return Array.from(buckets.values()).sort((left, right) => left.date.getTime() - right.date.getTime());
 });
+const statistics = computed<Record<string, WidgetChartStatistics | null>>(() =>
+    Object.fromEntries(
+        (series.value ?? []).map((area) => [
+            `area_${area.id}`,
+            calculateWidgetChartStatistics(area.data.map((point) => ({ date: new Date(point.time), value: point.count }))),
+        ]),
+    ),
+);
 const hasData = computed(() => chartData.value.length > 0);
 const latestDataAt = computed(() => chartData.value.at(-1)?.date ?? null);
 const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
+const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
+const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
+const countFormatter = new Intl.NumberFormat(APP_LOCALE, { maximumFractionDigits: 1 });
+const statisticMarkers = computed<StatisticMarker[]>(() => {
+    const summary = focusedStatistics.value;
+
+    if (!summary) {
+        return [];
+    }
+
+    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
+        return [{ ...summary.minimum, label: `Min / max ${formatCount(summary.minimum.value)}`, position: Position.Top }];
+    }
+
+    return [
+        { ...summary.minimum, label: `Min ${formatCount(summary.minimum.value)}`, position: Position.Top },
+        { ...summary.maximum, label: `Max ${formatCount(summary.maximum.value)}`, position: Position.Bottom },
+    ];
+});
 
 function seriesValue(point: ChartDataPoint, key: string): number | undefined {
     const value = point[key as `area_${number}`];
@@ -97,7 +138,15 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
+    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+        return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+    }
+
     return new Date(value).toLocaleTimeString(APP_LOCALE, { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatCount(value: number): string {
+    return countFormatter.format(value);
 }
 
 watch(timeRange, refresh);
@@ -106,7 +155,9 @@ watch(timeRange, refresh);
 <template>
     <WidgetShell title="Area Count History" :error="error" :last-updated="latestDataAt" span="full">
         <template #icon><Users /></template>
-        <template #actions><WidgetTimeRangeSelect v-model="timeRange" /></template>
+        <template #actions>
+            <WidgetHistoryControls v-model:time-range="timeRange" v-model:statistics-enabled="statisticsEnabled" />
+        </template>
 
         <div v-if="loading && !hasData" class="flex h-[280px] items-center justify-center sm:h-[350px]">
             <Skeleton class="h-full w-full" />
@@ -120,8 +171,13 @@ watch(timeRange, refresh);
             <p class="sr-only" aria-live="polite">
                 Area count history chart with {{ chartSeries.length }} series across {{ series?.length ?? 0 }} areas.
             </p>
-            <ChartContainer :config="chartConfig" class="h-[280px] w-full min-w-0 sm:h-[350px]" role="img" aria-label="Area count history">
-                <VisXYContainer :data="chartData" :margin="{ top: 8, right: 8, bottom: 24, left: 32 }">
+            <ChartContainer
+                :config="chartConfig"
+                :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
+                role="img"
+                aria-label="Area count history"
+            >
+                <VisXYContainer :data="chartData">
                     <template v-for="item in chartSeries" :key="item.key">
                         <VisLine
                             v-if="isSeriesVisible(item.key)"
@@ -132,12 +188,47 @@ watch(timeRange, refresh);
                             :line-width="2"
                         />
                     </template>
-                    <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
+                    <VisPlotline
+                        v-if="focusedSeries && focusedStatistics"
+                        axis="y"
+                        :value="focusedStatistics.average"
+                        :color="focusedSeries.color"
+                        :line-width="1"
+                        :line-style="PlotlineLineStylePresets.ShortDash"
+                        :label-text="`Avg ${formatCount(focusedStatistics.average)}`"
+                        :label-position="PlotlineLabelPosition.TopRight"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisScatter
+                        v-if="focusedSeries && statisticMarkers.length"
+                        :data="statisticMarkers"
+                        :x="(point: StatisticMarker) => point.date.getTime()"
+                        :y="(point: StatisticMarker) => point.value"
+                        :color="focusedSeries.color"
+                        :label="(point: StatisticMarker) => point.label"
+                        :label-position="(point: StatisticMarker) => point.position"
+                        :label-hide-overlapping="false"
+                        :size="8"
+                        stroke-color="var(--background)"
+                        :stroke-width="2"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisAxis
+                        type="x"
+                        :tick-line="false"
+                        :domain-line="false"
+                        :grid-line="false"
+                        :num-ticks="5"
+                        :min-max-ticks-only-when-width-is-less="500"
+                        :tick-text-hide-overlapping="true"
+                        :tick-format="formatTickDate"
+                    />
                     <VisAxis
                         type="y"
                         :tick-line="false"
                         :domain-line="false"
                         :grid-line="true"
+                        :num-ticks="4"
                         :tick-format="(value: number) => Math.round(value).toString()"
                     />
                     <ChartTooltip />
@@ -158,7 +249,14 @@ watch(timeRange, refresh);
                     />
                 </VisXYContainer>
             </ChartContainer>
-            <WidgetChartLegend :series="chartSeries" :hidden-series-keys="hiddenSeriesKeys" @select="selectSeries" />
+            <WidgetChartLegend
+                :series="chartSeries"
+                :hidden-series-keys="hiddenSeriesKeys"
+                :statistics-enabled="statisticsEnabled"
+                :statistics="statistics"
+                :format-value="formatCount"
+                @select="selectSeries"
+            />
         </div>
     </WidgetShell>
 </template>

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -252,7 +252,7 @@ watch(timeRange, refresh);
                 :series="chartSeries"
                 :hidden-series-keys="hiddenSeriesKeys"
                 :statistics-enabled="statisticsEnabled"
-                :statistics="statistics"
+                :statistics="statisticsEnabled ? statistics : undefined"
                 :format-value="formatCount"
                 @select="selectSeries"
             />

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -7,7 +7,8 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
-    WIDGET_TIME_RANGE_MINUTES,
+    widgetTimeRangeParams,
+    widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
     type WidgetChartValue,
@@ -66,9 +67,7 @@ const {
 });
 
 function timeParams(): { from: string; to: string } {
-    const to = new Date();
-    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
-    return { from: from.toISOString(), to: to.toISOString() };
+    return widgetTimeRangeParams(timeRange.value);
 }
 
 function shortenName(name: string, maxLength = 18): string {
@@ -138,7 +137,7 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
-    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+    if (widgetTimeRangeShowsDate(timeRange.value)) {
         return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
     }
 

--- a/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
+++ b/resources/js/components/peoplecount/MostActiveSensorsWidget.vue
@@ -81,34 +81,34 @@ watch(
         <template #actions>
             <div class="flex flex-wrap items-center gap-1">
                 <Button
-                    :class="{ 'bg-primary text-primary-foreground': selectedRange === '10m' }"
+                    :class="{ 'border-foreground/60 border': selectedRange === '10m' }"
                     :aria-pressed="selectedRange === '10m'"
                     size="sm"
-                    variant="outline"
+                    variant="ghost"
                     @click="selectedRange = '10m'"
                     >10m</Button
                 >
                 <Button
-                    :class="{ 'bg-primary text-primary-foreground': selectedRange === '30m' }"
+                    :class="{ 'border-foreground/60 border': selectedRange === '30m' }"
                     :aria-pressed="selectedRange === '30m'"
                     size="sm"
-                    variant="outline"
+                    variant="ghost"
                     @click="selectedRange = '30m'"
                     >30m</Button
                 >
                 <Button
-                    :class="{ 'bg-primary text-primary-foreground': selectedRange === '1h' }"
+                    :class="{ 'border-foreground/60 border': selectedRange === '1h' }"
                     :aria-pressed="selectedRange === '1h'"
                     size="sm"
-                    variant="outline"
+                    variant="ghost"
                     @click="selectedRange = '1h'"
                     >1h</Button
                 >
                 <Button
-                    :class="{ 'bg-primary text-primary-foreground': selectedRange === '2h' }"
+                    :class="{ 'border-foreground/60 border': selectedRange === '2h' }"
                     :aria-pressed="selectedRange === '2h'"
                     size="sm"
-                    variant="outline"
+                    variant="ghost"
                     @click="selectedRange = '2h'"
                     >2h</Button
                 >

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -270,6 +270,12 @@ describe('AreaCountHistoryWidget', () => {
         expect(mocks.get).toHaveBeenCalledWith('peoplecount.area-count-history.index');
         expect(mocks.request.from).toBe('2025-08-04T21:38:00.000Z');
         expect(mocks.request.to).toBe('2025-08-04T22:08:00.000Z');
+
+        await wrapper.find('[data-testid="range-select"]').setValue('yesterday');
+        await flushPromises();
+
+        expect(mocks.request.from).toBe(new Date(2025, 7, 4).toISOString());
+        expect(mocks.request.to).toBe(new Date(2025, 7, 5).toISOString());
     });
 
     it('queues a range change while a request is active', async () => {

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -28,9 +28,11 @@ vi.mock('@vueuse/core', async (importOriginal) => ({
 }));
 
 vi.mock('@unovis/vue', () => ({
-    VisXYContainer: { name: 'VisXYContainer', props: ['data'], template: '<div><slot /></div>' },
+    VisXYContainer: { name: 'VisXYContainer', props: ['data', 'margin'], template: '<div><slot /></div>' },
     VisLine: { name: 'VisLine', props: ['color', 'lineDashArray', 'y'], template: '<div />' },
     VisAxis: { template: '<div />' },
+    VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: { name: 'VisCrosshair', props: ['color'], template: '<div />' },
 }));
@@ -49,12 +51,20 @@ const globalStubs = {
         props: ['value'],
         template: '<option :value="value"><slot /></option>',
     },
-    VisXYContainer: { name: 'VisXYContainer', props: ['data'], template: '<div><slot /></div>' },
+    VisXYContainer: { name: 'VisXYContainer', props: ['data', 'margin'], template: '<div><slot /></div>' },
     VisLine: { name: 'VisLine', props: ['color', 'lineDashArray', 'y'], template: '<div></div>' },
     VisAxis: { template: '<div></div>' },
+    VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div></div>' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div></div>' },
     ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
     ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div></div>' },
     ChartTooltip: { template: '<div></div>' },
+    Switch: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template:
+            '<button aria-label="Show chart statistics" :aria-pressed="modelValue" @click="$emit(\'update:modelValue\', !modelValue)">Statistics</button>',
+    },
 };
 
 describe('AreaCountHistoryWidget', () => {
@@ -175,6 +185,32 @@ describe('AreaCountHistoryWidget', () => {
 
         await wrapper.get('[data-series="area_2"]').trigger('click', { shiftKey: true });
         expect(wrapper.findAllComponents({ name: 'VisLine' })).toHaveLength(2);
+    });
+
+    it('shows statistics and focused extrema for the visible series', async () => {
+        mocks.get.mockResolvedValue(mockSeries);
+        const wrapper = mount(AreaCountHistoryWidget, {
+            props: { organization: mockOrganization },
+            global: { stubs: globalStubs },
+        });
+        await flushPromises();
+
+        expect(wrapper.findComponent({ name: 'VisPlotline' }).exists()).toBe(false);
+        expect(wrapper.getComponent({ name: 'VisXYContainer' }).props('margin')).toBeUndefined();
+        expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('h-[240px]');
+
+        await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
+
+        expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('h-[220px]');
+        expect(wrapper.get('[data-series="area_1"]').text()).toContain('10');
+        expect(wrapper.get('[data-series="area_1"]').text()).toContain('12.5');
+        expect(wrapper.get('[data-series="area_1"]').text()).toContain('15');
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('value')).toBe(12.5);
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 12.5');
+
+        const scatter = wrapper.getComponent({ name: 'VisScatter' });
+        const markers = scatter.props('data') as Array<{ label: string }>;
+        expect(markers.map((marker) => marker.label)).toEqual(['Min 10', 'Max 15']);
     });
 
     it('keeps the empty state visible while another range loads', async () => {

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -274,8 +274,13 @@ describe('AreaCountHistoryWidget', () => {
         await wrapper.find('[data-testid="range-select"]').setValue('yesterday');
         await flushPromises();
 
-        expect(mocks.request.from).toBe(new Date(2025, 7, 4).toISOString());
-        expect(mocks.request.to).toBe(new Date(2025, 7, 5).toISOString());
+        const expectedTo = new Date();
+        expectedTo.setHours(0, 0, 0, 0);
+        const expectedFrom = new Date(expectedTo);
+        expectedFrom.setDate(expectedFrom.getDate() - 1);
+
+        expect(mocks.request.from).toBe(expectedFrom.toISOString());
+        expect(mocks.request.to).toBe(expectedTo.toISOString());
     });
 
     it('queues a range change while a request is active', async () => {

--- a/resources/js/components/peoplecount/_tests_/MostActiveSensorsWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/MostActiveSensorsWidget.test.ts
@@ -141,6 +141,18 @@ describe('MostActiveSensorsWidget', () => {
                 .find((button) => button.text() === '30m')!
                 .attributes('aria-pressed'),
         ).toBe('false');
+        expect(
+            wrapper
+                .findAll('button')
+                .find((button) => button.text() === '10m')!
+                .classes(),
+        ).toEqual(expect.arrayContaining(['border', 'border-foreground/60']));
+        expect(
+            wrapper
+                .findAll('button')
+                .find((button) => button.text() === '30m')!
+                .classes(),
+        ).not.toContain('border');
 
         // Click 30m -> sensor with Total 4 should be first
         await wrapper

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -7,7 +7,8 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
-    WIDGET_TIME_RANGE_MINUTES,
+    widgetTimeRangeParams,
+    widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
     type WidgetChartValue,
@@ -48,9 +49,7 @@ const { data, loading, error, refresh } = useWidgetPolling({
 });
 
 function timeParams(): { from: string; to: string } {
-    const to = new Date();
-    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
-    return { from: from.toISOString(), to: to.toISOString() };
+    return widgetTimeRangeParams(timeRange.value);
 }
 
 function seriesKey(sensorId: number): string {
@@ -158,7 +157,7 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
-    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+    if (widgetTimeRangeShowsDate(timeRange.value)) {
         return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
     }
 

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -2,16 +2,24 @@
 import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
 import { Skeleton } from '@/components/ui/skeleton';
 import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
+import WidgetHistoryControls from '@/components/widgets/WidgetHistoryControls.vue';
 import WidgetShell from '@/components/widgets/WidgetShell.vue';
-import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
-import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import {
+    calculateWidgetChartStatistics,
+    WIDGET_CHART_COLORS,
+    WIDGET_TIME_RANGE_MINUTES,
+    type WidgetChartSeries,
+    type WidgetChartStatistics,
+    type WidgetChartValue,
+    type WidgetTimeRange,
+} from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import type { Organization, StageSafetyLqiHistoryPayload } from '@/types';
 import { APP_LOCALE } from '@/utils/dateTimeHelpers';
 import { stageSafetySensorName } from '@/utils/stageSafety';
-import { CurveType, type Crosshair } from '@unovis/ts';
-import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position, type Crosshair } from '@unovis/ts';
+import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Radio } from 'lucide-vue-next';
 import { computed, h, nextTick, ref, render, watch } from 'vue';
@@ -21,8 +29,14 @@ interface ChartDataPoint {
     [key: string]: Date | number;
 }
 
+interface StatisticMarker extends WidgetChartValue {
+    label: string;
+    position: Position;
+}
+
 const props = defineProps<{ organization: Organization }>();
 const timeRange = ref<WidgetTimeRange>('1h');
+const statisticsEnabled = ref(false);
 const request = useHttp<{ from: string; to: string }, StageSafetyLqiHistoryPayload>({ from: '', to: '' });
 const { data, loading, error, refresh } = useWidgetPolling({
     interval: 60_000,
@@ -71,11 +85,39 @@ const chartData = computed(() =>
         .flat()
         .sort((left, right) => left.date.getTime() - right.date.getTime()),
 );
+const statistics = computed<Record<string, WidgetChartStatistics | null>>(() =>
+    Object.fromEntries(
+        chartSeries.value.map((item) => [
+            item.key,
+            calculateWidgetChartStatistics(
+                chartDataBySeries.value[item.key].map((point) => ({ date: point.date, value: seriesValue(point, item.key) as number })),
+            ),
+        ]),
+    ),
+);
 const hasData = computed(() => chartData.value.length > 0);
 const latestDataAt = computed(() => chartData.value.at(-1)?.date ?? null);
 const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
 const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
 const percentageFormatter = new Intl.NumberFormat('de-CH', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
+const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
+const statisticMarkers = computed<StatisticMarker[]>(() => {
+    const summary = focusedStatistics.value;
+
+    if (!summary) {
+        return [];
+    }
+
+    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
+        return [{ ...summary.minimum, label: `Min / max ${formatPercentage(summary.minimum.value)}`, position: Position.Top }];
+    }
+
+    return [
+        { ...summary.minimum, label: `Min ${formatPercentage(summary.minimum.value)}`, position: Position.Top },
+        { ...summary.maximum, label: `Max ${formatPercentage(summary.maximum.value)}`, position: Position.Bottom },
+    ];
+});
 
 function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: number | Date): string {
     const container = document.createElement('div');
@@ -116,11 +158,19 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
+    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+        return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+    }
+
     return new Date(value).toLocaleTimeString(APP_LOCALE, { hour: '2-digit', minute: '2-digit' });
 }
 
 function formatPercentageTick(value: number): string {
     return `${Math.round(value)}%`;
+}
+
+function formatPercentage(value: number): string {
+    return `${percentageFormatter.format(value)}%`;
 }
 
 watch(timeRange, refresh);
@@ -130,7 +180,9 @@ watch(chartData, () => void syncCrosshair());
 <template>
     <WidgetShell title="Link Quality History" subtitle="Normalized LQI in %" :error="error" :last-updated="latestDataAt" span="full">
         <template #icon><Radio /></template>
-        <template #actions><WidgetTimeRangeSelect v-model="timeRange" /></template>
+        <template #actions>
+            <WidgetHistoryControls v-model:time-range="timeRange" v-model:statistics-enabled="statisticsEnabled" />
+        </template>
 
         <div v-if="loading && !hasData" class="flex h-[280px] items-center justify-center sm:h-[350px]">
             <Skeleton class="h-full w-full" />
@@ -146,11 +198,11 @@ watch(chartData, () => void syncCrosshair());
             </p>
             <ChartContainer
                 :config="chartConfig"
-                class="h-[280px] w-full min-w-0 sm:h-[350px]"
+                :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
                 role="img"
                 aria-label="Link quality history in percent"
             >
-                <VisXYContainer :margin="{ top: 8, right: 8, bottom: 24, left: 38 }" :y-domain="[0, 100]">
+                <VisXYContainer :y-domain="[0, 100]">
                     <template v-for="item in chartSeries" :key="item.key">
                         <VisLine
                             v-if="isSeriesVisible(item.key)"
@@ -162,13 +214,54 @@ watch(chartData, () => void syncCrosshair());
                             :line-width="2"
                         />
                     </template>
-                    <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
-                    <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :tick-format="formatPercentageTick" />
+                    <VisPlotline
+                        v-if="focusedSeries && focusedStatistics"
+                        axis="y"
+                        :value="focusedStatistics.average"
+                        :color="focusedSeries.color"
+                        :line-width="1"
+                        :line-style="PlotlineLineStylePresets.ShortDash"
+                        :label-text="`Avg ${formatPercentage(focusedStatistics.average)}`"
+                        :label-position="PlotlineLabelPosition.TopRight"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisScatter
+                        v-if="focusedSeries && statisticMarkers.length"
+                        :data="statisticMarkers"
+                        :x="(point: StatisticMarker) => point.date.getTime()"
+                        :y="(point: StatisticMarker) => point.value"
+                        :color="focusedSeries.color"
+                        :label="(point: StatisticMarker) => point.label"
+                        :label-position="(point: StatisticMarker) => point.position"
+                        :label-hide-overlapping="false"
+                        :size="8"
+                        stroke-color="var(--background)"
+                        :stroke-width="2"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisAxis
+                        type="x"
+                        :tick-line="false"
+                        :domain-line="false"
+                        :grid-line="false"
+                        :num-ticks="5"
+                        :min-max-ticks-only-when-width-is-less="500"
+                        :tick-text-hide-overlapping="true"
+                        :tick-format="formatTickDate"
+                    />
+                    <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :num-ticks="4" :tick-format="formatPercentageTick" />
                     <ChartTooltip />
                     <ChartCrosshair ref="crosshairRef" :template="crosshairTemplate" :color="seriesColors" />
                 </VisXYContainer>
             </ChartContainer>
-            <WidgetChartLegend :series="chartSeries" :hidden-series-keys="hiddenSeriesKeys" @select="selectSeries" />
+            <WidgetChartLegend
+                :series="chartSeries"
+                :hidden-series-keys="hiddenSeriesKeys"
+                :statistics-enabled="statisticsEnabled"
+                :statistics="statistics"
+                :format-value="formatPercentage"
+                @select="selectSeries"
+            />
         </div>
     </WidgetShell>
 </template>

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -257,7 +257,7 @@ watch(chartData, () => void syncCrosshair());
                 :series="chartSeries"
                 :hidden-series-keys="hiddenSeriesKeys"
                 :statistics-enabled="statisticsEnabled"
-                :statistics="statistics"
+                :statistics="statisticsEnabled ? statistics : undefined"
                 :format-value="formatPercentage"
                 @select="selectSeries"
             />

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -279,7 +279,7 @@ watch(chartData, () => void syncCrosshair());
                 :series="chartSeries"
                 :hidden-series-keys="hiddenSeriesKeys"
                 :statistics-enabled="statisticsEnabled"
-                :statistics="statistics"
+                :statistics="statisticsEnabled ? statistics : undefined"
                 :format-value="formatWind"
                 @select="selectSeries"
             />

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -7,7 +7,8 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
-    WIDGET_TIME_RANGE_MINUTES,
+    widgetTimeRangeParams,
+    widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
     type WidgetChartValue,
@@ -48,9 +49,7 @@ const { data, loading, error, refresh } = useWidgetPolling({
 });
 
 function timeParams(): { from: string; to: string } {
-    const to = new Date();
-    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[timeRange.value] * 60 * 1000);
-    return { from: from.toISOString(), to: to.toISOString() };
+    return widgetTimeRangeParams(timeRange.value);
 }
 
 function seriesKey(sensorId: number, kind: StageSafetyReadingKind): string {
@@ -179,7 +178,7 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
-    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+    if (widgetTimeRangeShowsDate(timeRange.value)) {
         return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
     }
 

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -2,16 +2,24 @@
 import { ChartContainer, ChartCrosshair, ChartTooltip, ChartTooltipContent, type ChartConfig } from '@/components/ui/chart';
 import { Skeleton } from '@/components/ui/skeleton';
 import WidgetChartLegend from '@/components/widgets/WidgetChartLegend.vue';
+import WidgetHistoryControls from '@/components/widgets/WidgetHistoryControls.vue';
 import WidgetShell from '@/components/widgets/WidgetShell.vue';
-import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
-import { WIDGET_CHART_COLORS, WIDGET_TIME_RANGE_MINUTES, type WidgetChartSeries, type WidgetTimeRange } from '@/components/widgets/widgetChart';
+import {
+    calculateWidgetChartStatistics,
+    WIDGET_CHART_COLORS,
+    WIDGET_TIME_RANGE_MINUTES,
+    type WidgetChartSeries,
+    type WidgetChartStatistics,
+    type WidgetChartValue,
+    type WidgetTimeRange,
+} from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import type { Organization, StageSafetyReadingKind, StageSafetyWindHistoryPayload } from '@/types';
 import { APP_LOCALE } from '@/utils/dateTimeHelpers';
 import { metersPerSecondToKilometersPerHour, stageSafetySensorName } from '@/utils/stageSafety';
-import { CurveType, type Crosshair } from '@unovis/ts';
-import { VisAxis, VisLine, VisXYContainer } from '@unovis/vue';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position, type Crosshair } from '@unovis/ts';
+import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Wind } from 'lucide-vue-next';
 import { computed, h, nextTick, ref, render, watch } from 'vue';
@@ -21,8 +29,14 @@ interface ChartDataPoint {
     [key: string]: Date | number | undefined;
 }
 
+interface StatisticMarker extends WidgetChartValue {
+    label: string;
+    position: Position;
+}
+
 const props = defineProps<{ organization: Organization }>();
 const timeRange = ref<WidgetTimeRange>('1h');
+const statisticsEnabled = ref(false);
 const request = useHttp<{ from: string; to: string }, StageSafetyWindHistoryPayload>({ from: '', to: '' });
 const { data, loading, error, refresh } = useWidgetPolling({
     interval: 60_000,
@@ -93,9 +107,37 @@ const latestDataAt = computed(() => chartData.value.at(-1)?.date ?? null);
 const chartDataBySeries = computed<Record<string, ChartDataPoint[]>>(() =>
     Object.fromEntries(chartSeries.value.map((item) => [item.key, chartData.value.filter((point) => seriesValue(point, item.key) !== undefined)])),
 );
+const statistics = computed<Record<string, WidgetChartStatistics | null>>(() =>
+    Object.fromEntries(
+        chartSeries.value.map((item) => [
+            item.key,
+            calculateWidgetChartStatistics(
+                chartDataBySeries.value[item.key].map((point) => ({ date: point.date, value: seriesValue(point, item.key) as number })),
+            ),
+        ]),
+    ),
+);
 const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
 const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
 const windValueFormatter = new Intl.NumberFormat('de-CH', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
+const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
+const statisticMarkers = computed<StatisticMarker[]>(() => {
+    const summary = focusedStatistics.value;
+
+    if (!summary) {
+        return [];
+    }
+
+    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
+        return [{ ...summary.minimum, label: `Min / max ${formatWind(summary.minimum.value)}`, position: Position.Top }];
+    }
+
+    return [
+        { ...summary.minimum, label: `Min ${formatWind(summary.minimum.value)}`, position: Position.Top },
+        { ...summary.maximum, label: `Max ${formatWind(summary.maximum.value)}`, position: Position.Bottom },
+    ];
+});
 
 function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: number | Date): string {
     const container = document.createElement('div');
@@ -137,11 +179,19 @@ function seriesValue(point: ChartDataPoint, key: string): number | undefined {
 }
 
 function formatTickDate(value: number): string {
+    if (WIDGET_TIME_RANGE_MINUTES[timeRange.value] >= WIDGET_TIME_RANGE_MINUTES['12h']) {
+        return new Date(value).toLocaleString(APP_LOCALE, { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+    }
+
     return new Date(value).toLocaleTimeString(APP_LOCALE, { hour: '2-digit', minute: '2-digit' });
 }
 
 function formatWindTick(value: number): string {
     return value.toLocaleString([], { maximumFractionDigits: 1 });
+}
+
+function formatWind(value: number): string {
+    return `${windValueFormatter.format(value)} km/h`;
 }
 
 watch(timeRange, refresh);
@@ -151,7 +201,9 @@ watch(chartData, () => void syncCrosshair());
 <template>
     <WidgetShell title="Wind History" subtitle="Average and gust speed in km/h" :error="error" :last-updated="latestDataAt" span="full">
         <template #icon><Wind /></template>
-        <template #actions><WidgetTimeRangeSelect v-model="timeRange" /></template>
+        <template #actions>
+            <WidgetHistoryControls v-model:time-range="timeRange" v-model:statistics-enabled="statisticsEnabled" />
+        </template>
 
         <div v-if="loading && !hasData" class="flex h-[280px] items-center justify-center sm:h-[350px]">
             <Skeleton class="h-full w-full" />
@@ -167,11 +219,11 @@ watch(chartData, () => void syncCrosshair());
             </p>
             <ChartContainer
                 :config="chartConfig"
-                class="h-[280px] w-full min-w-0 sm:h-[350px]"
+                :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
                 role="img"
                 aria-label="Wind history in kilometers per hour"
             >
-                <VisXYContainer :margin="{ top: 8, right: 8, bottom: 24, left: 38 }">
+                <VisXYContainer>
                     <template v-for="item in chartSeries" :key="item.key">
                         <VisLine
                             v-if="isSeriesVisible(item.key)"
@@ -184,13 +236,54 @@ watch(chartData, () => void syncCrosshair());
                             :line-dash-array="item.dash"
                         />
                     </template>
-                    <VisAxis type="x" :tick-line="false" :domain-line="false" :grid-line="false" :tick-format="formatTickDate" />
-                    <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :tick-format="formatWindTick" />
+                    <VisPlotline
+                        v-if="focusedSeries && focusedStatistics"
+                        axis="y"
+                        :value="focusedStatistics.average"
+                        :color="focusedSeries.color"
+                        :line-width="1"
+                        :line-style="PlotlineLineStylePresets.ShortDash"
+                        :label-text="`Avg ${formatWind(focusedStatistics.average)}`"
+                        :label-position="PlotlineLabelPosition.TopRight"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisScatter
+                        v-if="focusedSeries && statisticMarkers.length"
+                        :data="statisticMarkers"
+                        :x="(point: StatisticMarker) => point.date.getTime()"
+                        :y="(point: StatisticMarker) => point.value"
+                        :color="focusedSeries.color"
+                        :label="(point: StatisticMarker) => point.label"
+                        :label-position="(point: StatisticMarker) => point.position"
+                        :label-hide-overlapping="false"
+                        :size="8"
+                        stroke-color="var(--background)"
+                        :stroke-width="2"
+                        :exclude-from-domain-calculation="true"
+                    />
+                    <VisAxis
+                        type="x"
+                        :tick-line="false"
+                        :domain-line="false"
+                        :grid-line="false"
+                        :num-ticks="5"
+                        :min-max-ticks-only-when-width-is-less="500"
+                        :tick-text-hide-overlapping="true"
+                        :tick-format="formatTickDate"
+                    />
+                    <VisAxis type="y" :tick-line="false" :domain-line="false" :grid-line="true" :num-ticks="4" :tick-format="formatWindTick" />
                     <ChartTooltip />
                     <ChartCrosshair ref="crosshairRef" :template="crosshairTemplate" :color="seriesColors" />
                 </VisXYContainer>
             </ChartContainer>
-            <WidgetChartLegend :series="chartSeries" :hidden-series-keys="hiddenSeriesKeys" @select="selectSeries" />
+            <WidgetChartLegend
+                :series="chartSeries"
+                :hidden-series-keys="hiddenSeriesKeys"
+                :statistics-enabled="statisticsEnabled"
+                :statistics="statistics"
+                :format-value="formatWind"
+                @select="selectSeries"
+            />
         </div>
     </WidgetShell>
 </template>

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -29,6 +29,8 @@ vi.mock('@unovis/vue', () => ({
         template: '<div class="series-line" />',
     },
     VisAxis: { template: '<div />' },
+    VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: {
         name: 'VisCrosshair',
@@ -76,6 +78,12 @@ const stubs = {
     ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
     ChartTooltip: { template: '<div />' },
     ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div />' },
+    Switch: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template:
+            '<button aria-label="Show chart statistics" :aria-pressed="modelValue" @click="$emit(\'update:modelValue\', !modelValue)">Statistics</button>',
+    },
 };
 
 describe('LqiHistoryWidget', () => {
@@ -139,5 +147,25 @@ describe('LqiHistoryWidget', () => {
 
         expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
         expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+    });
+
+    it('shows percentage statistics and annotates an isolated sensor', async () => {
+        mocks.get.mockResolvedValue(history);
+        const wrapper = mount(LqiHistoryWidget, { props: { organization }, global: { stubs } });
+        await flushPromises();
+
+        await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
+
+        expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('0.0%');
+        expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('25.4%');
+        expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('50.9%');
+        expect(wrapper.findComponent({ name: 'VisPlotline' }).exists()).toBe(false);
+
+        await wrapper.get('[data-series="sensor_1_lqi"]').trigger('click');
+
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('value')).toBeCloseTo(25.4487179487);
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 25.4%');
+        const markers = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
+        expect(markers.map((marker) => marker.label)).toEqual(['Min 0.0%', 'Max 50.9%']);
     });
 });

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -147,6 +147,12 @@ describe('LqiHistoryWidget', () => {
 
         expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
         expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+
+        await wrapper.get('[data-testid="range-select"]').setValue('yesterday');
+        await flushPromises();
+
+        expect(mocks.request.from).toBe(new Date(2026, 6, 24).toISOString());
+        expect(mocks.request.to).toBe(new Date(2026, 6, 25).toISOString());
     });
 
     it('shows percentage statistics and annotates an isolated sensor', async () => {

--- a/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
@@ -31,6 +31,8 @@ vi.mock('@unovis/vue', () => ({
         template: '<div class="series-line" />',
     },
     VisAxis: { template: '<div />' },
+    VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: {
         name: 'VisCrosshair',
@@ -79,6 +81,12 @@ const stubs = {
     ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
     ChartTooltip: { template: '<div />' },
     ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div />' },
+    Switch: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template:
+            '<button aria-label="Show chart statistics" :aria-pressed="modelValue" @click="$emit(\'update:modelValue\', !modelValue)">Statistics</button>',
+    },
 };
 
 describe('WindHistoryWidget', () => {
@@ -153,6 +161,30 @@ describe('WindHistoryWidget', () => {
 
         expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
         expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+    });
+
+    it('calculates statistics in km/h and annotates an isolated series', async () => {
+        mocks.get.mockResolvedValue(history);
+        const wrapper = mount(WindHistoryWidget, { props: { organization }, global: { stubs } });
+        await flushPromises();
+
+        await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
+
+        expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('18.0 km/h');
+        expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('19.8 km/h');
+        expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('21.6 km/h');
+        expect(wrapper.findComponent({ name: 'VisPlotline' }).exists()).toBe(false);
+
+        await wrapper.get('[data-series="sensor_1_wind_average"]').trigger('click');
+
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('value')).toBeCloseTo(19.8);
+        expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 19.8 km/h');
+        const markers = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
+        expect(markers.map((marker) => marker.label)).toEqual(['Min 18.0 km/h', 'Max 21.6 km/h']);
+
+        await wrapper.get('[data-series="sensor_1_wind_gust"]').trigger('click');
+        const singleMarker = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
+        expect(singleMarker.map((marker) => marker.label)).toEqual(['Min / max 28.8 km/h']);
     });
 
     it('isolates a legend series and restores all when selected again', async () => {

--- a/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
@@ -161,6 +161,12 @@ describe('WindHistoryWidget', () => {
 
         expect(mocks.request.from).toBe('2026-07-25T11:30:00.000Z');
         expect(mocks.request.to).toBe('2026-07-25T12:00:00.000Z');
+
+        await wrapper.get('[data-testid="range-select"]').setValue('yesterday');
+        await flushPromises();
+
+        expect(mocks.request.from).toBe(new Date(2026, 6, 24).toISOString());
+        expect(mocks.request.to).toBe(new Date(2026, 6, 25).toISOString());
     });
 
     it('calculates statistics in km/h and annotates an isolated series', async () => {

--- a/resources/js/components/widgets/WidgetChartLegend.vue
+++ b/resources/js/components/widgets/WidgetChartLegend.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import type { WidgetChartSeries } from '@/components/widgets/widgetChart';
+import type { WidgetChartStatistics } from '@/components/widgets/widgetChart';
 
 const props = defineProps<{
     series: WidgetChartSeries[];
     hiddenSeriesKeys: Set<string>;
+    statisticsEnabled?: boolean;
+    statistics?: Partial<Record<string, WidgetChartStatistics | null>>;
+    formatValue?: (value: number) => string;
 }>();
 
 const emit = defineEmits<{
@@ -13,10 +17,61 @@ const emit = defineEmits<{
 function isVisible(key: string): boolean {
     return !props.hiddenSeriesKeys.has(key);
 }
+
+function statisticValue(key: string, kind: 'minimum' | 'average' | 'maximum'): string {
+    const statistics = props.statistics?.[key];
+
+    if (!statistics) {
+        return 'N/A';
+    }
+
+    const value = kind === 'average' ? statistics.average : statistics[kind].value;
+
+    return props.formatValue?.(value) ?? value.toString();
+}
 </script>
 
 <template>
-    <div class="mt-4 flex flex-wrap gap-x-5 gap-y-2 border-t pt-3 text-sm">
+    <div v-if="statisticsEnabled" class="mt-2 border-t pt-2 text-sm sm:mt-4 sm:pt-3">
+        <div class="text-muted-foreground hidden grid-cols-[minmax(0,1fr)_repeat(3,minmax(4rem,auto))] gap-x-4 px-2 pb-1 text-xs sm:grid">
+            <span>Series</span>
+            <span class="text-right">Min</span>
+            <span class="text-right">Avg</span>
+            <span class="text-right">Max</span>
+        </div>
+        <button
+            v-for="item in series"
+            :key="item.key"
+            type="button"
+            class="hover:bg-accent grid w-full cursor-pointer grid-cols-3 gap-x-3 gap-y-2 rounded px-2 py-2 text-left sm:grid-cols-[minmax(0,1fr)_repeat(3,minmax(4rem,auto))] sm:gap-x-4 sm:gap-y-0"
+            :aria-label="`Show only ${item.label}. Shift-click to add or remove this series.`"
+            :aria-pressed="isVisible(item.key)"
+            :data-series="item.key"
+            :title="item.label"
+            @click="emit('select', item.key, $event.shiftKey)"
+        >
+            <span class="col-span-3 flex min-w-0 items-center gap-2 sm:col-span-1">
+                <svg width="24" height="8" :style="{ color: item.color }" :class="{ 'opacity-40': !isVisible(item.key) }" aria-hidden="true">
+                    <line x1="0" y1="4" x2="24" y2="4" stroke="currentColor" stroke-width="2" :stroke-dasharray="item.dash?.join(',') ?? 'none'" />
+                </svg>
+                <span class="truncate" :class="{ 'text-muted-foreground line-through': !isVisible(item.key) }">{{ item.label }}</span>
+            </span>
+            <span class="tabular-nums" :class="{ 'text-muted-foreground': !isVisible(item.key) }">
+                <span class="text-muted-foreground block text-xs sm:hidden">Min</span>
+                <span class="block sm:text-right">{{ statisticValue(item.key, 'minimum') }}</span>
+            </span>
+            <span class="tabular-nums" :class="{ 'text-muted-foreground': !isVisible(item.key) }">
+                <span class="text-muted-foreground block text-xs sm:hidden">Avg</span>
+                <span class="block sm:text-right">{{ statisticValue(item.key, 'average') }}</span>
+            </span>
+            <span class="tabular-nums" :class="{ 'text-muted-foreground': !isVisible(item.key) }">
+                <span class="text-muted-foreground block text-xs sm:hidden">Max</span>
+                <span class="block sm:text-right">{{ statisticValue(item.key, 'maximum') }}</span>
+            </span>
+        </button>
+    </div>
+
+    <div v-else class="mt-2 flex flex-wrap gap-x-5 gap-y-2 border-t pt-2 text-sm sm:mt-4 sm:pt-3">
         <button
             v-for="item in series"
             :key="item.key"

--- a/resources/js/components/widgets/WidgetHistoryControls.vue
+++ b/resources/js/components/widgets/WidgetHistoryControls.vue
@@ -23,7 +23,7 @@ const statisticsId = useId();
         <div class="min-w-0 flex-1 sm:flex-none">
             <WidgetTimeRangeSelect :model-value="timeRange" @update:model-value="emit('update:timeRange', $event)" />
         </div>
-        <div class="flex h-10 shrink-0 items-center gap-2 rounded-md border px-2">
+        <div class="flex h-10 shrink-0 items-center gap-2 px-1">
             <Label :for="statisticsId" class="cursor-pointer">Statistics</Label>
             <Switch
                 :id="statisticsId"

--- a/resources/js/components/widgets/WidgetHistoryControls.vue
+++ b/resources/js/components/widgets/WidgetHistoryControls.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import WidgetTimeRangeSelect from '@/components/widgets/WidgetTimeRangeSelect.vue';
+import type { WidgetTimeRange } from '@/components/widgets/widgetChart';
+import { useId } from 'vue';
+
+defineProps<{
+    timeRange: WidgetTimeRange;
+    statisticsEnabled: boolean;
+}>();
+
+const emit = defineEmits<{
+    'update:timeRange': [value: WidgetTimeRange];
+    'update:statisticsEnabled': [value: boolean];
+}>();
+
+const statisticsId = useId();
+</script>
+
+<template>
+    <div class="flex w-full items-center gap-2 sm:w-auto">
+        <div class="min-w-0 flex-1 sm:flex-none">
+            <WidgetTimeRangeSelect :model-value="timeRange" @update:model-value="emit('update:timeRange', $event)" />
+        </div>
+        <div class="flex h-10 shrink-0 items-center gap-2 rounded-md border px-2">
+            <Label :for="statisticsId" class="cursor-pointer">Statistics</Label>
+            <Switch
+                :id="statisticsId"
+                :model-value="statisticsEnabled"
+                aria-label="Show chart statistics"
+                @update:model-value="emit('update:statisticsEnabled', $event)"
+            />
+        </div>
+    </div>
+</template>

--- a/resources/js/components/widgets/WidgetShell.vue
+++ b/resources/js/components/widgets/WidgetShell.vue
@@ -30,7 +30,7 @@ function formatLastUpdated(date: Date): string {
 
 <template>
     <Card :class="cardClass" class="flex h-full min-w-0 flex-col">
-        <CardHeader class="flex flex-col gap-3 pb-4 sm:flex-row sm:items-start sm:justify-between sm:space-y-0">
+        <CardHeader class="flex flex-col gap-3 px-4 pt-4 pb-3 sm:flex-row sm:items-start sm:justify-between sm:space-y-0 sm:px-6 sm:pt-6 sm:pb-4">
             <div class="min-w-0">
                 <CardTitle class="flex items-center gap-2">
                     <span v-if="$slots.icon" class="shrink-0 [&>svg]:size-4" aria-hidden="true">
@@ -40,16 +40,16 @@ function formatLastUpdated(date: Date): string {
                 </CardTitle>
                 <p v-if="subtitle" class="text-muted-foreground mt-1 text-sm">{{ subtitle }}</p>
             </div>
-            <div v-if="$slots.actions" class="shrink-0">
+            <div v-if="$slots.actions" class="w-full shrink-0 sm:w-auto">
                 <slot name="actions" />
             </div>
         </CardHeader>
 
-        <CardContent class="flex min-w-0 flex-1 flex-col">
+        <CardContent class="flex min-w-0 flex-1 flex-col px-4 pb-4 sm:px-6 sm:pb-6">
             <WidgetNotice v-if="error" class="mb-4" variant="error">{{ error }}</WidgetNotice>
             <slot />
-            <div v-if="lastUpdated" class="mt-auto pt-4">
-                <div class="text-muted-foreground border-t pt-3 text-center text-xs">
+            <div v-if="lastUpdated" class="mt-auto pt-2 sm:pt-4">
+                <div class="text-muted-foreground border-t pt-2 text-center text-xs sm:pt-3">
                     Latest data:
                     <time :datetime="lastUpdated.toISOString()">{{ formatLastUpdated(lastUpdated) }}</time>
                 </div>

--- a/resources/js/components/widgets/WidgetTimeRangeSelect.vue
+++ b/resources/js/components/widgets/WidgetTimeRangeSelect.vue
@@ -23,12 +23,16 @@ const options: Array<{ value: WidgetTimeRange; label: string }> = [
     { value: '6h', label: 'Last 6 hours' },
     { value: '12h', label: 'Last 12 hours' },
     { value: '24h', label: 'Last 24 hours' },
+    { value: 'today', label: 'Today' },
+    { value: 'yesterday', label: 'Yesterday' },
+    { value: 'day-before-yesterday', label: 'Day before yesterday' },
+    { value: 'this-day-last-week', label: 'This day last week' },
 ];
 </script>
 
 <template>
     <Select v-model="selectedRange">
-        <SelectTrigger class="w-full sm:w-40" aria-label="History time range">
+        <SelectTrigger class="hover:bg-accent/50 w-full border-transparent bg-transparent px-2 shadow-none sm:w-40" aria-label="History time range">
             <SelectValue placeholder="Select range" />
         </SelectTrigger>
         <SelectContent>

--- a/resources/js/components/widgets/_tests_/WidgetChartLegend.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetChartLegend.test.ts
@@ -32,4 +32,30 @@ describe('WidgetChartLegend', () => {
             ['gust', true],
         ]);
     });
+
+    it('renders formatted statistics for visible and hidden series', () => {
+        const wrapper = mount(WidgetChartLegend, {
+            props: {
+                series,
+                hiddenSeriesKeys: new Set(['gust']),
+                statisticsEnabled: true,
+                statistics: {
+                    average: {
+                        count: 2,
+                        minimum: { date: new Date('2026-08-06T10:00:00Z'), value: 10 },
+                        maximum: { date: new Date('2026-08-06T10:05:00Z'), value: 20 },
+                        average: 15,
+                    },
+                    gust: null,
+                },
+                formatValue: (value: number) => `${value.toFixed(1)} km/h`,
+            },
+        });
+
+        expect(wrapper.get('[data-series="average"]').text()).toContain('10.0 km/h');
+        expect(wrapper.get('[data-series="average"]').text()).toContain('15.0 km/h');
+        expect(wrapper.get('[data-series="average"]').text()).toContain('20.0 km/h');
+        expect(wrapper.get('[data-series="gust"]').text()).toContain('N/A');
+        expect(wrapper.get('[data-series="gust"]').attributes('aria-pressed')).toBe('false');
+    });
 });

--- a/resources/js/components/widgets/_tests_/WidgetHistoryControls.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetHistoryControls.test.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import WidgetHistoryControls from '../WidgetHistoryControls.vue';
+
+const stubs = {
+    WidgetTimeRangeSelect: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template: '<button data-testid="range" @click="$emit(\'update:modelValue\', \'6h\')">{{ modelValue }}</button>',
+    },
+    Switch: {
+        props: ['modelValue', 'id'],
+        emits: ['update:modelValue'],
+        template: '<button :id="id" role="switch" :aria-checked="modelValue" @click="$emit(\'update:modelValue\', !modelValue)">Statistics</button>',
+    },
+    Label: { template: '<label v-bind="$attrs"><slot /></label>' },
+};
+
+describe('WidgetHistoryControls', () => {
+    it('emits range and statistics changes independently', async () => {
+        const wrapper = mount(WidgetHistoryControls, {
+            props: { timeRange: '1h', statisticsEnabled: false },
+            global: { stubs },
+        });
+
+        await wrapper.get('[data-testid="range"]').trigger('click');
+        expect(wrapper.emitted('update:timeRange')).toEqual([['6h']]);
+        expect(wrapper.emitted('update:statisticsEnabled')).toBeUndefined();
+
+        await wrapper.get('[role="switch"]').trigger('click');
+        expect(wrapper.emitted('update:statisticsEnabled')).toEqual([[true]]);
+        expect(wrapper.get('label').attributes('for')).toBe(wrapper.get('[role="switch"]').attributes('id'));
+    });
+});

--- a/resources/js/components/widgets/_tests_/WidgetHistoryControls.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetHistoryControls.test.ts
@@ -30,5 +30,6 @@ describe('WidgetHistoryControls', () => {
         await wrapper.get('[role="switch"]').trigger('click');
         expect(wrapper.emitted('update:statisticsEnabled')).toEqual([[true]]);
         expect(wrapper.get('label').attributes('for')).toBe(wrapper.get('[role="switch"]').attributes('id'));
+        expect(wrapper.get('[role="switch"]').element.parentElement?.classList).not.toContain('border');
     });
 });

--- a/resources/js/components/widgets/_tests_/WidgetShell.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetShell.test.ts
@@ -30,7 +30,7 @@ describe('WidgetShell', () => {
         expect(wrapper.text()).toContain('Latest data:');
         expect(wrapper.get('time').attributes('datetime')).toBe(lastUpdated.toISOString());
         expect(wrapper.get('time').text()).toBe('29.07.2026 13:57:30');
-        expect(wrapper.get('time').element.closest('.pt-4')).not.toBeNull();
+        expect(wrapper.get('time').element.closest('.pt-2')).not.toBeNull();
     });
 
     it('omits optional elements and uses one grid cell by default', () => {
@@ -45,5 +45,18 @@ describe('WidgetShell', () => {
         const wrapper = mount(WidgetShell, { props: { title: 'Wind History', span: 'full' } });
 
         expect(wrapper.classes()).toContain('col-span-full');
+    });
+
+    it('uses narrower mobile padding and full-width mobile actions', () => {
+        const wrapper = mount(WidgetShell, {
+            props: { title: 'History' },
+            slots: { actions: '<button>Action</button>' },
+        });
+
+        expect(wrapper.findComponent({ name: 'CardHeader' }).classes()).toEqual(expect.arrayContaining(['px-4', 'sm:px-6']));
+        expect(wrapper.findComponent({ name: 'CardHeader' }).classes()).toEqual(expect.arrayContaining(['pt-4', 'sm:pt-6', 'pb-3', 'sm:pb-4']));
+        expect(wrapper.findComponent({ name: 'CardContent' }).classes()).toEqual(expect.arrayContaining(['px-4', 'sm:px-6']));
+        expect(wrapper.findComponent({ name: 'CardContent' }).classes()).toEqual(expect.arrayContaining(['pb-4', 'sm:pb-6']));
+        expect(wrapper.get('button').element.parentElement?.classList).toContain('w-full');
     });
 });

--- a/resources/js/components/widgets/_tests_/WidgetTimeRangeSelect.test.ts
+++ b/resources/js/components/widgets/_tests_/WidgetTimeRangeSelect.test.ts
@@ -8,7 +8,7 @@ const stubs = {
         emits: ['update:modelValue'],
         template: '<select data-testid="range" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
     },
-    SelectTrigger: { template: '<div><slot /></div>' },
+    SelectTrigger: { name: 'SelectTrigger', template: '<div><slot /></div>' },
     SelectValue: { template: '<div />' },
     SelectContent: { template: '<div><slot /></div>' },
     SelectItem: { props: ['value'], template: '<option :value="value"><slot /></option>' },
@@ -28,7 +28,15 @@ describe('WidgetTimeRangeSelect', () => {
             ['6h', 'Last 6 hours'],
             ['12h', 'Last 12 hours'],
             ['24h', 'Last 24 hours'],
+            ['today', 'Today'],
+            ['yesterday', 'Yesterday'],
+            ['day-before-yesterday', 'Day before yesterday'],
+            ['this-day-last-week', 'This day last week'],
         ]);
+
+        expect(wrapper.getComponent({ name: 'SelectTrigger' }).classes()).toEqual(
+            expect.arrayContaining(['border-transparent', 'bg-transparent', 'shadow-none']),
+        );
     });
 
     it('emits the selected range', async () => {

--- a/resources/js/components/widgets/_tests_/widgetChart.test.ts
+++ b/resources/js/components/widgets/_tests_/widgetChart.test.ts
@@ -1,0 +1,32 @@
+import { calculateWidgetChartStatistics } from '@/components/widgets/widgetChart';
+import { describe, expect, it } from 'vitest';
+
+describe('calculateWidgetChartStatistics', () => {
+    it('calculates extrema and arithmetic average without rounding', () => {
+        const statistics = calculateWidgetChartStatistics([
+            { date: new Date('2026-08-06T10:00:00Z'), value: -2 },
+            { date: new Date('2026-08-06T10:05:00Z'), value: 0 },
+            { date: new Date('2026-08-06T10:10:00Z'), value: 3 },
+        ]);
+
+        expect(statistics).toMatchObject({ count: 3, average: 1 / 3 });
+        expect(statistics?.minimum.value).toBe(-2);
+        expect(statistics?.maximum.value).toBe(3);
+    });
+
+    it('uses earliest minimum and latest maximum when values tie', () => {
+        const statistics = calculateWidgetChartStatistics([
+            { date: new Date('2026-08-06T10:10:00Z'), value: 5 },
+            { date: new Date('2026-08-06T10:00:00Z'), value: 5 },
+            { date: new Date('2026-08-06T10:20:00Z'), value: 5 },
+        ]);
+
+        expect(statistics?.minimum.date.toISOString()).toBe('2026-08-06T10:00:00.000Z');
+        expect(statistics?.maximum.date.toISOString()).toBe('2026-08-06T10:20:00.000Z');
+    });
+
+    it('returns null when no valid samples exist', () => {
+        expect(calculateWidgetChartStatistics([])).toBeNull();
+        expect(calculateWidgetChartStatistics([{ date: new Date('invalid'), value: Number.NaN }])).toBeNull();
+    });
+});

--- a/resources/js/components/widgets/_tests_/widgetChart.test.ts
+++ b/resources/js/components/widgets/_tests_/widgetChart.test.ts
@@ -1,4 +1,4 @@
-import { calculateWidgetChartStatistics } from '@/components/widgets/widgetChart';
+import { calculateWidgetChartStatistics, widgetTimeRangeParams, widgetTimeRangeShowsDate } from '@/components/widgets/widgetChart';
 import { describe, expect, it } from 'vitest';
 
 describe('calculateWidgetChartStatistics', () => {
@@ -28,5 +28,38 @@ describe('calculateWidgetChartStatistics', () => {
     it('returns null when no valid samples exist', () => {
         expect(calculateWidgetChartStatistics([])).toBeNull();
         expect(calculateWidgetChartStatistics([{ date: new Date('invalid'), value: Number.NaN }])).toBeNull();
+    });
+});
+
+describe('widgetTimeRangeParams', () => {
+    it('calculates relative ranges', () => {
+        expect(widgetTimeRangeParams('1h', new Date('2026-08-06T15:00:00Z'))).toEqual({
+            from: '2026-08-06T14:00:00.000Z',
+            to: '2026-08-06T15:00:00.000Z',
+        });
+    });
+
+    it('calculates yesterday from local calendar midnights', () => {
+        const range = widgetTimeRangeParams('yesterday', new Date(2026, 7, 6, 15));
+        const from = new Date(range.from);
+        const to = new Date(range.to);
+
+        expect([from.getFullYear(), from.getMonth(), from.getDate(), from.getHours()]).toEqual([2026, 7, 5, 0]);
+        expect([to.getFullYear(), to.getMonth(), to.getDate(), to.getHours()]).toEqual([2026, 7, 6, 0]);
+        expect(widgetTimeRangeShowsDate('yesterday')).toBe(true);
+    });
+
+    it.each([
+        ['today', 6, 0, 6, 15],
+        ['day-before-yesterday', 4, 0, 5, 0],
+        ['this-day-last-week', 30, 0, 31, 0],
+    ] as const)('calculates the %s calendar range', (range, fromDay, fromHour, toDay, toHour) => {
+        const params = widgetTimeRangeParams(range, new Date(2026, 7, 6, 15));
+        const from = new Date(params.from);
+        const to = new Date(params.to);
+
+        expect([from.getDate(), from.getHours()]).toEqual([fromDay, fromHour]);
+        expect([to.getDate(), to.getHours()]).toEqual([toDay, toHour]);
+        expect(widgetTimeRangeShowsDate(range)).toBe(true);
     });
 });

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -16,6 +16,49 @@ export interface WidgetChartSeries {
     dash?: number[];
 }
 
+export interface WidgetChartValue {
+    date: Date;
+    value: number;
+}
+
+export interface WidgetChartStatistics {
+    count: number;
+    minimum: WidgetChartValue;
+    maximum: WidgetChartValue;
+    average: number;
+}
+
+export function calculateWidgetChartStatistics(values: WidgetChartValue[]): WidgetChartStatistics | null {
+    const validValues = values.filter((point) => Number.isFinite(point.value) && Number.isFinite(point.date.getTime()));
+
+    if (validValues.length === 0) {
+        return null;
+    }
+
+    let minimum = validValues[0];
+    let maximum = validValues[0];
+    let total = 0;
+
+    for (const point of validValues) {
+        if (point.value < minimum.value || (point.value === minimum.value && point.date < minimum.date)) {
+            minimum = point;
+        }
+
+        if (point.value > maximum.value || (point.value === maximum.value && point.date > maximum.date)) {
+            maximum = point;
+        }
+
+        total += point.value;
+    }
+
+    return {
+        count: validValues.length,
+        minimum,
+        maximum,
+        average: total / validValues.length,
+    };
+}
+
 export const WIDGET_CHART_COLORS = [
     'var(--color-chart-1)',
     'var(--color-chart-2)',

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -1,6 +1,8 @@
-export type WidgetTimeRange = '30m' | '1h' | '3h' | '6h' | '12h' | '24h';
+type CalendarWidgetTimeRange = 'today' | 'yesterday' | 'day-before-yesterday' | 'this-day-last-week';
+export type WidgetTimeRange = '30m' | '1h' | '3h' | '6h' | '12h' | '24h' | CalendarWidgetTimeRange;
+type RelativeWidgetTimeRange = Exclude<WidgetTimeRange, CalendarWidgetTimeRange>;
 
-export const WIDGET_TIME_RANGE_MINUTES: Record<WidgetTimeRange, number> = {
+const WIDGET_TIME_RANGE_MINUTES: Record<RelativeWidgetTimeRange, number> = {
     '30m': 30,
     '1h': 60,
     '3h': 180,
@@ -8,6 +10,35 @@ export const WIDGET_TIME_RANGE_MINUTES: Record<WidgetTimeRange, number> = {
     '12h': 720,
     '24h': 1440,
 };
+
+export function widgetTimeRangeParams(range: WidgetTimeRange, now = new Date()): { from: string; to: string } {
+    if (range === 'today') {
+        const from = new Date(now);
+        from.setHours(0, 0, 0, 0);
+
+        return { from: from.toISOString(), to: now.toISOString() };
+    }
+
+    if (range === 'yesterday' || range === 'day-before-yesterday' || range === 'this-day-last-week') {
+        const daysAgo = range === 'yesterday' ? 1 : range === 'day-before-yesterday' ? 2 : 7;
+        const from = new Date(now);
+        from.setHours(0, 0, 0, 0);
+        from.setDate(from.getDate() - daysAgo);
+        const to = new Date(from);
+        to.setDate(to.getDate() + 1);
+
+        return { from: from.toISOString(), to: to.toISOString() };
+    }
+
+    const to = new Date(now);
+    const from = new Date(to.getTime() - WIDGET_TIME_RANGE_MINUTES[range] * 60 * 1000);
+
+    return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export function widgetTimeRangeShowsDate(range: WidgetTimeRange): boolean {
+    return range === '12h' || range === '24h' || !Object.hasOwn(WIDGET_TIME_RANGE_MINUTES, range);
+}
 
 export interface WidgetChartSeries {
     key: string;

--- a/tests/Integration/Peoplecount/PeoplecountAreaCountHistoryWidgetControllerTest.php
+++ b/tests/Integration/Peoplecount/PeoplecountAreaCountHistoryWidgetControllerTest.php
@@ -240,7 +240,7 @@ it('rejects history ranges above maximum allowed duration', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->subHours(25)->toIso8601ZuluString('millisecond'),
+            'from' => Date::now()->subHours(26)->toIso8601ZuluString('millisecond'),
             'to' => Date::now()->toIso8601ZuluString('millisecond'),
         ]));
 
@@ -305,7 +305,7 @@ it('allows history ranges at maximum allowed duration', function () {
     $response = $this->actingAs($admin)
         ->getJson(route('peoplecount.area-count-history.index', [
             'organization' => $org->slug,
-            'from' => Date::now()->subHours(24)->toIso8601ZuluString('millisecond'),
+            'from' => Date::now()->subHours(25)->toIso8601ZuluString('millisecond'),
             'to' => Date::now()->toIso8601ZuluString('millisecond'),
         ]));
 

--- a/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
+++ b/tests/Integration/StageSafety/MonitoringWidgetControllerTest.php
@@ -112,8 +112,8 @@ it('rejects invalid history ranges', function (array $query, array $invalidField
         ->assertUnprocessable()
         ->assertJsonValidationErrors($invalidFields);
 })->with([
-    'longer than 24 hours' => [[
-        'from' => '2026-07-24T11:59:59.000Z',
+    'longer than 25 hours' => [[
+        'from' => '2026-07-24T10:59:59.000Z',
         'to' => '2026-07-25T12:00:00.000Z',
     ], ['to']],
     'reversed' => [[

--- a/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
+++ b/tests/Unit/Requests/Widgets/StageSafety/HistoryIndexRequestTest.php
@@ -12,7 +12,7 @@ it('defines paired bounded history inputs', function () {
         'from' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:to', 'before_or_equal:to'],
         'to' => ['nullable', 'date_format:Y-m-d\TH:i:s.v\Z', 'required_with:from', 'after_or_equal:from'],
     ])->and($request->after())->toHaveCount(1)
-        ->and(HistoryIndexRequest::MAX_RANGE_HOURS)->toBe(24);
+        ->and(HistoryIndexRequest::MAX_RANGE_HOURS)->toBe(25);
 });
 
 it('authorizes users with the monitoring permission', function () {


### PR DESCRIPTION
History widgets now support calendar-based ranges and optional chart statistics, making longer periods easier to inspect without losing existing series controls. Responsive controls and legends improve usability on small screens, with shared chart logic and focused component/integration coverage.

## Details

- [widgetChart.ts](https://github.com/musikfestwochen/musikfestapp/blob/feat/chart-statistics/resources/js/components/widgets/widgetChart.ts) - shared calendar range and statistics calculations
- [WidgetHistoryControls.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/chart-statistics/resources/js/components/widgets/WidgetHistoryControls.vue) - shared range and statistics controls
- [WidgetChartLegend.vue](https://github.com/musikfestwochen/musikfestapp/blob/feat/chart-statistics/resources/js/components/widgets/WidgetChartLegend.vue) - responsive series legend with Min/Avg/Max values

## Notes

Adds frontend tests for range calculations, chart statistics, controls, legends, and history widgets.

## Reviewer Setup

Frontend sources changed. Run:

```sh
npm run build
```

---
**«He who is contented is rich.»**
_Laozi_
