### PR TITLE
fix(widgets): improve chart statistic annotations

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -96,6 +96,14 @@
     }
 }
 
+.widget-history-chart g[class*='point-group'] text,
+.widget-history-chart g[class*='plotline-component'] text {
+    paint-order: stroke;
+    stroke: hsl(var(--card) / 95%);
+    stroke-width: 8px;
+    stroke-linejoin: round;
+}
+
 @layer utilities {
     body,
     html {

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -11,6 +11,7 @@ import {
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
+    type WidgetChartStatisticMarker,
     type WidgetChartStatistics,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
@@ -187,12 +188,12 @@ watch(chartData, () => void syncCrosshair());
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point) => point.date.getTime()"
-                        :y="(point) => point.value"
+                        :x="(point: WidgetChartStatisticMarker) => point.date.getTime()"
+                        :y="(point: WidgetChartStatisticMarker) => point.value"
                         color="hsl(var(--foreground))"
-                        :label="(point) => point.label"
+                        :label="(point: WidgetChartStatisticMarker) => point.label"
                         label-color="hsl(var(--foreground))"
-                        :label-position="(point) => point.position"
+                        :label-position="(point: WidgetChartStatisticMarker) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
                         stroke-color="hsl(var(--background))"

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -18,11 +18,11 @@ import {
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import { DATE_TIME_LOCALE, formatChartTick, formatChartTooltip } from '@/utils/dateTimeHelpers';
-import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, type Crosshair } from '@unovis/ts';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets } from '@unovis/ts';
 import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Users } from 'lucide-vue-next';
-import { computed, nextTick, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 interface DataPoint {
     time: string;
@@ -38,6 +38,7 @@ interface AreaSeries {
 
 interface ChartDataPoint {
     date: Date;
+    statistic?: WidgetChartStatisticMarker;
     [key: `area_${number}`]: number | null | undefined;
 }
 
@@ -107,11 +108,15 @@ const statistics = computed<Record<string, WidgetChartStatistics | null>>(() =>
 const hasData = computed(() => chartData.value.length > 0);
 const latestDataAt = computed(() => chartData.value.at(-1)?.date ?? null);
 const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
-const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
 const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
 const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
 const countFormatter = new Intl.NumberFormat(DATE_TIME_LOCALE, { maximumFractionDigits: 1 });
 const statisticMarkers = computed(() => widgetChartStatisticMarkers(focusedStatistics.value, formatCount));
+const annotatedChartData = computed(() => {
+    const markers = new Map(statisticMarkers.value.map((marker) => [marker.date.getTime(), marker]));
+
+    return chartData.value.map((point) => ({ ...point, statistic: markers.get(point.date.getTime()) }));
+});
 
 function seriesValue(point: ChartDataPoint, key: string): number | undefined {
     const value = point[key as `area_${number}`];
@@ -126,14 +131,7 @@ function formatCount(value: number): string {
     return countFormatter.format(value);
 }
 
-async function syncCrosshair(): Promise<void> {
-    await nextTick();
-    await nextTick();
-    crosshairRef.value?.component?.setData(chartData.value);
-}
-
 watch(timeRange, refresh);
-watch(chartData, () => void syncCrosshair());
 </script>
 
 <template>
@@ -162,11 +160,10 @@ watch(chartData, () => void syncCrosshair());
                 role="img"
                 aria-label="Area count history"
             >
-                <VisXYContainer>
+                <VisXYContainer :data="annotatedChartData">
                     <template v-for="item in chartSeries" :key="item.key">
                         <VisLine
                             v-if="isSeriesVisible(item.key)"
-                            :data="chartData"
                             :x="(point: ChartDataPoint) => point.date.getTime()"
                             :y="(point: ChartDataPoint) => seriesValue(point, item.key)"
                             :color="item.color"
@@ -187,13 +184,12 @@ watch(chartData, () => void syncCrosshair());
                     />
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
-                        :data="statisticMarkers"
-                        :x="(point: WidgetChartStatisticMarker) => point.date.getTime()"
-                        :y="(point: WidgetChartStatisticMarker) => point.value"
+                        :x="(point: ChartDataPoint) => point.date.getTime()"
+                        :y="(point: ChartDataPoint) => point.statistic?.value"
                         color="hsl(var(--foreground))"
-                        :label="(point: WidgetChartStatisticMarker) => point.label"
+                        :label="(point: ChartDataPoint) => point.statistic?.label ?? ''"
                         label-color="hsl(var(--foreground))"
-                        :label-position="(point: WidgetChartStatisticMarker) => point.position"
+                        :label-position="(point: ChartDataPoint) => point.statistic?.position"
                         :label-hide-overlapping="false"
                         :size="8"
                         stroke-color="hsl(var(--background))"
@@ -220,7 +216,6 @@ watch(chartData, () => void syncCrosshair());
                     />
                     <ChartTooltip />
                     <ChartCrosshair
-                        ref="crosshairRef"
                         :template="
                             componentToString(chartConfig, ChartTooltipContent, {
                                 indicator: 'line',

--- a/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
+++ b/resources/js/components/peoplecount/AreaCountHistoryWidget.vue
@@ -7,21 +7,21 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
+    widgetChartStatisticMarkers,
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
-    type WidgetChartValue,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
 import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import { DATE_TIME_LOCALE, formatChartTick, formatChartTooltip } from '@/utils/dateTimeHelpers';
-import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position } from '@unovis/ts';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, type Crosshair } from '@unovis/ts';
 import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Users } from 'lucide-vue-next';
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 
 interface DataPoint {
     time: string;
@@ -38,11 +38,6 @@ interface AreaSeries {
 interface ChartDataPoint {
     date: Date;
     [key: `area_${number}`]: number | null | undefined;
-}
-
-interface StatisticMarker extends WidgetChartValue {
-    label: string;
-    position: Position;
 }
 
 const props = defineProps<{
@@ -111,25 +106,11 @@ const statistics = computed<Record<string, WidgetChartStatistics | null>>(() =>
 const hasData = computed(() => chartData.value.length > 0);
 const latestDataAt = computed(() => chartData.value.at(-1)?.date ?? null);
 const seriesColors = computed(() => visibleChartSeries.value.map((item) => item.color));
+const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
 const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
 const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
 const countFormatter = new Intl.NumberFormat(DATE_TIME_LOCALE, { maximumFractionDigits: 1 });
-const statisticMarkers = computed<StatisticMarker[]>(() => {
-    const summary = focusedStatistics.value;
-
-    if (!summary) {
-        return [];
-    }
-
-    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
-        return [{ ...summary.minimum, label: `Min / max ${formatCount(summary.minimum.value)}`, position: Position.Top }];
-    }
-
-    return [
-        { ...summary.minimum, label: `Min ${formatCount(summary.minimum.value)}`, position: Position.Top },
-        { ...summary.maximum, label: `Max ${formatCount(summary.maximum.value)}`, position: Position.Bottom },
-    ];
-});
+const statisticMarkers = computed(() => widgetChartStatisticMarkers(focusedStatistics.value, formatCount));
 
 function seriesValue(point: ChartDataPoint, key: string): number | undefined {
     const value = point[key as `area_${number}`];
@@ -144,7 +125,14 @@ function formatCount(value: number): string {
     return countFormatter.format(value);
 }
 
+async function syncCrosshair(): Promise<void> {
+    await nextTick();
+    await nextTick();
+    crosshairRef.value?.component?.setData(chartData.value);
+}
+
 watch(timeRange, refresh);
+watch(chartData, () => void syncCrosshair());
 </script>
 
 <template>
@@ -167,15 +155,17 @@ watch(timeRange, refresh);
                 Area count history chart with {{ chartSeries.length }} series across {{ series?.length ?? 0 }} areas.
             </p>
             <ChartContainer
+                class="widget-history-chart"
                 :config="chartConfig"
                 :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
                 role="img"
                 aria-label="Area count history"
             >
-                <VisXYContainer :data="chartData">
+                <VisXYContainer>
                     <template v-for="item in chartSeries" :key="item.key">
                         <VisLine
                             v-if="isSeriesVisible(item.key)"
+                            :data="chartData"
                             :x="(point: ChartDataPoint) => point.date.getTime()"
                             :y="(point: ChartDataPoint) => seriesValue(point, item.key)"
                             :color="item.color"
@@ -197,14 +187,15 @@ watch(timeRange, refresh);
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point: StatisticMarker) => point.date.getTime()"
-                        :y="(point: StatisticMarker) => point.value"
-                        :color="focusedSeries.color"
-                        :label="(point: StatisticMarker) => point.label"
-                        :label-position="(point: StatisticMarker) => point.position"
+                        :x="(point) => point.date.getTime()"
+                        :y="(point) => point.value"
+                        color="hsl(var(--foreground))"
+                        :label="(point) => point.label"
+                        label-color="hsl(var(--foreground))"
+                        :label-position="(point) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
-                        stroke-color="var(--background)"
+                        stroke-color="hsl(var(--background))"
                         :stroke-width="2"
                         :exclude-from-domain-calculation="true"
                     />
@@ -228,6 +219,7 @@ watch(timeRange, refresh);
                     />
                     <ChartTooltip />
                     <ChartCrosshair
+                        ref="crosshairRef"
                         :template="
                             componentToString(chartConfig, ChartTooltipContent, {
                                 indicator: 'line',

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -170,7 +170,7 @@ describe('AreaCountHistoryWidget', () => {
         await flushPromises();
 
         const lines = wrapper.findAllComponents({ name: 'VisLine' });
-        const rows = lines[0].props('data') as Array<Record<string, number | Date | undefined>>;
+        const rows = wrapper.findComponent({ name: 'VisXYContainer' }).props('data') as Array<Record<string, number | Date | undefined>>;
         expect(lines).toHaveLength(2);
         expect(lines[0].props('color')).toBe('var(--color-chart-1)');
         expect(lines[1].props('color')).toBe('var(--color-chart-2)');
@@ -210,8 +210,9 @@ describe('AreaCountHistoryWidget', () => {
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 12.5');
 
         const scatter = wrapper.getComponent({ name: 'VisScatter' });
-        const markers = scatter.props('data') as Array<{ label: string }>;
-        expect(markers.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min 10  \|  .+$/), expect.stringMatching(/^Max 15  \|  .+$/)]);
+        const rows = wrapper.getComponent({ name: 'VisXYContainer' }).props('data') as Array<{ statistic?: { label: string } }>;
+        const markers = rows.flatMap((point) => (point.statistic ? [point.statistic] : []));
+        expect(markers.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min 10 \| .+$/), expect.stringMatching(/^Max 15 \| .+$/)]);
         expect(scatter.props('color')).toBe('hsl(var(--foreground))');
     });
 

--- a/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
+++ b/resources/js/components/peoplecount/_tests_/AreaCountHistoryWidget.test.ts
@@ -29,10 +29,10 @@ vi.mock('@vueuse/core', async (importOriginal) => ({
 
 vi.mock('@unovis/vue', () => ({
     VisXYContainer: { name: 'VisXYContainer', props: ['data', 'margin'], template: '<div><slot /></div>' },
-    VisLine: { name: 'VisLine', props: ['color', 'lineDashArray', 'y'], template: '<div />' },
+    VisLine: { name: 'VisLine', props: ['data', 'color', 'lineDashArray', 'y'], template: '<div />' },
     VisAxis: { template: '<div />' },
     VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
-    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label', 'color'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: { name: 'VisCrosshair', props: ['color'], template: '<div />' },
 }));
@@ -52,10 +52,10 @@ const globalStubs = {
         template: '<option :value="value"><slot /></option>',
     },
     VisXYContainer: { name: 'VisXYContainer', props: ['data', 'margin'], template: '<div><slot /></div>' },
-    VisLine: { name: 'VisLine', props: ['color', 'lineDashArray', 'y'], template: '<div></div>' },
+    VisLine: { name: 'VisLine', props: ['data', 'color', 'lineDashArray', 'y'], template: '<div></div>' },
     VisAxis: { template: '<div></div>' },
     VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div></div>' },
-    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div></div>' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label', 'color'], template: '<div></div>' },
     ChartContainer: { name: 'ChartContainer', props: ['config'], template: '<div><slot /></div>' },
     ChartCrosshair: { name: 'ChartCrosshair', props: ['color'], template: '<div></div>' },
     ChartTooltip: { template: '<div></div>' },
@@ -170,7 +170,7 @@ describe('AreaCountHistoryWidget', () => {
         await flushPromises();
 
         const lines = wrapper.findAllComponents({ name: 'VisLine' });
-        const rows = wrapper.findComponent({ name: 'VisXYContainer' }).props('data') as Array<Record<string, number | Date | undefined>>;
+        const rows = lines[0].props('data') as Array<Record<string, number | Date | undefined>>;
         expect(lines).toHaveLength(2);
         expect(lines[0].props('color')).toBe('var(--color-chart-1)');
         expect(lines[1].props('color')).toBe('var(--color-chart-2)');
@@ -198,6 +198,7 @@ describe('AreaCountHistoryWidget', () => {
         expect(wrapper.findComponent({ name: 'VisPlotline' }).exists()).toBe(false);
         expect(wrapper.getComponent({ name: 'VisXYContainer' }).props('margin')).toBeUndefined();
         expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('h-[240px]');
+        expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('widget-history-chart');
 
         await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
 
@@ -210,7 +211,8 @@ describe('AreaCountHistoryWidget', () => {
 
         const scatter = wrapper.getComponent({ name: 'VisScatter' });
         const markers = scatter.props('data') as Array<{ label: string }>;
-        expect(markers.map((marker) => marker.label)).toEqual(['Min 10', 'Max 15']);
+        expect(markers.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min 10  \|  .+$/), expect.stringMatching(/^Max 15  \|  .+$/)]);
+        expect(scatter.props('color')).toBe('hsl(var(--foreground))');
     });
 
     it('keeps the empty state visible while another range loads', async () => {

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -7,11 +7,11 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
+    widgetChartStatisticMarkers,
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
-    type WidgetChartValue,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
@@ -19,7 +19,7 @@ import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import type { Organization, StageSafetyLqiHistoryPayload } from '@/types';
 import { DATE_TIME_LOCALE, formatChartTick, formatChartTooltip } from '@/utils/dateTimeHelpers';
 import { stageSafetySensorName } from '@/utils/stageSafety';
-import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position, type Crosshair } from '@unovis/ts';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, type Crosshair } from '@unovis/ts';
 import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Radio } from 'lucide-vue-next';
@@ -28,11 +28,6 @@ import { computed, h, nextTick, ref, render, watch } from 'vue';
 interface ChartDataPoint {
     date: Date;
     [key: string]: Date | number;
-}
-
-interface StatisticMarker extends WidgetChartValue {
-    label: string;
-    position: Position;
 }
 
 const props = defineProps<{ organization: Organization }>();
@@ -101,22 +96,7 @@ const crosshairRef = ref<{ component: Crosshair<ChartDataPoint> } | null>(null);
 const percentageFormatter = new Intl.NumberFormat(DATE_TIME_LOCALE, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
 const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
 const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
-const statisticMarkers = computed<StatisticMarker[]>(() => {
-    const summary = focusedStatistics.value;
-
-    if (!summary) {
-        return [];
-    }
-
-    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
-        return [{ ...summary.minimum, label: `Min / max ${formatPercentage(summary.minimum.value)}`, position: Position.Top }];
-    }
-
-    return [
-        { ...summary.minimum, label: `Min ${formatPercentage(summary.minimum.value)}`, position: Position.Top },
-        { ...summary.maximum, label: `Max ${formatPercentage(summary.maximum.value)}`, position: Position.Bottom },
-    ];
-});
+const statisticMarkers = computed(() => widgetChartStatisticMarkers(focusedStatistics.value, formatPercentage));
 
 function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: number | Date): string {
     const container = document.createElement('div');
@@ -186,6 +166,7 @@ watch(chartData, () => void syncCrosshair());
                 Link quality history chart with {{ chartSeries.length }} series across {{ data?.sensors.length ?? 0 }} sensors.
             </p>
             <ChartContainer
+                class="widget-history-chart"
                 :config="chartConfig"
                 :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
                 role="img"
@@ -217,14 +198,15 @@ watch(chartData, () => void syncCrosshair());
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point: StatisticMarker) => point.date.getTime()"
-                        :y="(point: StatisticMarker) => point.value"
-                        :color="focusedSeries.color"
-                        :label="(point: StatisticMarker) => point.label"
-                        :label-position="(point: StatisticMarker) => point.position"
+                        :x="(point) => point.date.getTime()"
+                        :y="(point) => point.value"
+                        color="hsl(var(--foreground))"
+                        :label="(point) => point.label"
+                        label-color="hsl(var(--foreground))"
+                        :label-position="(point) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
-                        stroke-color="var(--background)"
+                        stroke-color="hsl(var(--background))"
                         :stroke-width="2"
                         :exclude-from-domain-calculation="true"
                     />

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -11,6 +11,7 @@ import {
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
+    type WidgetChartStatisticMarker,
     type WidgetChartStatistics,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
@@ -198,12 +199,12 @@ watch(chartData, () => void syncCrosshair());
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point) => point.date.getTime()"
-                        :y="(point) => point.value"
+                        :x="(point: WidgetChartStatisticMarker) => point.date.getTime()"
+                        :y="(point: WidgetChartStatisticMarker) => point.value"
                         color="hsl(var(--foreground))"
-                        :label="(point) => point.label"
+                        :label="(point: WidgetChartStatisticMarker) => point.label"
                         label-color="hsl(var(--foreground))"
-                        :label-position="(point) => point.position"
+                        :label-position="(point: WidgetChartStatisticMarker) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
                         stroke-color="hsl(var(--background))"

--- a/resources/js/components/stage-safety/LqiHistoryWidget.vue
+++ b/resources/js/components/stage-safety/LqiHistoryWidget.vue
@@ -121,6 +121,7 @@ function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: 
 }
 
 async function syncCrosshair(): Promise<void> {
+    // The Vue wrapper omits its typed data prop at runtime and creates the core Crosshair in its own nextTick callback.
     await nextTick();
     await nextTick();
     crosshairRef.value?.component.setData(chartData.value);

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -142,7 +142,7 @@ function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: 
 }
 
 async function syncCrosshair(): Promise<void> {
-    // Unovis creates the exposed Crosshair one tick after its Vue wrapper mounts.
+    // The Vue wrapper omits its typed data prop at runtime and creates the core Crosshair in its own nextTick callback.
     await nextTick();
     await nextTick();
     crosshairRef.value?.component.setData(chartData.value);

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -7,11 +7,11 @@ import WidgetShell from '@/components/widgets/WidgetShell.vue';
 import {
     calculateWidgetChartStatistics,
     WIDGET_CHART_COLORS,
+    widgetChartStatisticMarkers,
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
     type WidgetChartStatistics,
-    type WidgetChartValue,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
 import { useChartSeriesVisibility } from '@/composables/useChartSeriesVisibility';
@@ -19,7 +19,7 @@ import { useWidgetPolling } from '@/composables/useWidgetPolling';
 import type { Organization, StageSafetyReadingKind, StageSafetyWindHistoryPayload } from '@/types';
 import { DATE_TIME_LOCALE, formatChartTick, formatChartTooltip } from '@/utils/dateTimeHelpers';
 import { metersPerSecondToKilometersPerHour, stageSafetySensorName } from '@/utils/stageSafety';
-import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, Position, type Crosshair } from '@unovis/ts';
+import { CurveType, PlotlineLabelPosition, PlotlineLineStylePresets, type Crosshair } from '@unovis/ts';
 import { VisAxis, VisLine, VisPlotline, VisScatter, VisXYContainer } from '@unovis/vue';
 import { useHttp } from '@inertiajs/vue3';
 import { Wind } from 'lucide-vue-next';
@@ -28,11 +28,6 @@ import { computed, h, nextTick, ref, render, watch } from 'vue';
 interface ChartDataPoint {
     date: Date;
     [key: string]: Date | number | undefined;
-}
-
-interface StatisticMarker extends WidgetChartValue {
-    label: string;
-    position: Position;
 }
 
 const props = defineProps<{ organization: Organization }>();
@@ -122,22 +117,7 @@ const windValueFormatter = new Intl.NumberFormat(DATE_TIME_LOCALE, { minimumFrac
 const windTickFormatter = new Intl.NumberFormat(DATE_TIME_LOCALE, { maximumFractionDigits: 1 });
 const focusedSeries = computed(() => (statisticsEnabled.value && visibleChartSeries.value.length === 1 ? visibleChartSeries.value[0] : null));
 const focusedStatistics = computed(() => (focusedSeries.value ? statistics.value[focusedSeries.value.key] : null));
-const statisticMarkers = computed<StatisticMarker[]>(() => {
-    const summary = focusedStatistics.value;
-
-    if (!summary) {
-        return [];
-    }
-
-    if (summary.minimum.date.getTime() === summary.maximum.date.getTime()) {
-        return [{ ...summary.minimum, label: `Min / max ${formatWind(summary.minimum.value)}`, position: Position.Top }];
-    }
-
-    return [
-        { ...summary.minimum, label: `Min ${formatWind(summary.minimum.value)}`, position: Position.Top },
-        { ...summary.maximum, label: `Max ${formatWind(summary.maximum.value)}`, position: Position.Bottom },
-    ];
-});
+const statisticMarkers = computed(() => widgetChartStatisticMarkers(focusedStatistics.value, formatWind));
 
 function crosshairTemplate(datum: ChartDataPoint | { data: ChartDataPoint }, x: number | Date): string {
     const container = document.createElement('div');
@@ -208,6 +188,7 @@ watch(chartData, () => void syncCrosshair());
                 Wind history chart with {{ chartSeries.length }} series across {{ data?.sensors.length ?? 0 }} sensors.
             </p>
             <ChartContainer
+                class="widget-history-chart"
                 :config="chartConfig"
                 :class="[statisticsEnabled ? 'h-[220px]' : 'h-[240px]', 'w-full min-w-0 sm:h-[350px]']"
                 role="img"
@@ -240,14 +221,15 @@ watch(chartData, () => void syncCrosshair());
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point: StatisticMarker) => point.date.getTime()"
-                        :y="(point: StatisticMarker) => point.value"
-                        :color="focusedSeries.color"
-                        :label="(point: StatisticMarker) => point.label"
-                        :label-position="(point: StatisticMarker) => point.position"
+                        :x="(point) => point.date.getTime()"
+                        :y="(point) => point.value"
+                        color="hsl(var(--foreground))"
+                        :label="(point) => point.label"
+                        label-color="hsl(var(--foreground))"
+                        :label-position="(point) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
-                        stroke-color="var(--background)"
+                        stroke-color="hsl(var(--background))"
                         :stroke-width="2"
                         :exclude-from-domain-calculation="true"
                     />

--- a/resources/js/components/stage-safety/WindHistoryWidget.vue
+++ b/resources/js/components/stage-safety/WindHistoryWidget.vue
@@ -11,6 +11,7 @@ import {
     widgetTimeRangeParams,
     widgetTimeRangeShowsDate,
     type WidgetChartSeries,
+    type WidgetChartStatisticMarker,
     type WidgetChartStatistics,
     type WidgetTimeRange,
 } from '@/components/widgets/widgetChart';
@@ -221,12 +222,12 @@ watch(chartData, () => void syncCrosshair());
                     <VisScatter
                         v-if="focusedSeries && statisticMarkers.length"
                         :data="statisticMarkers"
-                        :x="(point) => point.date.getTime()"
-                        :y="(point) => point.value"
+                        :x="(point: WidgetChartStatisticMarker) => point.date.getTime()"
+                        :y="(point: WidgetChartStatisticMarker) => point.value"
                         color="hsl(var(--foreground))"
-                        :label="(point) => point.label"
+                        :label="(point: WidgetChartStatisticMarker) => point.label"
                         label-color="hsl(var(--foreground))"
-                        :label-position="(point) => point.position"
+                        :label-position="(point: WidgetChartStatisticMarker) => point.position"
                         :label-hide-overlapping="false"
                         :size="8"
                         stroke-color="hsl(var(--background))"

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -174,7 +174,10 @@ describe('LqiHistoryWidget', () => {
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 25.4%');
         const scatter = wrapper.getComponent({ name: 'VisScatter' });
         const markers = scatter.props('data') as Array<{ label: string }>;
-        expect(markers.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min 0\.0%  \|  .+$/), expect.stringMatching(/^Max 50\.9%  \|  .+$/)]);
+        expect(markers.map((marker) => marker.label)).toEqual([
+            expect.stringMatching(/^Min 0\.0%  \|  .+$/),
+            expect.stringMatching(/^Max 50\.9%  \|  .+$/),
+        ]);
         expect(scatter.props('color')).toBe('hsl(var(--foreground))');
     });
 });

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -175,8 +175,8 @@ describe('LqiHistoryWidget', () => {
         const scatter = wrapper.getComponent({ name: 'VisScatter' });
         const markers = scatter.props('data') as Array<{ label: string }>;
         expect(markers.map((marker) => marker.label)).toEqual([
-            expect.stringMatching(/^Min 0\.0%  \|  .+$/),
-            expect.stringMatching(/^Max 50\.9%  \|  .+$/),
+            expect.stringMatching(/^Min 0\.0% \| .+$/),
+            expect.stringMatching(/^Max 50\.9% \| .+$/),
         ]);
         expect(scatter.props('color')).toBe('hsl(var(--foreground))');
     });

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -129,6 +129,7 @@ describe('LqiHistoryWidget', () => {
         expect(lines.every((line) => line.props('curveType') === CurveType.MonotoneX)).toBe(true);
 
         const crosshair = wrapper.findComponent({ name: 'VisCrosshair' });
+        expect(mocks.crosshair.setData).toHaveBeenCalledWith(expect.arrayContaining(firstRows));
         const template = crosshair.props('template') as (datum: Record<string, number | Date>, x: Date) => string;
         expect(template(firstRows[1], firstRows[1].date as Date)).toContain('50.9%');
         expect(wrapper.get('time').attributes('datetime')).toBe('2026-07-25T11:40:00.000Z');

--- a/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/LqiHistoryWidget.test.ts
@@ -30,7 +30,7 @@ vi.mock('@unovis/vue', () => ({
     },
     VisAxis: { template: '<div />' },
     VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
-    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label', 'color'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: {
         name: 'VisCrosshair',
@@ -162,6 +162,7 @@ describe('LqiHistoryWidget', () => {
 
         await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
 
+        expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('widget-history-chart');
         expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('0.0%');
         expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('25.4%');
         expect(wrapper.get('[data-series="sensor_1_lqi"]').text()).toContain('50.9%');
@@ -171,7 +172,9 @@ describe('LqiHistoryWidget', () => {
 
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('value')).toBeCloseTo(25.4487179487);
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 25.4%');
-        const markers = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
-        expect(markers.map((marker) => marker.label)).toEqual(['Min 0.0%', 'Max 50.9%']);
+        const scatter = wrapper.getComponent({ name: 'VisScatter' });
+        const markers = scatter.props('data') as Array<{ label: string }>;
+        expect(markers.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min 0\.0%  \|  .+$/), expect.stringMatching(/^Max 50\.9%  \|  .+$/)]);
+        expect(scatter.props('color')).toBe('hsl(var(--foreground))');
     });
 });

--- a/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
@@ -189,14 +189,14 @@ describe('WindHistoryWidget', () => {
         const scatter = wrapper.getComponent({ name: 'VisScatter' });
         const markers = scatter.props('data') as Array<{ label: string }>;
         expect(markers.map((marker) => marker.label)).toEqual([
-            expect.stringMatching(/^Min 18\.0 km\/h  \|  .+$/),
-            expect.stringMatching(/^Max 21\.6 km\/h  \|  .+$/),
+            expect.stringMatching(/^Min 18\.0 km\/h \| .+$/),
+            expect.stringMatching(/^Max 21\.6 km\/h \| .+$/),
         ]);
         expect(scatter.props('color')).toBe('hsl(var(--foreground))');
 
         await wrapper.get('[data-series="sensor_1_wind_gust"]').trigger('click');
         const singleMarker = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
-        expect(singleMarker.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min \/ max 28\.8 km\/h  \|  .+$/)]);
+        expect(singleMarker.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min \/ max 28\.8 km\/h \| .+$/)]);
     });
 
     it('isolates a legend series and restores all when selected again', async () => {

--- a/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
+++ b/resources/js/components/stage-safety/_tests_/WindHistoryWidget.test.ts
@@ -32,7 +32,7 @@ vi.mock('@unovis/vue', () => ({
     },
     VisAxis: { template: '<div />' },
     VisPlotline: { name: 'VisPlotline', props: ['value', 'labelText'], template: '<div />' },
-    VisScatter: { name: 'VisScatter', props: ['data', 'label'], template: '<div />' },
+    VisScatter: { name: 'VisScatter', props: ['data', 'label', 'color'], template: '<div />' },
     VisTooltip: { template: '<div />' },
     VisCrosshair: {
         name: 'VisCrosshair',
@@ -176,6 +176,7 @@ describe('WindHistoryWidget', () => {
 
         await wrapper.get('[aria-label="Show chart statistics"]').trigger('click');
 
+        expect(wrapper.getComponent({ name: 'ChartContainer' }).classes()).toContain('widget-history-chart');
         expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('18.0 km/h');
         expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('19.8 km/h');
         expect(wrapper.get('[data-series="sensor_1_wind_average"]').text()).toContain('21.6 km/h');
@@ -185,12 +186,17 @@ describe('WindHistoryWidget', () => {
 
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('value')).toBeCloseTo(19.8);
         expect(wrapper.getComponent({ name: 'VisPlotline' }).props('labelText')).toBe('Avg 19.8 km/h');
-        const markers = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
-        expect(markers.map((marker) => marker.label)).toEqual(['Min 18.0 km/h', 'Max 21.6 km/h']);
+        const scatter = wrapper.getComponent({ name: 'VisScatter' });
+        const markers = scatter.props('data') as Array<{ label: string }>;
+        expect(markers.map((marker) => marker.label)).toEqual([
+            expect.stringMatching(/^Min 18\.0 km\/h  \|  .+$/),
+            expect.stringMatching(/^Max 21\.6 km\/h  \|  .+$/),
+        ]);
+        expect(scatter.props('color')).toBe('hsl(var(--foreground))');
 
         await wrapper.get('[data-series="sensor_1_wind_gust"]').trigger('click');
         const singleMarker = wrapper.getComponent({ name: 'VisScatter' }).props('data') as Array<{ label: string }>;
-        expect(singleMarker.map((marker) => marker.label)).toEqual(['Min / max 28.8 km/h']);
+        expect(singleMarker.map((marker) => marker.label)).toEqual([expect.stringMatching(/^Min \/ max 28\.8 km\/h  \|  .+$/)]);
     });
 
     it('isolates a legend series and restores all when selected again', async () => {

--- a/resources/js/components/widgets/_tests_/widgetChart.test.ts
+++ b/resources/js/components/widgets/_tests_/widgetChart.test.ts
@@ -1,4 +1,10 @@
-import { calculateWidgetChartStatistics, widgetTimeRangeParams, widgetTimeRangeShowsDate } from '@/components/widgets/widgetChart';
+import {
+    calculateWidgetChartStatistics,
+    widgetChartStatisticMarkers,
+    widgetTimeRangeParams,
+    widgetTimeRangeShowsDate,
+} from '@/components/widgets/widgetChart';
+import { Position } from '@unovis/ts';
 import { describe, expect, it } from 'vitest';
 
 describe('calculateWidgetChartStatistics', () => {
@@ -28,6 +34,47 @@ describe('calculateWidgetChartStatistics', () => {
     it('returns null when no valid samples exist', () => {
         expect(calculateWidgetChartStatistics([])).toBeNull();
         expect(calculateWidgetChartStatistics([{ date: new Date('invalid'), value: Number.NaN }])).toBeNull();
+    });
+});
+
+describe('widgetChartStatisticMarkers', () => {
+    it('formats extrema labels and positions', () => {
+        const markers = widgetChartStatisticMarkers(
+            {
+                count: 2,
+                minimum: { date: new Date('2026-08-06T10:00:00Z'), value: 10 },
+                maximum: { date: new Date('2026-08-06T10:05:00Z'), value: 20 },
+                average: 15,
+            },
+            (value) => `${value.toFixed(1)} km/h`,
+        );
+
+        expect(markers).toMatchObject([
+            { value: 10, position: Position.Top },
+            { value: 20, position: Position.Bottom },
+        ]);
+        expect(markers.map((marker) => marker.label)).toEqual([
+            expect.stringMatching(/^Min 10\.0 km\/h  \|  .+$/),
+            expect.stringMatching(/^Max 20\.0 km\/h  \|  .+$/),
+        ]);
+    });
+
+    it('combines extrema at the same timestamp', () => {
+        const date = new Date('2026-08-06T10:00:00Z');
+        const markers = widgetChartStatisticMarkers(
+            {
+                count: 1,
+                minimum: { date, value: 10 },
+                maximum: { date, value: 10 },
+                average: 10,
+            },
+            String,
+        );
+
+        expect(markers).toHaveLength(1);
+        expect(markers[0]).toMatchObject({ value: 10, position: Position.Top });
+        expect(markers[0].label).toMatch(/^Min \/ max 10  \|  .+$/);
+        expect(widgetChartStatisticMarkers(null, String)).toEqual([]);
     });
 });
 

--- a/resources/js/components/widgets/_tests_/widgetChart.test.ts
+++ b/resources/js/components/widgets/_tests_/widgetChart.test.ts
@@ -54,8 +54,8 @@ describe('widgetChartStatisticMarkers', () => {
             { value: 20, position: Position.Bottom },
         ]);
         expect(markers.map((marker) => marker.label)).toEqual([
-            expect.stringMatching(/^Min 10\.0 km\/h  \|  .+$/),
-            expect.stringMatching(/^Max 20\.0 km\/h  \|  .+$/),
+            expect.stringMatching(/^Min 10\.0 km\/h \| .+$/),
+            expect.stringMatching(/^Max 20\.0 km\/h \| .+$/),
         ]);
     });
 
@@ -73,7 +73,7 @@ describe('widgetChartStatisticMarkers', () => {
 
         expect(markers).toHaveLength(1);
         expect(markers[0]).toMatchObject({ value: 10, position: Position.Top });
-        expect(markers[0].label).toMatch(/^Min \/ max 10  \|  .+$/);
+        expect(markers[0].label).toMatch(/^Min \/ max 10 \| .+$/);
         expect(widgetChartStatisticMarkers(null, String)).toEqual([]);
     });
 });

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -1,3 +1,6 @@
+import { formatChartTooltip } from '@/utils/dateTimeHelpers';
+import { Position } from '@unovis/ts';
+
 type CalendarWidgetTimeRange = 'today' | 'yesterday' | 'day-before-yesterday' | 'this-day-last-week';
 export type WidgetTimeRange = '30m' | '1h' | '3h' | '6h' | '12h' | '24h' | CalendarWidgetTimeRange;
 type RelativeWidgetTimeRange = Exclude<WidgetTimeRange, CalendarWidgetTimeRange>;
@@ -103,8 +106,7 @@ export function widgetChartStatisticMarkers(
         return [];
     }
 
-    const label = (kind: string, point: WidgetChartValue): string =>
-        `${kind} ${formatValue(point.value)}  |  ${formatChartTooltip(point.date)}`;
+    const label = (kind: string, point: WidgetChartValue): string => `${kind} ${formatValue(point.value)}  |  ${formatChartTooltip(point.date)}`;
 
     if (statistics.minimum.date.getTime() === statistics.maximum.date.getTime()) {
         return [{ ...statistics.minimum, label: label('Min / max', statistics.minimum), position: Position.Top }];
@@ -123,5 +125,3 @@ export const WIDGET_CHART_COLORS = [
     'var(--color-chart-4)',
     'var(--color-chart-5)',
 ];
-import { formatChartTooltip } from '@/utils/dateTimeHelpers';
-import { Position } from '@unovis/ts';

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -59,6 +59,11 @@ export interface WidgetChartStatistics {
     average: number;
 }
 
+export interface WidgetChartStatisticMarker extends WidgetChartValue {
+    label: string;
+    position: Position;
+}
+
 export function calculateWidgetChartStatistics(values: WidgetChartValue[]): WidgetChartStatistics | null {
     const validValues = values.filter((point) => Number.isFinite(point.value) && Number.isFinite(point.date.getTime()));
 
@@ -90,6 +95,27 @@ export function calculateWidgetChartStatistics(values: WidgetChartValue[]): Widg
     };
 }
 
+export function widgetChartStatisticMarkers(
+    statistics: WidgetChartStatistics | null,
+    formatValue: (value: number) => string,
+): WidgetChartStatisticMarker[] {
+    if (!statistics) {
+        return [];
+    }
+
+    const label = (kind: string, point: WidgetChartValue): string =>
+        `${kind} ${formatValue(point.value)}  |  ${formatChartTooltip(point.date)}`;
+
+    if (statistics.minimum.date.getTime() === statistics.maximum.date.getTime()) {
+        return [{ ...statistics.minimum, label: label('Min / max', statistics.minimum), position: Position.Top }];
+    }
+
+    return [
+        { ...statistics.minimum, label: label('Min', statistics.minimum), position: Position.Top },
+        { ...statistics.maximum, label: label('Max', statistics.maximum), position: Position.Bottom },
+    ];
+}
+
 export const WIDGET_CHART_COLORS = [
     'var(--color-chart-1)',
     'var(--color-chart-2)',
@@ -97,3 +123,5 @@ export const WIDGET_CHART_COLORS = [
     'var(--color-chart-4)',
     'var(--color-chart-5)',
 ];
+import { formatChartTooltip } from '@/utils/dateTimeHelpers';
+import { Position } from '@unovis/ts';

--- a/resources/js/components/widgets/widgetChart.ts
+++ b/resources/js/components/widgets/widgetChart.ts
@@ -106,7 +106,7 @@ export function widgetChartStatisticMarkers(
         return [];
     }
 
-    const label = (kind: string, point: WidgetChartValue): string => `${kind} ${formatValue(point.value)}  |  ${formatChartTooltip(point.date)}`;
+    const label = (kind: string, point: WidgetChartValue): string => `${kind} ${formatValue(point.value)} | ${formatChartTooltip(point.date)}`;
 
     if (statistics.minimum.date.getTime() === statistics.maximum.date.getTime()) {
         return [{ ...statistics.minimum, label: label('Min / max', statistics.minimum), position: Position.Top }];


### PR DESCRIPTION
Improves chart statistic annotations across area count, wind, and link quality history widgets. Min/max labels now render reliably in every chart, include clear timestamps, and remain readable over plotted data in light and dark themes.

## Details

- Centralizes statistic marker creation and formatting in `widgetChart.ts`.
- Fixes area chart series data wiring so annotations render on the plot.
- Scopes annotation contrast styling to history charts.
- Adds adaptive halos for min/max and average labels.
- Preserves independent Wind/LQI series timebases while synchronizing Crosshair data after the installed Unovis Vue wrapper creates its core component.

## Notes

Wind/LQI Crosshair synchronization is intentionally documented in the widgets because the installed Vue wrapper advertises a `data` prop in types but does not forward it at runtime.

Full precommit suite passes: 42 test files, 223 tests, frontend typecheck, PHPStan, Rector, Peck, and E2E tests.

## Reviewer Setup

Frontend sources changed. Run:

```sh
npm run build
```

---
**« It always seems impossible until it is done. »**
_Nelson Mandela_